### PR TITLE
fix(rc_conf,rustrc): harden source resolution, shutdown, and convergence

### DIFF
--- a/rc_conf/README.md
+++ b/rc_conf/README.md
@@ -94,6 +94,12 @@ Warts
 -----
 
 - A string with `'{'` and `'}'` characters outside the variable declarations won't parse right now.
+- `source` directives are now resolved relative to the file containing the directive.
+
+Backwards-Incompatible Changes
+------------------------------
+
+- `source` paths now resolve relative to the current rc file directory rather than process working directory.  If you previously relied on cwd-based relative sources, update those directives so they resolve from the owning file’s directory.
 
 Updating
 --------

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::time::SystemTime;
@@ -831,7 +832,7 @@ impl RcConf {
             }
             if let Some(source) = line.trim().strip_prefix("source ") {
                 if is_safe_source_path(source) {
-                    Self::parse_recursive(&Path::from(source), seen, items)?;
+                    Self::parse_recursive(&path.dirname().join(source), seen, items)?;
                 } else {
                     return Err(Error::invalid_rc_conf(path, number, "unsafe source path"));
                 }
@@ -1005,10 +1006,9 @@ impl RcConf {
                 if !is_safe_source_path(source) {
                     return Err(Error::invalid_rc_conf(path, number, "unsafe source path"));
                 }
-                let source = Path::from(source);
+                let source = path.dirname().join(source);
                 if !seen.contains(&source) {
                     *rc_conf += &format!("# begin source {source:?}\n");
-                    seen.insert(path.clone().into_owned());
                     Self::examine_recursive(&source, seen, rc_conf)?;
                     *rc_conf += &format!("# end source {source:?}\n");
                 } else {
@@ -1326,7 +1326,12 @@ pub fn load_services(
         }
         for dirent in std::fs::read_dir(rc_d)? {
             let dirent = dirent?;
-            let path = Path::try_from(dirent.path())?.into_owned();
+            let dirent_path = dirent.path();
+            let metadata = std::fs::metadata(&dirent_path)?;
+            if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
+                continue;
+            }
+            let path = Path::try_from(dirent_path)?.into_owned();
             let name = dirent.file_name().to_string_lossy().to_string();
             match services.entry(name) {
                 Entry::Occupied(mut entry) => {

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -569,6 +569,10 @@ fn is_safe_source_path(path: &str) -> bool {
     true
 }
 
+fn strip_self_dir_prefix(path: &Path) -> Path<'static> {
+    Path::from(path.as_str().trim_start_matches("./").to_string())
+}
+
 impl shvar::VariableProvider for EnvironmentVariableProvider {
     fn lookup(&self, ident: &str) -> Option<String> {
         // Sanitize environment variable name: must be valid identifier
@@ -624,7 +628,7 @@ impl RcConf {
         let mut seen = HashSet::default();
         let mut items = HashMap::default();
         for piece in path.split(':') {
-            let piece = Path::from(piece);
+            let piece = strip_self_dir_prefix(&Path::from(piece));
             if !piece.exists() {
                 continue;
             }
@@ -832,7 +836,8 @@ impl RcConf {
             }
             if let Some(source) = line.trim().strip_prefix("source ") {
                 if is_safe_source_path(source) {
-                    Self::parse_recursive(&path.dirname().join(source), seen, items)?;
+                    let source = strip_self_dir_prefix(&path.dirname().join(source));
+                    Self::parse_recursive(&source, seen, items)?;
                 } else {
                     return Err(Error::invalid_rc_conf(path, number, "unsafe source path"));
                 }
@@ -975,7 +980,7 @@ impl RcConf {
         let mut seen = HashSet::default();
         let mut rc_conf = String::new();
         for (idx, piece) in path.split(':').enumerate() {
-            let piece = Path::from(piece);
+            let piece = strip_self_dir_prefix(&Path::from(piece));
             if !piece.exists() {
                 continue;
             }
@@ -1006,7 +1011,7 @@ impl RcConf {
                 if !is_safe_source_path(source) {
                     return Err(Error::invalid_rc_conf(path, number, "unsafe source path"));
                 }
-                let source = path.dirname().join(source);
+                let source = strip_self_dir_prefix(&path.dirname().join(source));
                 if !seen.contains(&source) {
                     *rc_conf += &format!("# begin source {source:?}\n");
                     Self::examine_recursive(&source, seen, rc_conf)?;

--- a/rustrc/README.md
+++ b/rustrc/README.md
@@ -12,6 +12,7 @@ Scope
 -----
 
 This library provides the rustrc binary.
+It consumes `rc_conf` configuration files and therefore inherits any breaking parser behavior changes (for example anchored `source` resolution).
 
 Documentation
 -------------

--- a/rustrc/src/bin/rustrc.rs
+++ b/rustrc/src/bin/rustrc.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use arrrg::CommandLine;
 use utf8path::Path;
@@ -181,10 +182,18 @@ fn main() {
     // Create a thread to listen for signals and cancel the context if need be.
     let signal_pid1 = Arc::downgrade(&pid1);
     let signal_context = context.clone();
+    let signal_running = Arc::new(AtomicBool::new(true));
+    let signal_running_thread = Arc::clone(&signal_running);
     let signal = std::thread::spawn(move || {
         loop {
+            if !signal_running_thread.load(Ordering::Acquire) {
+                break;
+            }
             let signal_set = minimal_signals::SignalSet::new().fill();
             let signal = minimal_signals::wait(signal_set);
+            if !signal_running_thread.load(Ordering::Acquire) {
+                break;
+            }
             if signal == Some(minimal_signals::SIGCHLD) {
                 continue;
             }
@@ -212,7 +221,9 @@ fn main() {
 
     // Cleanup
     server.join().unwrap();
-    drop(signal);
+    signal_running.store(false, Ordering::Release);
+    let _ = unsafe { libc::kill(libc::getpid(), libc::SIGCHLD) };
+    signal.join().unwrap();
     let _ = std::fs::remove_file(options.control_sock);
 
     // NOTE(rescrv):  This is a spin loop because there's no good way to synchronize this simply.

--- a/rustrc/src/lib.rs
+++ b/rustrc/src/lib.rs
@@ -293,7 +293,7 @@ impl From<&Error> for indicio::Value {
             }
             Error::NulError => {
                 indicio::value!({
-                    generating_execution_id: true,
+                    nul_error: true,
                 })
             }
         }
@@ -666,12 +666,9 @@ impl Pid1 {
             {
                 let mut state = state.lock().unwrap();
                 state.processes.retain(|p| !Arc::ptr_eq(p, &exec));
-                state.converge = state.converge.saturating_add(1);
                 state.set_backoff(service, Instant::now() + backoff);
                 coord.converge.notify_all();
-                if state.converge == u64::MAX {
-                    todo!();
-                }
+                state.converge = state.converge.wrapping_add(1);
             }
         }
     }
@@ -687,7 +684,7 @@ impl Pid1 {
             let c = {
                 let mut state = state.lock().unwrap();
                 clue!(COLLECTOR, INFO, { wait: format!("{:?}", wait), });
-                while !state.shutdown && converge >= state.converge {
+                while !state.shutdown && converge == state.converge {
                     let timed_out: WaitTimeoutResult;
                     (state, timed_out) = coord.converge.wait_timeout(state, wait).unwrap();
                     if timed_out.timed_out() {
@@ -891,10 +888,7 @@ impl Pid1 {
         {
             let mut state = self.state.lock().unwrap();
             state.config = config;
-            state.converge = state.converge.saturating_add(1);
-            if state.converge == u64::MAX {
-                todo!();
-            }
+            state.converge = state.converge.wrapping_add(1);
         }
         self.coord.converge.notify_all();
         Ok(())
@@ -1003,7 +997,7 @@ impl Pid1 {
         if state.service_switch(service) == SwitchPosition::Manual {
             state.spawn(&self.coord, self.reclaim.clone(), service, &[])?;
         }
-        state.converge += 1;
+        state.converge = state.converge.wrapping_add(1);
         self.coord.converge.notify_all();
         Ok(())
     }
@@ -1024,7 +1018,7 @@ impl Pid1 {
         };
         while let Some(proc) = processes.pop() {
             if proc.pid().is_none() {
-                todo!();
+                continue;
             }
             for iter in 1..=3 {
                 for _ in 0..(1 << iter) * 10 {


### PR DESCRIPTION
rc_conf changes:
- Resolve source directives relative to the containing file directory
  instead of the process working directory.
- Skip non-file and non-executable entries when scanning rc.d
  directories in load_services.
- Remove a spurious seen.insert of the parent path in
  examine_recursive that prevented correct cycle detection.

rustrc binary changes:
- Cleanly join the signal-handling thread on shutdown by using an
  AtomicBool flag and a self-directed SIGCHLD to unblock
  minimal_signals::wait, replacing the previous drop-and-leak.

rustrc library changes:
- Replace saturating_add with wrapping_add for the converge counter
  and remove the unreachable todo!() guard on u64::MAX.
- Fix the converge loop predicate from >= to == so a single
  notification is sufficient to unblock the coordinator.
- Replace todo!() with continue when stopping a process whose pid
  is not yet assigned.
- Correct the indicio::Value label for NulError from
  generating_execution_id to nul_error.

BREAKING CHANGE: source paths in rc.conf now resolve relative to
the owning file rather than the process working directory.

Co-authored-by: AI
