### PR TITLE
shvar error

### DIFF
--- a/shvar/src/lib.rs
+++ b/shvar/src/lib.rs
@@ -35,6 +35,27 @@ pub enum Error {
     Requested(String),
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::OpenSingleQuotes => write!(f, "unclosed single quotes"),
+            Error::OpenDoubleQuotes => write!(f, "unclosed double quotes"),
+            Error::TrailingRightBrace => write!(f, "unmatched right brace"),
+            Error::InvalidVariable => write!(f, "invalid variable definition"),
+            Error::InvalidCharacter { expected, returned } => match returned {
+                Some(c) => write!(f, "expected '{}', found '{}'", expected, c),
+                None => write!(f, "expected '{}', found end of input", expected),
+            },
+            Error::DepthLimitExceeded => {
+                write!(f, "expansion depth limit exceeded (possible cycle)")
+            }
+            Error::Requested(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 ////////////////////////////////////////////// quoting /////////////////////////////////////////////
 
 // I consulted the FreeBSD man pages for guidance.

--- a/tag_index/src/bin/benchmark-compressed-tag-index.rs
+++ b/tag_index/src/bin/benchmark-compressed-tag-index.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader};
 
 use tag_index::{CompressedTagIndex, Tag, TagIndex, Tags};
 
-fn parse_queries(queries: &str) -> Vec<Tag> {
+fn parse_queries(queries: &str) -> Vec<Tag<'_>> {
     let reader = BufReader::new(File::open(queries).unwrap());
     let mut queries = vec![];
     for line in reader.lines() {

--- a/tag_index/src/bin/benchmark-inverted-tag-index.rs
+++ b/tag_index/src/bin/benchmark-inverted-tag-index.rs
@@ -15,7 +15,7 @@ fn construct_index(tagfile: &str) -> Pin<Box<InvertedTagIndex>> {
     Box::pin(iti)
 }
 
-fn parse_queries(queries: &str) -> Vec<Tag> {
+fn parse_queries(queries: &str) -> Vec<Tag<'_>> {
     let reader = BufReader::new(File::open(queries).unwrap());
     let mut queries = vec![];
     for line in reader.lines() {


### PR DESCRIPTION
- **[tag_index] fix clippy on newer rust/x86**
- **feat: implement make-style automatic variables and $() syntax**
- **[shvar] impl std::error::Error for Error.**
