### PR TITLE
fix(sync42):  Cache line separation.

### DIFF
--- a/sync42/src/spin_lock.rs
+++ b/sync42/src/spin_lock.rs
@@ -1,4 +1,4 @@
-//! An efficient FIFO spin lock.  Threads will contend in much the same way as an MCU lock, relying
+//! An efficient FIFO spin lock.  Threads will contend in much the same way as an MCS lock, relying
 //! on the caching system to shoot down the cache line when it gets written.
 
 use std::cell::UnsafeCell;
@@ -6,23 +6,42 @@ use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/////////////////////////////////////////// CacheAligned ///////////////////////////////////////////
+
+#[repr(align(64))]
+struct CacheAligned<T>(T);
+
+impl<T> Deref for CacheAligned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for CacheAligned<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 ///////////////////////////////////////////// SpinLock /////////////////////////////////////////////
 
 /// [SpinLock] provides fast synchronization where blocking threads would be too costly.  Use only
 /// for situations where a small, countable number of operations happen under lock.
 pub struct SpinLock<T> {
-    acquires: AtomicU64,
+    acquires: CacheAligned<AtomicU64>,
     releases: AtomicU64,
-    data: UnsafeCell<T>,
+    data: CacheAligned<UnsafeCell<T>>,
 }
 
 impl<T> SpinLock<T> {
     /// Create a new [SpinLock] that protects a `T`.
     pub fn new(t: T) -> Self {
         Self {
-            acquires: AtomicU64::new(0),
+            acquires: CacheAligned(AtomicU64::new(0)),
             releases: AtomicU64::new(0),
-            data: UnsafeCell::new(t),
+            data: CacheAligned(UnsafeCell::new(t)),
         }
     }
 
@@ -37,7 +56,7 @@ impl<T> SpinLock<T> {
 
     /// Consume the spinlock and return its data.
     pub fn into_inner(self) -> T {
-        self.data.into_inner()
+        self.data.0.into_inner()
     }
 }
 


### PR DESCRIPTION
The intended semantics of the spin lock weren't honored because I failed
to put things on separate cache lines.  This PR corrects that.

The reason you want things on separate cache lines is the same insight
as the famous MCS paper:  Spinning readers will not contend on the cache
like spinning writers will.  But failure to put the data on a separate
cache line means spinning readers hinder locked writers, hurting
everyone.  The fix is to separate cache lines.
