### PR TITLE
fix: resolve clippy warnings across multiple modules

### DIFF
--- a/sig_fig_histogram/tests/bucketize.rs
+++ b/sig_fig_histogram/tests/bucketize.rs
@@ -31,6 +31,7 @@
 //     print(3, |x| format!("{:0.2e}", x));
 //     println!("}}");
 // }
+#![allow(clippy::approx_constant)]
 
 use sig_fig_histogram::SigFigBucketizer;
 #[test]
@@ -577,6 +578,7 @@ fn two_sig_figs() {
     assert_eq!(269, sfb.bucket_for(9.9e2));
     assert!((sfb.boundary_for(269) - 9.9e2).abs() < 1e-10);
 }
+
 #[test]
 fn three_sig_figs() {
     let sfb = SigFigBucketizer::new(3);

--- a/sst/src/sbbf.rs
+++ b/sst/src/sbbf.rs
@@ -157,7 +157,7 @@ impl TryFrom<&[u8]> for Filter {
         if bytes.is_empty() {
             return Err("bloom filter must have a non-zero length");
         }
-        if bytes.len() % 32 != 0 {
+        if !bytes.len().is_multiple_of(32) {
             return Err("bloom filter must be a multiple of 32 in length");
         }
         let limit = bytes.len() / 32;

--- a/tuple_key/tests/tuple_key.rs
+++ b/tuple_key/tests/tuple_key.rs
@@ -234,7 +234,7 @@ proptest::proptest! {
 
     #[test]
     fn tuple_key_proptest(elements in proptest::collection::vec((arb_field_number(), arb_direction(), arb_element()), 0..32)
-                              .prop_filter("reverse unit", |v| v.iter().all(|e| (e.1 != Direction::Reverse || e.2 != TestElement::Unit)))) {
+                              .prop_filter("reverse unit", |v| v.iter().all(|e| e.1 != Direction::Reverse || e.2 != TestElement::Unit))) {
         let mut key = TupleKey::default();
         for (field_number, direction, element) in elements.iter() {
             element.extend(*field_number, *direction, &mut key);


### PR DESCRIPTION
Address clippy warnings by:
- Adding #[allow(clippy::approx_constant)] to sig_fig_histogram test
- Using is_multiple_of() instead of modulo comparison in sst/sbbf.rs
- Simplifying boolean logic in tuple_key proptest filter
- Adding missing blank line in test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-by: Claude <noreply@anthropic.com>
