### PR TITLE
ci: speed up CI with caching, profiling, and lint fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,11 +6,16 @@ on:
     branches: [ "main" ]
 env:
   CARGO_TERM_COLOR: always
+  CARGO_TOOLS_ROOT: ${{ runner.temp }}/cargo-tools
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: rustc cache key
+      id: rustc
+      run: |
+        echo "commit_hash=$(rustc -Vv | sed -n 's/^commit-hash: //p')" >> "$GITHUB_OUTPUT"
     - uses: actions/cache@v4
       with:
         path: |
@@ -19,7 +24,24 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
+    - name: add cargo tools to PATH
+      run: echo "${CARGO_TOOLS_ROOT}/bin" >> "$GITHUB_PATH"
+    - uses: actions/cache@v4
+      with:
+        path: ${{ env.CARGO_TOOLS_ROOT }}
+        key: ${{ runner.os }}-cargo-tools-${{ steps.rustc.outputs.commit_hash }}-cargo-hack-v1
+    - uses: actions/cache@v4
+      with:
+        path: |
+          target/.rustc_info.json
+          target/release
+        key: ${{ runner.os }}-target-release-${{ steps.rustc.outputs.commit_hash }}-${{ hashFiles('**/Cargo.lock', '.github/workflows/rust.yml', 'ci') }}
+        restore-keys: |
+          ${{ runner.os }}-target-release-${{ steps.rustc.outputs.commit_hash }}-
     - name: cargo hack
-      run: cargo install cargo-hack
+      run: |
+        if [ ! -x "${CARGO_TOOLS_ROOT}/bin/cargo-hack" ]; then
+          cargo install --locked --root "${CARGO_TOOLS_ROOT}" cargo-hack
+        fi
     - name: run ci
       run: ./ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,10 +6,11 @@ on:
     branches: [ "main" ]
 env:
   CARGO_TERM_COLOR: always
-  CARGO_TOOLS_ROOT: ${{ runner.temp }}/cargo-tools
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TOOLS_ROOT: ${{ github.workspace }}/../.cargo-tools
     steps:
     - uses: actions/checkout@v4
     - name: rustc cache key

--- a/caternary/src/combinators.rs
+++ b/caternary/src/combinators.rs
@@ -652,7 +652,7 @@ mod tests {
         let tokens = parse("1 2 [ADD] CALL").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(3)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -661,7 +661,7 @@ mod tests {
         let tokens = parse("1 2 [[ADD] CALL] CALL").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(3)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -670,7 +670,7 @@ mod tests {
         let tokens = parse(r#""hello world" ECHO"#).unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Word("hello world".to_string())]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -679,7 +679,7 @@ mod tests {
         let tokens = parse(r#"["hello world" ECHO]CALL"#).unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Word("hello world".to_string())]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -692,7 +692,7 @@ mod tests {
         let tokens = parse("1 2 3 [ADD] DIP").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(3), Value::Int(3)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -701,7 +701,7 @@ mod tests {
         let tokens = parse("10 20 [DUP] DIP").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(10), Value::Int(10), Value::Int(20)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -714,7 +714,7 @@ mod tests {
         let tokens = parse("5 [DUP MUL] KEEP").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(25), Value::Int(5)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -727,7 +727,7 @@ mod tests {
         let tokens = parse("5 [DUP ADD] [DUP MUL] BI").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(10), Value::Int(25)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -740,7 +740,7 @@ mod tests {
         let tokens = parse("3 4 [DUP MUL] [DUP ADD] BI*").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(9), Value::Int(8)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -753,7 +753,7 @@ mod tests {
         let tokens = parse("3 4 [DUP MUL] BI@").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(9), Value::Int(16)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -766,7 +766,7 @@ mod tests {
         let tokens = parse("5 [[DUP ADD] [DUP MUL] [1 ADD]] CLEAVE").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(10), Value::Int(25), Value::Int(6)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -779,7 +779,7 @@ mod tests {
         let tokens = parse("1 2 3 [[DUP ADD] [DUP MUL] [1 ADD]] SPREAD").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(2), Value::Int(4), Value::Int(4)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -792,7 +792,7 @@ mod tests {
         let tokens = parse("[1 ADD] [2 MUL] COMPOSE 5 SWAP CALL").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(12)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -805,7 +805,7 @@ mod tests {
         let tokens = parse("10 [ADD] CURRY 5 SWAP CALL").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(15)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -818,7 +818,7 @@ mod tests {
         let tokens = parse("true [1] [2] IF").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(1)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -827,7 +827,7 @@ mod tests {
         let tokens = parse("false [1] [2] IF").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(2)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -836,7 +836,7 @@ mod tests {
         let tokens = parse("5 3 GT [yes] [no] IF").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Word("yes".to_string())]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -849,7 +849,7 @@ mod tests {
         let tokens = parse("true [42] WHEN").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(42)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -858,7 +858,7 @@ mod tests {
         let tokens = parse("false [42] WHEN").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert!(result.is_empty());
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -871,7 +871,7 @@ mod tests {
         let tokens = parse("false [42] UNLESS").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(42)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     #[test]
@@ -880,7 +880,7 @@ mod tests {
         let tokens = parse("true [42] UNLESS").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert!(result.is_empty());
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -900,7 +900,7 @@ mod tests {
                 Value::Int(9)
             ])]
         );
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -920,7 +920,7 @@ mod tests {
                 Value::Int(6)
             ])]
         );
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -933,7 +933,7 @@ mod tests {
         let tokens = parse("[1 2 3 4 5] 0 [ADD] FOLD").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(15)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -946,7 +946,7 @@ mod tests {
         let tokens = parse("0 [1 2 3] [ADD] EACH").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(6)]);
-        println!("Stack: {:?}", result);
+        println!("Stack: {result:?}");
     }
 
     // ========================================================================
@@ -959,7 +959,7 @@ mod tests {
         let tokens = parse("42 CALL").unwrap();
         let result = eval.eval(&tokens);
         assert!(result.is_err());
-        println!("Error: {:?}", result);
+        println!("Error: {result:?}");
     }
 
     #[test]
@@ -968,6 +968,6 @@ mod tests {
         let tokens = parse("[ADD] DIP").unwrap();
         let result = eval.eval(&tokens);
         assert!(result.is_err());
-        println!("Error: {:?}", result);
+        println!("Error: {result:?}");
     }
 }

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -265,6 +265,7 @@ mod tests {
 
     #[test]
     fn operator_error_propagates() {
+        #[allow(clippy::ptr_arg)]
         fn fail(_stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {
             Err(operator_error("intentional failure"))
         }
@@ -474,6 +475,7 @@ mod tests {
 
     #[test]
     fn redefine_operator() {
+        #[allow(clippy::ptr_arg)]
         fn first(_stack: &mut Vec<Value>, _eval: &Evaluator<Value>) -> Result<(), EvalError> {
             Err(operator_error("first"))
         }

--- a/ci
+++ b/ci
@@ -59,6 +59,29 @@ package_name_for_member() {
     ' "$1/Cargo.toml"
 }
 
+manifest_has_default_feature() {
+    awk '
+        $0 == "[features]" {
+            in_features = 1
+            next
+        }
+        /^\[/ {
+            in_features = 0
+        }
+        in_features {
+            line = $0
+            sub(/[[:space:]]*#.*$/, "", line)
+            if (line ~ /^[[:space:]]*default[[:space:]]*=/) {
+                found = 1
+                exit 0
+            }
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$1/Cargo.toml"
+}
+
 run_binaries_check() {
     (
         cd "$1"
@@ -133,11 +156,16 @@ done < .ci.packages
 for package in "${packages[@]}"
 do
     package_name="$(package_name_for_member "$package")"
-    if rg -q '^default\s*=' "$package/Cargo.toml"
+    if manifest_has_default_feature "$package"
     then
         run_profiled package/test "${package_name} cargo hack" \
             cargo hack -p "$package_name" --feature-powerset --exclude-features default test --release
     else
+        status=$?
+        if [ "$status" -ne 1 ]
+        then
+            exit "$status"
+        fi
         run_profiled package/test "${package_name} cargo hack" \
             cargo hack -p "$package_name" --feature-powerset test --release
     fi

--- a/ci
+++ b/ci
@@ -5,23 +5,145 @@ set -u
 set -o errexit
 set -o pipefail
 
-cargo fmt -- --check
+ROOTDIR="$(pwd)"
+PROFILE_LOG="${ROOTDIR}/.ci.profile"
+TAB="$(printf '\t')"
 
-ROOTDIR="`pwd`"
-export PATH="$PATH":"`pwd`"/target/release
+format_duration() {
+    local total_seconds="$1"
+    local hours=$((total_seconds / 3600))
+    local minutes=$(((total_seconds % 3600) / 60))
+    local seconds=$((total_seconds % 60))
+    printf '%02d:%02d:%02d' "$hours" "$minutes" "$seconds"
+}
 
-cargo build --release --bins
-target/release/publish > .ci.packages
+record_profile() {
+    local phase="$1"
+    local label="$2"
+    local elapsed="$3"
+    printf '%s\t%s\t%s\n' "$phase" "$elapsed" "$label" >> "$PROFILE_LOG"
+    printf '[ci][%s] %s %s\n' "$phase" "$(format_duration "$elapsed")" "$label"
+}
 
-for package in `cat .ci.packages`
+run_profiled() {
+    local phase="$1"
+    local label="$2"
+    shift 2
+    local start=$SECONDS
+    local status=0
+    if "$@"
+    then
+        status=0
+    else
+        status=$?
+    fi
+    local elapsed=$((SECONDS - start))
+    record_profile "$phase" "$label" "$elapsed"
+    return "$status"
+}
+
+package_name_for_member() {
+    awk '
+        $0 == "[package]" {
+            in_package = 1
+            next
+        }
+        /^\[/ {
+            in_package = 0
+        }
+        in_package && $1 == "name" {
+            gsub(/"/, "", $3)
+            print $3
+            exit
+        }
+    ' "$1/Cargo.toml"
+}
+
+run_binaries_check() {
+    (
+        cd "$1"
+        "${ROOTDIR}/target/release/binaries"
+    )
+}
+
+print_profile_summary() {
+    if [ ! -f "$PROFILE_LOG" ]
+    then
+        return
+    fi
+
+    echo "CI PROFILE SUMMARY BY PHASE"
+    awk -F "$TAB" '
+        {
+            elapsed[$1] += $2;
+            count[$1] += 1;
+        }
+        END {
+            for (phase in elapsed) {
+                printf "%s\t%d\t%d\n", phase, elapsed[phase], count[phase];
+            }
+        }
+    ' "$PROFILE_LOG" | sort -t "$TAB" -k2,2nr | while IFS="$TAB" read -r phase elapsed count
+    do
+        printf '  %s  %3s  %s\n' "$(format_duration "$elapsed")" "$count" "$phase"
+    done
+
+    echo "CI PROFILE SLOWEST STEPS"
+    sort -t "$TAB" -k2,2nr "$PROFILE_LOG" | head -n 10 | while IFS="$TAB" read -r phase elapsed label
+    do
+        printf '  %s  %-18s  %s\n' "$(format_duration "$elapsed")" "$phase" "$label"
+    done
+}
+
+on_exit() {
+    local status=$?
+    set +x
+    print_profile_summary
+    if [ "$status" -eq 0 ]
+    then
+        echo SUCCESS: this concludes our successful CI adventure
+    fi
+    return "$status"
+}
+
+: > "$PROFILE_LOG"
+trap on_exit EXIT
+
+export PATH="$PATH":"${ROOTDIR}/target/release"
+
+run_profiled workspace/fmt "cargo fmt -- --check" \
+    cargo fmt -- --check
+
+# Integration tests expect the workspace binaries to be present in target/release.
+run_profiled workspace/build-bins "cargo build --release --bins" \
+    cargo build --release --bins
+
+run_profiled workspace/package-list "target/release/publish > .ci.packages" \
+    bash -c 'target/release/publish > .ci.packages'
+
+run_profiled workspace/clippy "cargo clippy --workspace --exclude ci --exclude paxos_pb --no-deps --all-targets" \
+    cargo clippy --workspace --exclude ci --exclude paxos_pb --no-deps --all-targets -- -D warnings -D clippy::all
+
+packages=()
+while IFS= read -r package
 do
-    pushd $package
-    cargo clippy --no-deps --all-targets -- -D warnings -D clippy::all
-    cargo hack --feature-powerset test --release
-    cargo doc --no-deps
-    "${ROOTDIR}/target/release/binaries"
-    popd
+    packages+=("$package")
+done < .ci.packages
+
+for package in "${packages[@]}"
+do
+    package_name="$(package_name_for_member "$package")"
+    if rg -q '^default\s*=' "$package/Cargo.toml"
+    then
+        run_profiled package/test "${package_name} cargo hack" \
+            cargo hack -p "$package_name" --feature-powerset --exclude-features default test --release
+    else
+        run_profiled package/test "${package_name} cargo hack" \
+            cargo hack -p "$package_name" --feature-powerset test --release
+    fi
+    run_profiled package/binaries "${package} binaries" \
+        run_binaries_check "$package"
 done
 
-set +x
-echo SUCCESS: this concludes our successful CI adventure
+run_profiled workspace/doc "cargo doc --workspace --exclude ci --exclude paxos_pb --no-deps" \
+    cargo doc --workspace --exclude ci --exclude paxos_pb --no-deps

--- a/rc_conf/tests/invoke.rs
+++ b/rc_conf/tests/invoke.rs
@@ -1,97 +1,65 @@
-#[test]
-fn example1() {
-    use std::process::Command;
+mod common;
 
-    // Test rcinvoke as an integration test by spawning it as a subprocess
+use std::path::Path;
+use std::process::{Command, Output};
+
+use common::cargo_dir;
+
+fn run_rcinvoke(service: &str) -> Output {
+    let cargo_dir = cargo_dir();
+    let cargo_dir = cargo_dir.into_std();
+    let rcinvoke = cargo_dir.join("rcinvoke");
+    let cargo_dir = cargo_dir
+        .to_str()
+        .expect("cargo_dir should be valid UTF-8")
+        .to_string();
     let current_path = std::env::var("PATH").unwrap_or_default();
-    let debug_path = "../target/debug";
     let new_path = if current_path.is_empty() {
-        debug_path.to_string()
+        cargo_dir
     } else {
-        format!("{debug_path}:{current_path}")
+        format!("{cargo_dir}:{current_path}")
     };
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--bin",
-            "rcinvoke",
-            "--",
-            "--rc-conf-path",
-            "rc.conf",
-            "--rc-d-path",
-            "rc.d",
-            "example1",
-        ])
+    Command::new(rcinvoke)
+        .args(["--rc-conf-path", "rc.conf", "--rc-d-path", "rc.d", service])
+        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
         .env("PATH", new_path)
-        .output();
+        .output()
+        .expect("rcinvoke should spawn")
+}
 
-    match output {
-        Ok(output) => {
-            // The command should execute and return a status code
-            // It may fail due to service not being enabled or other config issues,
-            // but it should not panic or hang indefinitely
-            assert!(
-                output.status.code().is_some(),
-                "rcinvoke should exit with a status code: stderr={}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-        Err(e) => {
-            panic!("Failed to execute rcinvoke integration test: {e}");
-        }
-    }
+#[test]
+fn example1() {
+    let output = run_rcinvoke("example1");
+
+    // The command should execute and return a status code.
+    // It may fail due to service not being enabled or other config issues,
+    // but it should not panic or hang indefinitely.
+    assert!(
+        output.status.code().is_some(),
+        "rcinvoke should exit with a status code: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
 fn jfk_planetexpress_example4() {
-    use std::process::Command;
+    let output = run_rcinvoke("Jfk_PlanetExpress_example4");
 
-    // Test that Jfk_PlanetExpress_example4 produces the expected output
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    let debug_path = "../target/debug";
-    let new_path = if current_path.is_empty() {
-        debug_path.to_string()
-    } else {
-        format!("{debug_path}:{current_path}")
-    };
+    assert!(
+        output.status.success(),
+        "rcinvoke should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--bin",
-            "rcinvoke",
-            "--",
-            "--rc-conf-path",
-            "rc.conf",
-            "--rc-d-path",
-            "rc.d",
-            "Jfk_PlanetExpress_example4",
-        ])
-        .env("PATH", new_path)
-        .output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = "['--field1', 'Good News', '--field2', 'Everyone!']\n";
 
-    match output {
-        Ok(output) => {
-            assert!(
-                output.status.success(),
-                "rcinvoke should succeed: stderr={}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let expected = "['--field1', 'Good News', '--field2', 'Everyone!']\n";
-
-            assert_eq!(
-                stdout.trim(),
-                expected.trim(),
-                "Output should match expected format. Got: {}, Expected: {}",
-                stdout.trim(),
-                expected.trim()
-            );
-        }
-        Err(e) => {
-            panic!("Failed to execute rcinvoke integration test: {e}");
-        }
-    }
+    assert_eq!(
+        stdout.trim(),
+        expected.trim(),
+        "Output should match expected format. Got: {}, Expected: {}",
+        stdout.trim(),
+        expected.trim()
+    );
 }


### PR DESCRIPTION
Rework the GitHub Actions workflow and the ci script to reduce
wall-clock time on repeat runs:

- Cache cargo-hack in a separate .cargo-tools prefix keyed by the
  rustc commit hash so it is only installed once per toolchain.
- Cache target/release artifacts keyed by rustc, Cargo.lock, the
  workflow file, and the ci script itself.
- Run clippy and doc at the workspace level instead of per-package,
  avoiding redundant dependency analysis.
- Add run_profiled helper and an EXIT trap that prints a per-phase
  summary and the ten slowest steps.
- Detect a "default" feature in Cargo.toml and pass
  --exclude-features default to cargo hack so the powerset does not
  include it.

Also fix minor lint issues surfaced by the stricter CI:

- Inline format args in caternary test println! calls
  (clippy::uninlined_format_args).
- Allow clippy::ptr_arg on two test-only operator functions in
  caternary/src/evaluator.rs.
- Refactor rc_conf integration tests to call the pre-built rcinvoke
  binary directly instead of spawning cargo run, removing duplicated
  PATH setup into a   PATH setup into a   PATH sethored-by: AI

Co-authored-by: AI
