### PR TITLE
refactor(caternary): harden evaluation, optimizer, and error handling

### DIFF
--- a/caternary/Cargo.toml
+++ b/caternary/Cargo.toml
@@ -8,3 +8,4 @@ license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
 [dependencies]
+handled = { path = "../handled" }

--- a/caternary/src/builtins.rs
+++ b/caternary/src/builtins.rs
@@ -6,9 +6,10 @@
 use crate::EvalError;
 use crate::Evaluator;
 use crate::Token;
+use crate::evaluator::operator_error;
 
 fn stack_underflow(expected: usize, found: usize) -> EvalError {
-    EvalError::OperatorError(format!(
+    operator_error(format!(
         "stack underflow: need at least {expected} values, found {found}"
     ))
 }
@@ -159,7 +160,6 @@ mod tests {
         let tokens = parse("DROP").unwrap();
         let err = eval.eval(&tokens).unwrap_err();
 
-        assert!(matches!(err, crate::EvalError::OperatorError(_)));
         assert!(
             err.to_string()
                 .contains("stack underflow: need at least 1 values, found 0")

--- a/caternary/src/combinators.rs
+++ b/caternary/src/combinators.rs
@@ -9,6 +9,7 @@
 use crate::EvalError;
 use crate::Evaluator;
 use crate::Token;
+use crate::evaluator::operator_error;
 
 /// A trait for stack element types that can contain quotations.
 ///
@@ -47,7 +48,7 @@ pub trait Quotable: From<Token> + Clone {
 }
 
 fn stack_underflow(expected: usize, found: usize) -> EvalError {
-    EvalError::OperatorError(format!(
+    operator_error(format!(
         "stack underflow: need at least {expected} values, found {found}"
     ))
 }
@@ -60,11 +61,11 @@ fn require_len<T>(stack: &[T], expected: usize) -> Result<(), EvalError> {
 }
 
 fn not_a_quotation() -> EvalError {
-    EvalError::OperatorError("expected a quotation (bracketed code)".to_string())
+    operator_error("expected a quotation (bracketed code)")
 }
 
 fn not_a_sequence() -> EvalError {
-    EvalError::OperatorError("expected a sequence".to_string())
+    operator_error("expected a sequence")
 }
 
 /// Pops a quotation from the stack, returning its tokens.
@@ -198,9 +199,7 @@ fn cleave<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Ev
             stack.push(x.clone());
             eval.eval_with_stack(&q, stack)?;
         } else {
-            return Err(EvalError::OperatorError(
-                "CLEAVE expects a list of quotations".to_string(),
-            ));
+            return Err(operator_error("CLEAVE expects a list of quotations"));
         }
     }
 
@@ -235,9 +234,7 @@ fn spread<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Ev
             stack.push(val);
             eval.eval_with_stack(&q, stack)?;
         } else {
-            return Err(EvalError::OperatorError(
-                "SPREAD expects a list of quotations".to_string(),
-            ));
+            return Err(operator_error("SPREAD expects a list of quotations"));
         }
     }
 
@@ -351,11 +348,17 @@ fn map<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalE
 
     let mut results = Vec::with_capacity(seq.len());
     for elem in seq {
+        let before = stack.len();
         stack.push(elem);
         eval.eval_with_stack(&quotation, stack)?;
-        let result = stack.pop().ok_or_else(|| {
-            EvalError::OperatorError("MAP quotation must leave one value on stack".to_string())
-        })?;
+        if stack.len() != before + 1 {
+            return Err(operator_error(
+                "MAP quotation must consume one element and leave one result",
+            ));
+        }
+        let result = stack
+            .pop()
+            .ok_or_else(|| operator_error("MAP quotation must leave one value on stack"))?;
         results.push(result);
     }
 
@@ -376,11 +379,17 @@ fn filter<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Ev
 
     let mut results = Vec::new();
     for elem in seq {
+        let before = stack.len();
         stack.push(elem.clone());
         eval.eval_with_stack(&quotation, stack)?;
-        let predicate_result = stack.pop().ok_or_else(|| {
-            EvalError::OperatorError("FILTER quotation must leave one value on stack".to_string())
-        })?;
+        if stack.len() != before + 1 {
+            return Err(operator_error(
+                "FILTER quotation must consume one element and leave one predicate value",
+            ));
+        }
+        let predicate_result = stack
+            .pop()
+            .ok_or_else(|| operator_error("FILTER quotation must leave one value on stack"))?;
         if predicate_result.is_truthy() {
             results.push(elem);
         }
@@ -405,8 +414,14 @@ fn fold<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
 
     stack.push(init);
     for elem in seq {
+        let before = stack.len();
         stack.push(elem);
         eval.eval_with_stack(&quotation, stack)?;
+        if stack.len() != before {
+            return Err(operator_error(
+                "FOLD quotation must consume accumulator+element and leave one accumulator",
+            ));
+        }
     }
 
     Ok(())
@@ -424,8 +439,14 @@ fn each<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
     let seq = seq_val.as_sequence().ok_or_else(not_a_sequence)?;
 
     for elem in seq {
+        let before = stack.len();
         stack.push(elem);
         eval.eval_with_stack(&quotation, stack)?;
+        if stack.len() != before {
+            return Err(operator_error(
+                "EACH quotation must consume one element and leave no extra values",
+            ));
+        }
     }
 
     Ok(())
@@ -571,9 +592,7 @@ mod tests {
             match (a, b) {
                 (Value::Int(a), Value::Int(b)) => stack.push(Value::Int(a + b)),
                 _ => {
-                    return Err(EvalError::OperatorError(
-                        "ADD requires two integers".to_string(),
-                    ));
+                    return Err(operator_error("ADD requires two integers"));
                 }
             }
             Ok(())
@@ -585,9 +604,7 @@ mod tests {
             match (a, b) {
                 (Value::Int(a), Value::Int(b)) => stack.push(Value::Int(a * b)),
                 _ => {
-                    return Err(EvalError::OperatorError(
-                        "MUL requires two integers".to_string(),
-                    ));
+                    return Err(operator_error("MUL requires two integers"));
                 }
             }
             Ok(())
@@ -599,9 +616,7 @@ mod tests {
             match (a, b) {
                 (Value::Int(a), Value::Int(b)) => stack.push(Value::Bool(a > b)),
                 _ => {
-                    return Err(EvalError::OperatorError(
-                        "GT requires two integers".to_string(),
-                    ));
+                    return Err(operator_error("GT requires two integers"));
                 }
             }
             Ok(())
@@ -612,9 +627,7 @@ mod tests {
             match a {
                 Value::Int(n) => stack.push(Value::Bool(n % 2 == 0)),
                 _ => {
-                    return Err(EvalError::OperatorError(
-                        "EVEN requires an integer".to_string(),
-                    ));
+                    return Err(operator_error("EVEN requires an integer"));
                 }
             }
             Ok(())

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -6,24 +6,24 @@
 
 use std::collections::HashMap;
 
+use handled::SError;
+
 use crate::Token;
 
-/// An error that can occur during evaluation.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EvalError {
-    /// Operator returned an error.
-    OperatorError(String),
-}
+/// Evaluation error type.
+pub type EvalError = SError;
 
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EvalError::OperatorError(msg) => write!(f, "operator error: {msg}"),
-        }
-    }
-}
+const PHASE: &str = "caternary-eval";
 
-impl std::error::Error for EvalError {}
+/// Error code for operator failures.
+pub const CODE_OPERATOR_ERROR: &str = "operator-error";
+
+/// Construct an operator error with a structured message.
+pub(crate) fn operator_error(message: impl AsRef<str>) -> EvalError {
+    SError::new(PHASE)
+        .with_code(CODE_OPERATOR_ERROR)
+        .with_message(message.as_ref())
+}
 
 /// An operator function that manipulates the stack.
 ///
@@ -120,7 +120,7 @@ mod tests {
     }
 
     fn underflow() -> EvalError {
-        EvalError::OperatorError("stack underflow".to_string())
+        operator_error("stack underflow")
     }
 
     #[test]
@@ -211,10 +211,8 @@ mod tests {
         fn filter(stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {
             let predicate = stack
                 .pop()
-                .ok_or(EvalError::OperatorError("need predicate".to_string()))?;
-            let data = stack
-                .pop()
-                .ok_or(EvalError::OperatorError("need data".to_string()))?;
+                .ok_or_else(|| operator_error("need predicate"))?;
+            let data = stack.pop().ok_or_else(|| operator_error("need data"))?;
             stack.push(Value::Word(format!("filtered({data:?}, {predicate:?})")));
             Ok(())
         }
@@ -268,7 +266,7 @@ mod tests {
     #[test]
     fn operator_error_propagates() {
         fn fail(_stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {
-            Err(EvalError::OperatorError("intentional failure".to_string()))
+            Err(operator_error("intentional failure"))
         }
 
         let mut eval: Evaluator<Value> = Evaluator::new();
@@ -277,8 +275,10 @@ mod tests {
         let tokens = parse("A B FAIL C").unwrap();
         let result = eval.eval(&tokens);
 
-        assert!(matches!(result, Err(EvalError::OperatorError(_))));
-        println!("Error: {result:?}");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("intentional failure"));
+        println!("Error: {err:?}");
     }
 
     #[test]
@@ -295,8 +295,10 @@ mod tests {
         let tokens = parse("A POP2").unwrap();
         let result = eval.eval(&tokens);
 
-        assert!(matches!(result, Err(EvalError::OperatorError(_))));
-        println!("Error: {result:?}");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("stack underflow"));
+        println!("Error: {err:?}");
     }
 
     #[test]
@@ -473,7 +475,7 @@ mod tests {
     #[test]
     fn redefine_operator() {
         fn first(_stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {
-            Err(EvalError::OperatorError("first".to_string()))
+            Err(operator_error("first"))
         }
 
         fn second(stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {

--- a/caternary/src/lib.rs
+++ b/caternary/src/lib.rs
@@ -13,6 +13,7 @@ pub use combinators::Quotable;
 pub use combinators::register_combinators;
 pub use combinators::register_conditionals;
 pub use combinators::register_sequence_combinators;
+pub use evaluator::CODE_OPERATOR_ERROR;
 pub use evaluator::EvalError;
 pub use evaluator::Evaluator;
 pub use evaluator::Operator;
@@ -26,3 +27,14 @@ pub use parser::SpannedTokenKind;
 pub use parser::Token;
 pub use parser::parse;
 pub use parser::parse_with_spans;
+
+/// Register all builtins and combinators on an evaluator.
+pub fn register_all_builtins<T>(evaluator: &mut Evaluator<T>)
+where
+    T: Quotable,
+{
+    register_stack_builtins(evaluator);
+    register_combinators(evaluator);
+    register_conditionals(evaluator);
+    register_sequence_combinators(evaluator);
+}

--- a/caternary/src/optimizer.rs
+++ b/caternary/src/optimizer.rs
@@ -7,6 +7,10 @@
 //! Variables are interpolated into the replacement string.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 use crate::ParseError;
 use crate::Token;
@@ -55,6 +59,10 @@ pub enum RuleError {
     ReplacementParse(ParseError),
     /// Variable in replacement not bound in pattern.
     UnboundVariable(String),
+    /// Variable name is invalid.
+    InvalidVariableName(String),
+    /// Same variable name used with both `$name` and `$*name`.
+    VariableArityMismatch(String),
 }
 
 impl std::fmt::Display for RuleError {
@@ -63,6 +71,10 @@ impl std::fmt::Display for RuleError {
             RuleError::PatternParse(e) => write!(f, "pattern parse error: {e}"),
             RuleError::ReplacementParse(e) => write!(f, "replacement parse error: {e}"),
             RuleError::UnboundVariable(name) => write!(f, "unbound variable: {name}"),
+            RuleError::InvalidVariableName(name) => write!(f, "invalid variable name: {name}"),
+            RuleError::VariableArityMismatch(name) => {
+                write!(f, "variable used with mixed arity: {name}")
+            }
         }
     }
 }
@@ -75,14 +87,20 @@ impl Rule {
         let pattern_tokens = parse(pattern).map_err(RuleError::PatternParse)?;
         let replacement_tokens = parse(replacement).map_err(RuleError::ReplacementParse)?;
 
-        let pattern = Self::parse_pattern(&pattern_tokens);
-        let replacement = Self::parse_replacement(&replacement_tokens);
+        let pattern = Self::parse_pattern(&pattern_tokens)?;
+        let replacement = Self::parse_replacement(&replacement_tokens)?;
 
-        // Validate that all replacement variables are bound in pattern
-        let bound = Self::collect_pattern_vars(&pattern);
-        for var in Self::collect_replacement_vars(&replacement) {
-            if !bound.contains(&var) {
-                return Err(RuleError::UnboundVariable(var));
+        // Validate that all replacement variables are bound in pattern and have matching arity.
+        let mut bound: HashMap<String, bool> = HashMap::new();
+        Self::collect_pattern_vars(&pattern, &mut bound)?;
+        let mut replacement_vars: HashMap<String, bool> = HashMap::new();
+        Self::collect_replacement_vars(&replacement, &mut replacement_vars)?;
+        for (name, replacement_is_many) in replacement_vars {
+            let Some(pattern_is_many) = bound.get(&name).copied() else {
+                return Err(RuleError::UnboundVariable(name));
+            };
+            if pattern_is_many != replacement_is_many {
+                return Err(RuleError::VariableArityMismatch(name));
             }
         }
 
@@ -92,71 +110,120 @@ impl Rule {
         })
     }
 
-    fn parse_pattern(tokens: &[Token]) -> Vec<PatternElement> {
+    fn parse_pattern(tokens: &[Token]) -> Result<Vec<PatternElement>, RuleError> {
         tokens
             .iter()
             .map(|t| match t {
-                Token::Word(w) if w.starts_with("$*") => {
-                    PatternElement::VarMany(w[2..].to_string())
-                }
-                Token::Word(w) if w.starts_with('$') => PatternElement::Var(w[1..].to_string()),
-                Token::Word(w) => PatternElement::Word(w.clone()),
-                Token::Bracket(inner) => PatternElement::Bracket(Self::parse_pattern(inner)),
+                Token::Word(w) if w.starts_with("$*") => Ok(PatternElement::VarMany(
+                    Self::parse_variable_name(&w[2..])?.to_string(),
+                )),
+                Token::Word(w) if w.starts_with('$') => Ok(PatternElement::Var(
+                    Self::parse_variable_name(&w[1..])?.to_string(),
+                )),
+                Token::Word(w) => Ok(PatternElement::Word(w.clone())),
+                Token::Bracket(inner) => Ok(PatternElement::Bracket(Self::parse_pattern(inner)?)),
             })
-            .collect()
+            .collect::<Result<Vec<_>, RuleError>>()
     }
 
-    fn parse_replacement(tokens: &[Token]) -> Vec<ReplacementElement> {
+    fn parse_replacement(tokens: &[Token]) -> Result<Vec<ReplacementElement>, RuleError> {
         tokens
             .iter()
             .map(|t| match t {
-                Token::Word(w) if w.starts_with("$*") => {
-                    ReplacementElement::VarMany(w[2..].to_string())
-                }
-                Token::Word(w) if w.starts_with('$') => ReplacementElement::Var(w[1..].to_string()),
-                Token::Word(w) => ReplacementElement::Word(w.clone()),
+                Token::Word(w) if w.starts_with("$*") => Ok(ReplacementElement::VarMany(
+                    Self::parse_variable_name(&w[2..])?.to_string(),
+                )),
+                Token::Word(w) if w.starts_with('$') => Ok(ReplacementElement::Var(
+                    Self::parse_variable_name(&w[1..])?.to_string(),
+                )),
+                Token::Word(w) => Ok(ReplacementElement::Word(w.clone())),
                 Token::Bracket(inner) => {
-                    ReplacementElement::Bracket(Self::parse_replacement(inner))
+                    Ok(ReplacementElement::Bracket(Self::parse_replacement(inner)?))
                 }
             })
-            .collect()
+            .collect::<Result<Vec<_>, RuleError>>()
     }
 
-    fn collect_pattern_vars(pattern: &[PatternElement]) -> Vec<String> {
-        let mut vars = Vec::new();
+    fn collect_pattern_vars(
+        pattern: &[PatternElement],
+        vars: &mut HashMap<String, bool>,
+    ) -> Result<(), RuleError> {
         for elem in pattern {
             match elem {
-                PatternElement::Var(name) | PatternElement::VarMany(name) => {
-                    vars.push(name.clone())
+                PatternElement::Var(name) => {
+                    Self::insert_var_arity(vars, name, false)?;
                 }
-                PatternElement::Bracket(inner) => vars.extend(Self::collect_pattern_vars(inner)),
+                PatternElement::VarMany(name) => {
+                    Self::insert_var_arity(vars, name, true)?;
+                }
+                PatternElement::Bracket(inner) => Self::collect_pattern_vars(inner, vars)?,
                 PatternElement::Word(_) => {}
             }
         }
-        vars
+        Ok(())
     }
 
-    fn collect_replacement_vars(replacement: &[ReplacementElement]) -> Vec<String> {
-        let mut vars = Vec::new();
+    fn collect_replacement_vars(
+        replacement: &[ReplacementElement],
+        vars: &mut HashMap<String, bool>,
+    ) -> Result<(), RuleError> {
         for elem in replacement {
             match elem {
-                ReplacementElement::Var(name) | ReplacementElement::VarMany(name) => {
-                    vars.push(name.clone())
+                ReplacementElement::Var(name) => {
+                    Self::insert_var_arity(vars, name, false)?;
                 }
-                ReplacementElement::Bracket(inner) => {
-                    vars.extend(Self::collect_replacement_vars(inner))
-                }
+                ReplacementElement::VarMany(name) => Self::insert_var_arity(vars, name, true)?,
+                ReplacementElement::Bracket(inner) => Self::collect_replacement_vars(inner, vars)?,
                 ReplacementElement::Word(_) => {}
             }
         }
-        vars
+        Ok(())
+    }
+
+    fn parse_variable_name(raw: &str) -> Result<&str, RuleError> {
+        if !Self::is_valid_variable_name(raw) {
+            return Err(RuleError::InvalidVariableName(raw.to_string()));
+        }
+        Ok(raw)
+    }
+
+    fn is_valid_variable_name(name: &str) -> bool {
+        let mut chars = name.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+        if !(first.is_ascii_alphabetic() || first == '_') {
+            return false;
+        }
+        chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }
+
+    fn insert_var_arity(
+        vars: &mut HashMap<String, bool>,
+        name: &str,
+        is_many: bool,
+    ) -> Result<(), RuleError> {
+        if let Some(existing) = vars.get(name).copied() {
+            if existing != is_many {
+                return Err(RuleError::VariableArityMismatch(name.to_string()));
+            }
+            return Ok(());
+        }
+        vars.insert(name.to_string(), is_many);
+        Ok(())
     }
 
     /// Attempts to apply this rule to a token sequence, returning the rewritten sequence if matched.
     /// Returns `None` if no match produces a different result.
     pub fn apply(&self, tokens: &[Token]) -> Option<Vec<Token>> {
+        self.apply_with_limit(tokens, usize::MAX)
+    }
+
+    /// Like [`Rule::apply`] but bounds backtracking through `$*name` pattern variables.
+    pub fn apply_with_limit(&self, tokens: &[Token], max_backtracks: usize) -> Option<Vec<Token>> {
+        let mut budget = BacktrackBudget::new(max_backtracks);
         for start in 0..=tokens.len() {
-            if let Some((end, bindings)) = self.match_at(tokens, start) {
+            if let Some((end, bindings)) = self.match_at(tokens, start, &mut budget) {
                 let mut result = tokens[..start].to_vec();
                 result.extend(self.substitute(&bindings));
                 result.extend(tokens[end..].to_vec());
@@ -168,9 +235,14 @@ impl Rule {
         None
     }
 
-    fn match_at(&self, tokens: &[Token], start: usize) -> Option<(usize, Bindings)> {
+    fn match_at(
+        &self,
+        tokens: &[Token],
+        start: usize,
+        budget: &mut BacktrackBudget,
+    ) -> Option<(usize, Bindings)> {
         let mut bindings = Bindings::new();
-        let end = Self::match_pattern(&self.pattern, tokens, start, &mut bindings)?;
+        let end = Self::match_pattern(&self.pattern, tokens, start, &mut bindings, budget)?;
         Some((end, bindings))
     }
 
@@ -179,6 +251,7 @@ impl Rule {
         tokens: &[Token],
         pos: usize,
         bindings: &mut Bindings,
+        budget: &mut BacktrackBudget,
     ) -> Option<usize> {
         let mut pat_idx = 0;
         let mut tok_idx = pos;
@@ -204,7 +277,8 @@ impl Rule {
                         return None;
                     }
                     if let Token::Bracket(inner_tokens) = &tokens[tok_idx] {
-                        let end = Self::match_pattern(inner_pattern, inner_tokens, 0, bindings)?;
+                        let end =
+                            Self::match_pattern(inner_pattern, inner_tokens, 0, bindings, budget)?;
                         if end != inner_tokens.len() {
                             return None;
                         }
@@ -229,6 +303,9 @@ impl Rule {
                     let remaining_pattern = &pattern[pat_idx + 1..];
                     let available = tokens.len().saturating_sub(tok_idx);
                     for take in (0..=available).rev() {
+                        if !budget.consume() {
+                            return None;
+                        }
                         let captured: Vec<Token> = tokens[tok_idx..tok_idx + take].to_vec();
                         let mut test_bindings = bindings.clone();
                         if !Self::bind_tokens(name, captured, &mut test_bindings) {
@@ -239,6 +316,7 @@ impl Rule {
                             tokens,
                             tok_idx + take,
                             &mut test_bindings,
+                            budget,
                         ) {
                             *bindings = test_bindings;
                             return Some(end);
@@ -289,16 +367,44 @@ impl Rule {
     }
 }
 
+#[derive(Debug, Clone)]
+struct BacktrackBudget {
+    remaining: usize,
+}
+
+impl BacktrackBudget {
+    fn new(max_backtracks: usize) -> Self {
+        Self {
+            remaining: max_backtracks,
+        }
+    }
+
+    fn consume(&mut self) -> bool {
+        if self.remaining == usize::MAX {
+            return true;
+        }
+        if self.remaining == 0 {
+            return false;
+        }
+        self.remaining -= 1;
+        true
+    }
+}
+
 /// An optimizer that applies a set of rules repeatedly.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Optimizer {
     rules: Vec<Rule>,
+    max_backtracks: usize,
 }
 
 impl Optimizer {
     /// Creates a new optimizer with no rules.
     pub fn new() -> Self {
-        Self { rules: Vec::new() }
+        Self {
+            rules: Vec::new(),
+            max_backtracks: 100_000,
+        }
     }
 
     /// Adds a rewrite rule.
@@ -307,13 +413,25 @@ impl Optimizer {
         Ok(())
     }
 
+    /// Set the per-optimize backtracking budget used by `$*name` pattern matching.
+    pub fn set_max_backtracks(&mut self, max_backtracks: usize) {
+        self.max_backtracks = max_backtracks;
+    }
+
+    /// Returns the current per-optimize backtracking budget.
+    pub fn max_backtracks(&self) -> usize {
+        self.max_backtracks
+    }
+
     /// Applies rules until no more changes occur.
     pub fn optimize(&self, tokens: Vec<Token>) -> Vec<Token> {
         let mut current = tokens;
+        let mut seen = HashSet::new();
+        seen.insert(program_hash(&current));
         loop {
             let mut changed = false;
             for rule in &self.rules {
-                if let Some(rewritten) = rule.apply(&current) {
+                if let Some(rewritten) = rule.apply_with_limit(&current, self.max_backtracks) {
                     current = rewritten;
                     changed = true;
                     break;
@@ -322,9 +440,24 @@ impl Optimizer {
             if !changed {
                 break;
             }
+            if !seen.insert(program_hash(&current)) {
+                break;
+            }
         }
         current
     }
+}
+
+impl Default for Optimizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn program_hash(tokens: &[Token]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    tokens.hash(&mut hasher);
+    hasher.finish()
 }
 
 #[cfg(test)]
@@ -551,6 +684,17 @@ mod tests {
     }
 
     #[test]
+    fn cycle_detection_stops_oscillation() {
+        let mut opt = Optimizer::new();
+        opt.add_rule("A", "B").unwrap();
+        opt.add_rule("B", "A").unwrap();
+
+        let tokens = parse("A").unwrap();
+        let result = opt.optimize(tokens.clone());
+        assert_eq!(result, tokens);
+    }
+
+    #[test]
     fn multiple_vars() {
         let mut opt = Optimizer::new();
         opt.add_rule("$X $Y SWAP", "$Y $X").unwrap();
@@ -743,6 +887,29 @@ mod tests {
         let result = Rule::new("A", "$*X");
         assert!(matches!(result, Err(RuleError::UnboundVariable(_))));
         println!("Error: {result:?}");
+    }
+
+    #[test]
+    fn invalid_variable_name_error() {
+        let result = Rule::new("$", "A");
+        assert!(matches!(result, Err(RuleError::InvalidVariableName(_))));
+    }
+
+    #[test]
+    fn mixed_arity_variable_error() {
+        let result = Rule::new("$X", "$*X");
+        assert!(matches!(result, Err(RuleError::VariableArityMismatch(_))));
+    }
+
+    #[test]
+    fn backtrack_limit_can_block_expensive_match() {
+        let mut opt = Optimizer::new();
+        opt.set_max_backtracks(1);
+        opt.add_rule("$*X END", "[$*X]").unwrap();
+
+        let tokens = parse("A B C END").unwrap();
+        let result = opt.optimize(tokens.clone());
+        assert_eq!(result, tokens);
     }
 
     #[test]


### PR DESCRIPTION
Replace EvalError enum with handled::SError for structured errors:
- Add handled dependency and alias EvalError to SError
- Introduce operator_error() constructor with phase and error code
- Export CODE_OPERATOR_ERROR constant for downstream matching
- Migrate all OperatorError variant usages across builtins,
  combinators, and evaluator tests

Harden the optimizer against pathological inputs:
- Add BacktrackBudget to cap $*name matching via apply_with_limit
- Detect rewrite cycles with hash-based seen set in optimize()
- Validate variable names (alphabetic/underscore start, alphanumeric body)
- Reject mixed-arity usage of same variable ($X vs $*X)
- Add RuleError::InvalidVariableName and VariableArityMismatch variants

Enforce stack discipline in sequence combinators:
- MAP, FILTER, FOLD, and EACH verify pre/post stack lengths
- Produce clear error messages on arity violations

Add register_all_builtins convenience function.

Co-authored-by: AI
