### PR TITLE
chore:  centralize all deps with workspace = true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,71 @@ members = [
     "zerror_full",
 ]
 
+[workspace.dependencies]
+armnod = { path = "armnod", version = "0.11.0" }
+arrrg = { path = "arrrg", version = "0.8.0" }
+arrrg_derive = { path = "arrrg_derive", version = "0.8.0" }
+biometrics = { path = "biometrics", version = "0.12.0" }
+biometrics_prometheus = { path = "biometrics_prometheus", version = "0.9.0" }
+biometrics_sys = { path = "biometrics_sys", version = "0.7.0" }
+bloomcalc = { path = "bloomcalc", version = "0.8.0" }
+buffertk = { path = "buffertk", version = "0.13.0" }
+busyrpc = { path = "busyrpc", version = "0.13.0" }
+derive_util = { path = "derive_util", version = "0.5.0" }
+guacamole = { path = "guacamole", version = "0.14.0" }
+handled = { path = "handled", version = "0.6.0" }
+indicio = { path = "indicio", version = "0.12.0" }
+k8src = { path = "k8src", version = "0.15.0" }
+listfree = { path = "listfree", version = "0.7.0" }
+mani = { path = "mani", version = "0.10.0" }
+minimal_signals = { path = "minimal_signals", version = "0.5.0" }
+one_two_eight = { path = "one_two_eight", version = "0.10.0" }
+prototk = { path = "prototk", version = "0.13.0" }
+prototk_derive = { path = "prototk_derive", version = "0.13.0" }
+rc_conf = { path = "rc_conf", version = "0.13.0" }
+rpc_pb = { path = "rpc_pb", version = "0.14.0" }
+scrunch = { path = "scrunch", version = "0.9.0" }
+setsum = { path = "setsum", version = "0.7.0" }
+shvar = { path = "shvar", version = "0.8.0" }
+sig_fig_histogram = { path = "sig_fig_histogram", version = "0.6.0" }
+skipfree = { path = "skipfree", version = "0.9.0" }
+sst = { path = "sst", version = "0.18.0" }
+statslicer = { path = "statslicer", version = "0.9.0" }
+sync42 = { path = "sync42", version = "0.15.0" }
+tag_index = { path = "tag_index", version = "0.8.0" }
+tatl = { path = "tatl", version = "0.13.0" }
+tuple_key = { path = "tuple_key", version = "0.13.0" }
+tuple_key_derive = { path = "tuple_key_derive", version = "0.11.0" }
+tuple_routing = { path = "tuple_routing", version = "0.8.0" }
+unix_sock = { path = "unix_sock", version = "0.9.0" }
+utf8path = { path = "utf8path", version = "0.9.1" }
+utilz = { path = "utilz", version = "0.7.0" }
+zerror = { path = "zerror", version = "0.8.0" }
+zerror_core = { path = "zerror_core", version = "0.13.0" }
+zerror_derive = { path = "zerror_derive", version = "0.7.0" }
+
+crc32c = { version = "0.6" }
+syn = { version = "1.0" }
+sha3 = { version = "0.10" }
+libc = { version = "0.2" }
+rand = { version = "0.7" }
+toml = { version = "0.7" }
+nom = { version = "7.1" }
+serde = { version = "1.0", features = ["derive"] }
+boring = { version = "4.9.1" }
+chrono = { version = "0.4" }
+semver = { version = "1.0" }
+getopts = { version = "0.2" }
+proptest = { version = "1.0" }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+proc-macro2 = { version = "1.0" }
+rustyline = { version = "11.0" }
+quote = { version = "1.0" }
+serde_yaml = { version = "0.9" }
+serde_json = { version = "1.0" }
+siphasher = { version = "1.0.0" }
+libsodium-sys-stable = { version = "1.19" }
+
 [profile.dev]
 panic = "abort"
 

--- a/analogize/Cargo.toml
+++ b/analogize/Cargo.toml
@@ -13,28 +13,27 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-chrono = "0.4"
-getopts = "0.2"
-libc = "0.2"
-nom = "7.1"
-rustyline = "11.0"
+chrono = { workspace = true }
+getopts = { workspace = true }
+libc = { workspace = true }
+nom = { workspace = true }
+rustyline = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
-buffertk = { path = "../buffertk", version = "0.13" }
-guacamole = { path = "../guacamole", version = "0.14" }
-indicio = { path = "../indicio", version = "0.12", features = ["prototk"] }
-mani = { path = "../mani", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-scrunch = { path = "../scrunch", version = "0.9" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+buffertk = { workspace = true }
+guacamole = { workspace = true }
+indicio = { workspace = true, features = ["prototk"] }
+mani = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+scrunch = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
-
+proptest = { workspace = true }
 [[bin]]
 name = "analogize"
 path = "src/bin/analogize.rs"

--- a/armnod/Cargo.toml
+++ b/armnod/Cargo.toml
@@ -14,11 +14,11 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-guacamole = { path = "../guacamole", version = "0.14" }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+guacamole = { workspace = true }
 
 [[bin]]
 name = "armnod"

--- a/arrrg/Cargo.toml
+++ b/arrrg/Cargo.toml
@@ -8,6 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-getopts = "0.2"
+getopts = { workspace = true }
 
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
+arrrg_derive = { workspace = true }

--- a/arrrg_derive/Cargo.toml
+++ b/arrrg_derive/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/rescrv/blue"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
-derive_util = { path = "../derive_util", version = "0.5" }
+derive_util = { workspace = true }

--- a/biometrics/Cargo.toml
+++ b/biometrics/Cargo.toml
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-sig_fig_histogram = { path = "../sig_fig_histogram", version = "0.6" }
+sig_fig_histogram = { workspace = true }

--- a/biometrics_pb/Cargo.toml
+++ b/biometrics_pb/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-tuple_key = { path = "../tuple_key", version = "0.13" }
-tuple_key_derive = { path = "../tuple_key_derive", version = "0.11" }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+tuple_key = { workspace = true }
+tuple_key_derive = { workspace = true }

--- a/biometrics_prometheus/Cargo.toml
+++ b/biometrics_prometheus/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-utf8path = { path = "../utf8path", version = "0.9" }
+biometrics = { workspace = true }
+utf8path = { workspace = true }
 
 [dev-dependencies]
-biometrics_sys = { path = "../biometrics_sys", version = "0.7" }
+biometrics_sys = { workspace = true }

--- a/biometrics_sys/Cargo.toml
+++ b/biometrics_sys/Cargo.toml
@@ -13,6 +13,6 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
+biometrics = { workspace = true }

--- a/bloomcalc/Cargo.toml
+++ b/bloomcalc/Cargo.toml
@@ -14,10 +14,10 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
 
 [[bin]]
 name = "bloomcalc"

--- a/buffertk/Cargo.toml
+++ b/buffertk/Cargo.toml
@@ -15,9 +15,9 @@ binaries = []
 [dependencies]
 
 [dev-dependencies]
-arrrg = { path = "../arrrg", version = "0.8" }
-guacamole = { path = "../guacamole", version = "0.14" }
-statslicer = { path = "../statslicer", version = "0.9" }
+arrrg = { workspace = true }
+guacamole = { workspace = true }
+statslicer = { workspace = true }
 
 [[bin]]
 name = "unvarint"

--- a/busyrpc/Cargo.toml
+++ b/busyrpc/Cargo.toml
@@ -14,25 +14,24 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-libc = "0.2"
-boring = "4.9.1"
-crc32c = "0.6"
+libc = { workspace = true }
+boring = { workspace = true }
+crc32c = { workspace = true }
+getopts = { workspace = true, optional = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-indicio = { path = "../indicio", version = "0.12" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-sync42 = { path = "../sync42", version = "0.15" }
-tatl = { path = "../tatl", version = "0.13" }
-utilz = { path = "../utilz", version = "0.7" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-
-getopts = { version = "0.2", optional = true }
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+indicio = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+rpc_pb = { workspace = true }
+sync42 = { workspace = true }
+tatl = { workspace = true }
+utilz = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
 
 [[example]]
 name = "busyrpc-benchmark-client"

--- a/busyrpc_service_discovery/Cargo.toml
+++ b/busyrpc_service_discovery/Cargo.toml
@@ -14,18 +14,18 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-busyrpc = { path = "../busyrpc", version = "0.13" }
-indicio = { path = "../indicio", version = "0.12" }
-minimal_signals = { path = "../minimal_signals", version = "0.5" }
-prototk = { path = "../prototk", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-tuple_key = { path = "../tuple_key", version = "0.13" }
-tuple_routing = { path = "../tuple_routing", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+busyrpc = { workspace = true }
+indicio = { workspace = true }
+minimal_signals = { workspace = true }
+prototk = { workspace = true }
+rpc_pb = { workspace = true }
+tuple_key = { workspace = true }
+tuple_routing = { workspace = true }
+zerror_core = { workspace = true }
 
 [[bin]]
 name = "busyrpc-service-discovery-server"

--- a/derive_util/Cargo.toml
+++ b/derive_util/Cargo.toml
@@ -8,6 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/guacamole/Cargo.toml
+++ b/guacamole/Cargo.toml
@@ -13,10 +13,10 @@ default = ["binaries"]
 binaries = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
 
 [[bin]]
 name = "guacamole"

--- a/handled/Cargo.toml
+++ b/handled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handled"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2021"
 description = "handled is an error handling library"
@@ -13,10 +13,10 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
+biometrics = { workspace = true }
 
 [dev-dependencies]
-guacamole = { path = "../guacamole" }
+guacamole = { workspace = true }
 
 [[example]]
 name = "generror"

--- a/indicio/Cargo.toml
+++ b/indicio/Cargo.toml
@@ -14,11 +14,11 @@ binaries = []
 prototk = ["dep:buffertk", "dep:prototk", "dep:prototk_derive"]
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13", optional = true }
-prototk = { path = "../prototk", version = "0.13", optional = true }
-prototk_derive = { path = "../prototk_derive", version = "0.13", optional = true }
-tatl = { path = "../tatl", version = "0.13" }
+biometrics = { workspace = true }
+buffertk = { workspace = true, optional = true }
+prototk = { workspace = true, optional = true }
+prototk_derive = { workspace = true, optional = true }
+tatl = { workspace = true }
 
 [[example]]
 name = "macros"

--- a/k8src/Cargo.toml
+++ b/k8src/Cargo.toml
@@ -14,16 +14,16 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-siphasher = "1"
+getopts = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_yaml = { workspace = true }
+siphasher = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-rc_conf = { path = "../rc_conf", version = "0.13" }
-shvar = { path = "../shvar", version = "0.8" }
-utf8path = { path = "../utf8path", version = "0.9" }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+rc_conf = { workspace = true }
+shvar = { workspace = true }
+utf8path = { workspace = true }
 
 [[bin]]
 name = "k8src"

--- a/listfree/Cargo.toml
+++ b/listfree/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/rescrv/blue"
 [dependencies]
 
 [dev-dependencies]
-guacamole = { path = "../guacamole", version = "0.14" }
+guacamole = { workspace = true }

--- a/lsmtk/Cargo.toml
+++ b/lsmtk/Cargo.toml
@@ -14,25 +14,25 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-indicio = { path = "../indicio", version = "0.12" }
-mani = { path = "../mani", version = "0.10" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-setsum = { path = "../setsum", version = "0.7" }
-skipfree = { path = "../skipfree", version = "0.9" }
-sst = { path = "../sst", version = "0.18" }
-sync42 = { path = "../sync42", version = "0.15" }
-utilz = { path = "../utilz", version = "0.7" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+indicio = { workspace = true }
+mani = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+setsum = { workspace = true }
+skipfree = { workspace = true }
+sst = { workspace = true }
+sync42 = { workspace = true }
+utilz = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [[bin]]
 name = "lsmtk-init"

--- a/macarunes/Cargo.toml
+++ b/macarunes/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-libsodium-sys-stable = "1.19"
+libsodium-sys-stable = { workspace = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }

--- a/manage
+++ b/manage
@@ -80,7 +80,7 @@ if __name__ == '__main__':
             print('skipping')
             continue
         subprocess.check_call((os.path.join(root, 'update-version'), crate, old_version, short_version(old_version), new_version, short_version(new_version)), cwd=root)
-        subprocess.check_call(('git', 'add', *glob.glob('*/Cargo.toml')), cwd=root)
+        subprocess.check_call(('git', 'add', 'Cargo.toml', *glob.glob('*/Cargo.toml')), cwd=root)
         subprocess.check_call(('git', 'commit', '-m', '[{}] v{}'.format(crate, new_version)))
         subprocess.check_call(('git', 'tag', '-a', '-m', '[{}] v{}'.format(crate, new_version), '{}@{}'.format(crate, new_version)))
         subprocess.check_call(('cargo', 'publish', '-p', crate, '-n'))

--- a/mani/Cargo.toml
+++ b/mani/Cargo.toml
@@ -14,25 +14,24 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-crc32c = "0.6"
+crc32c = { workspace = true }
+getopts = { workspace = true, optional = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-tatl = { path = "../tatl", version = "0.13" }
-utilz = { path = "../utilz", version = "0.7" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
-
-getopts = { version = "0.2", optional = true }
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+tatl = { workspace = true }
+utilz = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
 
 [dev-dependencies]
-armnod = { path = "../armnod", version = "0.11" }
-guacamole = { path = "../guacamole", version = "0.14" }
+armnod = { workspace = true }
+guacamole = { workspace = true }
 
 [[bin]]
 name = "mani-append"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = "2021"
 
 [dependencies]
-chrono = "0.4"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-semver = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-toml = "0.7"
+chrono = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+toml = { workspace = true }

--- a/minimal_signals/Cargo.toml
+++ b/minimal_signals/Cargo.toml
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }

--- a/one_two_eight/Cargo.toml
+++ b/one_two_eight/Cargo.toml
@@ -12,5 +12,5 @@ default = ["generate_id_prototk"]
 generate_id_prototk = ["buffertk", "prototk"]
 
 [dependencies]
-buffertk = { path = "../buffertk", version = "0.13", optional = true }
-prototk = { path = "../prototk", version = "0.13", optional = true }
+buffertk = { workspace = true, optional = true }
+prototk = { workspace = true, optional = true }

--- a/paxos_pb/Cargo.toml
+++ b/paxos_pb/Cargo.toml
@@ -8,12 +8,12 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-buffertk = { path = "../buffertk", version = "0.13" }
-guacamole = { path = "../guacamole", version = "0.14" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+buffertk = { workspace = true }
+guacamole = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+rpc_pb = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }

--- a/protoql/Cargo.toml
+++ b/protoql/Cargo.toml
@@ -13,21 +13,20 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-nom = "7.1"
+nom = { workspace = true }
 
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-sst = { path = "../sst", version = "0.18" }
-tuple_key = { path = "../tuple_key", version = "0.13" }
-tuple_key_derive = { path = "../tuple_key_derive", version = "0.11" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+sst = { workspace = true }
+tuple_key = { workspace = true }
+tuple_key_derive = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
-
+proptest = { workspace = true }
 [[bin]]
 name = "protoql-schema-to-protobuf"
 path = "src/bin/protoql-schema-to-protobuf.rs"

--- a/prototk/Cargo.toml
+++ b/prototk/Cargo.toml
@@ -8,6 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-zerror = { path = "../zerror", version = "0.8" }
+buffertk = { workspace = true }
+prototk_derive = { workspace = true }
+zerror = { workspace = true }

--- a/prototk_derive/Cargo.toml
+++ b/prototk_derive/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/rescrv/blue"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
-buffertk = { path = "../buffertk", version = "0.13" }
+buffertk = { workspace = true }

--- a/rc_conf/Cargo.toml
+++ b/rc_conf/Cargo.toml
@@ -13,13 +13,13 @@ default = ["binaries"]
 binaries = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
+getopts = { workspace = true, optional = true }
 
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-biometrics = { path = "../biometrics", version = "0.12" }
-shvar = { path = "../shvar", version = "0.8" }
-utf8path = { path = "../utf8path", version = "0.9" }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+biometrics = { workspace = true }
+shvar = { workspace = true }
+utf8path = { workspace = true }
 
 [[bin]]
 name = "rcscript"

--- a/rpc_pb/Cargo.toml
+++ b/rpc_pb/Cargo.toml
@@ -14,19 +14,19 @@ binaries = []
 indicio = ["dep:indicio"]
 
 [dependencies]
-crc32c = "0.6"
+crc32c = { workspace = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-guacamole = { path = "../guacamole", version = "0.14" }
-indicio = { path = "../indicio", version = "0.12", optional = true }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-utilz = { path = "../utilz", version = "0.7" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+guacamole = { workspace = true }
+indicio = { workspace = true, optional = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+utilz = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [[bin]]
 name = "rpc-pb-gen-host-id"

--- a/rustrc/Cargo.toml
+++ b/rustrc/Cargo.toml
@@ -13,19 +13,19 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-libc = "0.2"
-getopts = { version = "0.2" }
+libc = { workspace = true }
+getopts = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
-biometrics = { path = "../biometrics", version = "0.12" }
-indicio = { path = "../indicio", version = "0.12" }
-minimal_signals = { path = "../minimal_signals", version = "0.5" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-rc_conf = { path = "../rc_conf", version = "0.13" }
-shvar = { path = "../shvar", version = "0.8" }
-unix_sock = { path = "../unix_sock", version = "0.9" }
-utf8path = { path = "../utf8path", version = "0.9" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+biometrics = { workspace = true }
+indicio = { workspace = true }
+minimal_signals = { workspace = true }
+one_two_eight = { workspace = true }
+rc_conf = { workspace = true }
+shvar = { workspace = true }
+unix_sock = { workspace = true }
+utf8path = { workspace = true }
 
 [[bin]]
 name = "rustrc"

--- a/saros/Cargo.toml
+++ b/saros/Cargo.toml
@@ -13,33 +13,33 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-chrono = "0.4"
-getopts = "0.2"
-nom = "7.1"
+chrono = { workspace = true }
+getopts = { workspace = true }
+nom = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-indicio = { path = "../indicio", version = "0.12" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-shvar = { path = "../shvar", version = "0.8" }
-tag_index = { path = "../tag_index", version = "0.8" }
-tatl = { path = "../tatl", version = "0.13" }
-utf8path = { path = "../utf8path", version = "0.9" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+indicio = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+rpc_pb = { workspace = true }
+shvar = { workspace = true }
+tag_index = { workspace = true }
+tatl = { workspace = true }
+utf8path = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }
 
-biometrics_prometheus = { path = "../biometrics_prometheus", version = "0.9" }
-guacamole = { path = "../guacamole", version = "0.14" }
-sig_fig_histogram = { path = "../sig_fig_histogram", version = "0.6" }
+biometrics_prometheus = { workspace = true }
+guacamole = { workspace = true }
+sig_fig_histogram = { workspace = true }
 
 [[bin]]
 name = "sarosd-recovery"

--- a/scrunch/Cargo.toml
+++ b/scrunch/Cargo.toml
@@ -13,16 +13,16 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-guacamole = { path = "../guacamole", version = "0.14" }
-statslicer = { path = "../statslicer", version = "0.9" }
+arrrg = { workspace = true }
+guacamole = { workspace = true }
+statslicer = { workspace = true }
 
 [[bin]]
 name = "scrunch"

--- a/setsum/Cargo.toml
+++ b/setsum/Cargo.toml
@@ -13,8 +13,7 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-sha3 = "0.10"
-
+sha3 = { workspace = true }
 [[bin]]
 name = "setsum-calculator"
 path = "src/bin/setsum-calculator.rs"

--- a/shvar/Cargo.toml
+++ b/shvar/Cargo.toml
@@ -15,8 +15,7 @@ binaries = []
 [dependencies]
 
 [dev-dependencies]
-proptest = "1.0"
-
+proptest = { workspace = true }
 [[example]]
 name = "tests"
 path = "examples/tests.rs"

--- a/skipfree/Cargo.toml
+++ b/skipfree/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-rand = "0.7"
-
+rand = { workspace = true }
 [dev-dependencies]
-guacamole = { path = "../guacamole", version = "0.14" }
+guacamole = { workspace = true }

--- a/split_channel/Cargo.toml
+++ b/split_channel/Cargo.toml
@@ -14,22 +14,21 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-libc = "0.2"
-boring = "4.7.0"
-crc32c = "0.6"
+libc = { workspace = true }
+boring = { workspace = true }
+crc32c = { workspace = true }
+getopts = { workspace = true, optional = true }
 
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-utilz = { path = "../utilz", version = "0.7" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-
-getopts = { version = "0.2", optional = true }
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+rpc_pb = { workspace = true }
+utilz = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
 
 [[example]]
 name = "split_channel-benchmark-client"

--- a/sst/Cargo.toml
+++ b/sst/Cargo.toml
@@ -14,30 +14,29 @@ binaries = ["command_line"]
 command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
 
 [dependencies]
-getopts = { version = "0.2", optional = true }
-libc = "0.2"
-crc32c = "0.6"
-nom = "7.1"
-siphasher = "1.0.0"
+getopts = { workspace = true, optional = true }
+libc = { workspace = true }
+crc32c = { workspace = true }
+nom = { workspace = true }
+siphasher = { workspace = true }
 
-armnod = { path = "../armnod", version = "0.11" }
-handled = { path = "../handled", version = "0.5" }
-arrrg = { path = "../arrrg", version = "0.8", optional = true }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8", optional = true }
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-guacamole = { path = "../guacamole", version = "0.14" }
-indicio = { path = "../indicio", version = "0.12" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-setsum = { path = "../setsum", version = "0.7" }
-sync42 = { path = "../sync42", version = "0.15" }
-tatl = { path = "../tatl", version = "0.13" }
-utilz = { path = "../utilz", version = "0.7" }
+armnod = { workspace = true }
+handled = { workspace = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+guacamole = { workspace = true }
+indicio = { workspace = true }
+prototk_derive = { workspace = true }
+prototk = { workspace = true }
+setsum = { workspace = true }
+sync42 = { workspace = true }
+tatl = { workspace = true }
+utilz = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
-
+proptest = { workspace = true }
 [[bin]]
 name = "jester-from-plaintext"
 path = "src/bin/jester-from-plaintext.rs"

--- a/statslicer/Cargo.toml
+++ b/statslicer/Cargo.toml
@@ -13,14 +13,14 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-getopts = "0.2"
+getopts = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
-sig_fig_histogram = { path = "../sig_fig_histogram", version = "0.6" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+sig_fig_histogram = { workspace = true }
 
 [dev-dependencies]
-guacamole = { path = "../guacamole", version = "0.14" }
+guacamole = { workspace = true }
 
 [[bin]]
 name = "statslicer"

--- a/stdioredirect/Cargo.toml
+++ b/stdioredirect/Cargo.toml
@@ -13,11 +13,11 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-getopts = { version = "0.2" }
-libc = "0.2"
+getopts = { workspace = true }
+libc = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
 
 [[bin]]
 name = "stdioredirect"

--- a/symphonize/Cargo.toml
+++ b/symphonize/Cargo.toml
@@ -13,15 +13,15 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-getopts = { version = "0.2" }
+getopts = { workspace = true }
 
-arrrg = { path = "../arrrg", version = "0.8" }
-arrrg_derive = { path = "../arrrg_derive", version = "0.8" }
-indicio = { path = "../indicio", version = "0.12" }
-k8src = { path = "../k8src", version = "0.15" }
-rc_conf = { path = "../rc_conf", version = "0.13" }
-shvar = { path = "../shvar", version = "0.8" }
-utf8path = { path = "../utf8path", version = "0.9" }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+indicio = { workspace = true }
+k8src = { workspace = true }
+rc_conf = { workspace = true }
+shvar = { workspace = true }
+utf8path = { workspace = true }
 
 [[bin]]
 name = "symphonize"

--- a/sync42/Cargo.toml
+++ b/sync42/Cargo.toml
@@ -13,10 +13,10 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
+biometrics = { workspace = true }
 
 [dev-dependencies]
-guacamole = { path = "../guacamole", version = "0.14" }
+guacamole = { workspace = true }
 
 [[example]]
 name = "clicker"

--- a/tag_index/Cargo.toml
+++ b/tag_index/Cargo.toml
@@ -14,16 +14,16 @@ benchmarks = []
 binaries = []
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
-buffertk = { path = "../buffertk", version = "0.13" }
-listfree = { path = "../listfree", version = "0.7" }
-scrunch = { path = "../scrunch", version = "0.9" }
+buffertk = { workspace = true }
+listfree = { workspace = true }
+scrunch = { workspace = true }
 
 [dev-dependencies]
-arrrg = { path = "../arrrg", version = "0.8" }
-guacamole = { path = "../guacamole", version = "0.14" }
-statslicer = { path = "../statslicer", version = "0.9" }
+arrrg = { workspace = true }
+guacamole = { workspace = true }
+statslicer = { workspace = true }
 
 [[bin]]
 name = "benchmark-compressed-tag-index"

--- a/tatl/Cargo.toml
+++ b/tatl/Cargo.toml
@@ -8,6 +8,6 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
+biometrics = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }

--- a/texttale/Cargo.toml
+++ b/texttale/Cargo.toml
@@ -13,9 +13,9 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-rustyline = "11.0"
+rustyline = { workspace = true }
 
-utilz = { path = "../utilz", version = "0.7" }
+utilz = { workspace = true }
 
 [[example]]
 name = "texttale"

--- a/tiny_lfu/Cargo.toml
+++ b/tiny_lfu/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/rescrv/blue"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-bloomcalc = { path = "../bloomcalc", version = "0.8" }
+biometrics = { workspace = true }
+bloomcalc = { workspace = true }

--- a/tuple_key/Cargo.toml
+++ b/tuple_key/Cargo.toml
@@ -8,13 +8,13 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-tuple_key_derive = { path = "../tuple_key_derive", version = "0.11" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+buffertk = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+tuple_key_derive = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }

--- a/tuple_key_derive/Cargo.toml
+++ b/tuple_key_derive/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/rescrv/blue"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
+buffertk = { workspace = true }
+prototk = { workspace = true }

--- a/tuple_routing/Cargo.toml
+++ b/tuple_routing/Cargo.toml
@@ -8,21 +8,21 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-nom = "7.1"
+nom = { workspace = true }
 
-buffertk = { path = "../buffertk", version = "0.13" }
-busyrpc = { path = "../busyrpc", version = "0.13" }
-indicio = { path = "../indicio", version = "0.12" }
-one_two_eight = { path = "../one_two_eight", version = "0.10" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-rpc_pb = { path = "../rpc_pb", version = "0.14" }
-sync42 = { path = "../sync42", version = "0.15" }
-tuple_key = { path = "../tuple_key", version = "0.13" }
-utf8path = { path = "../utf8path", version = "0.9" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+buffertk = { workspace = true }
+busyrpc = { workspace = true }
+indicio = { workspace = true }
+one_two_eight = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+rpc_pb = { workspace = true }
+sync42 = { workspace = true }
+tuple_key = { workspace = true }
+utf8path = { workspace = true }
+zerror = { workspace = true }
+zerror_core = { workspace = true }
+zerror_derive = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = { workspace = true }

--- a/unix_sock/Cargo.toml
+++ b/unix_sock/Cargo.toml
@@ -13,9 +13,9 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
-utf8path = { path = "../utf8path", version = "0.9" }
+utf8path = { workspace = true }
 
 [[example]]
 name = "unix-sock-client"

--- a/update-version
+++ b/update-version
@@ -19,6 +19,6 @@ TO_SHORT_VER=$1
 shift
 
 sed -i -e 's|version = "'$FROM_VER'"|version = "'$TO_VER'"|g' $PACKAGE/Cargo.toml
-sed -i -e 's|'$PACKAGE' = { path = "../'$PACKAGE'", version = "'$FROM_SHORT_VER'"|'$PACKAGE' = { path = "../'$PACKAGE'", version = "'$TO_SHORT_VER'"|g' */Cargo.toml
+sed -i -e 's|'$PACKAGE' = { path = "'$PACKAGE'", version = "'$FROM_VER'" }|'$PACKAGE' = { path = "'$PACKAGE'", version = "'$TO_VER'" }|g' Cargo.toml
 cargo check --all-targets
-rm **/Cargo.toml-e
+rm -f Cargo.toml-e $PACKAGE/Cargo.toml-e

--- a/utilz/Cargo.toml
+++ b/utilz/Cargo.toml
@@ -13,8 +13,7 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-libc = "0.2"
-
+libc = { workspace = true }
 [[bin]]
 name = "with-lock"
 path = "src/bin/with-lock.rs"

--- a/zerror_core/Cargo.toml
+++ b/zerror_core/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-tatl = { path = "../tatl", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-zerror = { path = "../zerror", version = "0.8" }
-zerror_derive = { path = "../zerror_derive", version = "0.7" }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+tatl = { workspace = true }
+prototk = { workspace = true }
+prototk_derive = { workspace = true }
+zerror = { workspace = true }
+zerror_derive = { workspace = true }

--- a/zerror_derive/Cargo.toml
+++ b/zerror_derive/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/rescrv/blue"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
-derive_util = { path = "../derive_util", version = "0.5" }
+derive_util = { workspace = true }

--- a/zerror_full/Cargo.toml
+++ b/zerror_full/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/rescrv/blue"
 
 [dependencies]
 [dev-dependencies]
-biometrics = { path = "../biometrics", version = "0.12" }
-buffertk = { path = "../buffertk", version = "0.13" }
-prototk_derive = { path = "../prototk_derive", version = "0.13" }
-prototk = { path = "../prototk", version = "0.13" }
-zerror_core = { path = "../zerror_core", version = "0.13" }
-zerror = { path = "../zerror", version = "0.8" }
+biometrics = { workspace = true }
+buffertk = { workspace = true }
+prototk_derive = { workspace = true }
+prototk = { workspace = true }
+zerror_core = { workspace = true }
+zerror = { workspace = true }


### PR DESCRIPTION
This moves every dependency to the workspace Cargo.toml and references
it with `dep = { workspace = true }`.

Co-authored-by: AI
