### PR TITLE
fix(rc_conf): harden error handling and fix argument indexing

### DIFF
--- a/caternary/src/parser.rs
+++ b/caternary/src/parser.rs
@@ -257,7 +257,7 @@ fn shell_words(input: &str) -> Result<Vec<ShellWord>, ParseError> {
     debug_assert_eq!(split.len(), spans.len());
 
     let mut shell_words = Vec::with_capacity(split.len());
-    for (text, span) in split.into_iter().zip(spans.into_iter()) {
+    for (text, span) in split.into_iter().zip(spans) {
         let emitted = decode_shell_word(&input[span.start..span.end], span.start);
         debug_assert_eq!(text, emitted.iter().map(|c| c.ch).collect::<String>());
         shell_words.push(ShellWord {

--- a/rc_conf/src/bin/rcbootstrap.rs
+++ b/rc_conf/src/bin/rcbootstrap.rs
@@ -39,6 +39,7 @@ fn main() {
         }
         Err(err) => {
             eprintln!("{err:#?}");
+            std::process::exit(1);
         }
     }
 }

--- a/rc_conf/src/bin/rccat.rs
+++ b/rc_conf/src/bin/rccat.rs
@@ -45,7 +45,7 @@ fn main() {
     let name = if let Ok(path) = std::env::var("RCVAR_ARGV0") {
         path.to_string()
     } else {
-        rc_conf::name_from_path(&Path::new(&args[0]))
+        rc_conf::name_from_path(&Path::new(&args[1]))
     };
     let prefix = rc_conf::var_prefix_from_service(&name);
     // Read stdin.

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -1534,13 +1534,17 @@ edition = "2021"
         .arg("vendor")
         .arg("--no-delete")
         .arg("--manifest-path")
-        .arg(tmp)
+        .arg(&tmp)
         .arg(path.as_str())
         .output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(Error::exec_failed(
-            format!("cargo vendor --no-delete --manifest-path {} {}", tmp.as_str(), path.as_str()),
+            format!(
+                "cargo vendor --no-delete --manifest-path {} {}",
+                tmp.display(),
+                path.as_str()
+            ),
             std::io::Error::other(format!("command failed: {stderr}")),
         ));
     }

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -493,6 +493,9 @@ impl RcScript {
 
         let exp = shvar::expand_recursive(&(&meta, &evp), &self.command)?;
         let mut cmd = shvar::split(&exp)?;
+        if cmd.is_empty() {
+            return Err(Error::invalid_invocation("expanded command is empty"));
+        }
         if !args.is_empty() {
             cmd.push("--".to_string());
         }
@@ -942,6 +945,9 @@ impl RcConf {
         path: &Path,
         items: &mut HashMap<String, String>,
     ) -> Result<(), Error> {
+        if !is_safe_source_path(path.as_str()) {
+            return Err(Error::invalid_rc_conf(path, 0, "unsafe source path"));
+        }
         let contents = std::fs::read_to_string(path.as_str())?;
         for (number, line, _) in linearize(path, &contents)? {
             if line.trim().starts_with('#') || line.trim().is_empty() {
@@ -1524,13 +1530,20 @@ edition = "2021"
 "#
         ),
     )?;
-    std::process::Command::new("cargo")
+    let output = std::process::Command::new("cargo")
         .arg("vendor")
         .arg("--no-delete")
         .arg("--manifest-path")
         .arg(tmp)
         .arg(path.as_str())
         .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::exec_failed(
+            format!("cargo vendor --no-delete --manifest-path {} {}", tmp.as_str(), path.as_str()),
+            std::io::Error::other(format!("command failed: {stderr}")),
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Exit with status 1 on error in rcbootstrap instead of silently
succeeding. Fix off-by-one in rccat where name_from_path read
args[0] (the binary) instead of args[1] (the script path).

Add defensive checks in the library:
- Guard against empty expanded command in RcScript invocation.
- Validate source paths with is_safe_source_path before reading.
- Check cargo vendor exit status and propagate a meaningful error.

Co-authored-by: AI
