### PR TITLE
fix(rc_conf,rustrc): validate services before exec and rollback on reconfigure failure

### DIFF
--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -1435,7 +1435,7 @@ fn exec_rc_with_override(
 /// This does not return.
 pub fn exec_container(
     rc_conf_path: &str,
-    _: &str,
+    rc_d_path: &str,
     command: &str,
     container: &str,
     service: &str,
@@ -1445,9 +1445,33 @@ pub fn exec_container(
         eprintln!("failed to parse rc_conf: {e}");
         std::process::exit(133);
     });
+    let rc_d = load_services(rc_d_path).unwrap_or_else(|e| {
+        eprintln!("failed to load services: {e}");
+        std::process::exit(134);
+    });
     if !rc_conf.service_switch(service).can_be_started() {
         eprintln!("service not enabled");
         std::process::exit(132);
+    }
+    let path = if let Some(alias) = rc_conf.aliases.get(service) {
+        let Some(path) = rc_d.get(rc_conf.resolve_alias(&alias.aliases)) else {
+            eprintln!("expected alias of service to be available via --rc-d-path");
+            std::process::exit(130);
+        };
+        path
+    } else {
+        let Some(path) = rc_d.get(service) else {
+            eprintln!("expected service to be available via --rc-d-path");
+            std::process::exit(130);
+        };
+        path
+    };
+    match path {
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("service encountered an error: {err:?}");
+            std::process::exit(131);
+        }
     }
     let mut env = HashMap::new();
     env.insert("RCVAR_ARGV0".to_string(), var_name_from_service(service));

--- a/rustrc/src/lib.rs
+++ b/rustrc/src/lib.rs
@@ -869,11 +869,18 @@ impl Pid1 {
         clue!(COLLECTOR, INFO, {
             reconfigure: indicio::Value::from(&options),
         });
-        {
-            let options2 = options.clone();
-            *self.options.lock().unwrap() = options2;
+        let mut options_guard = self.options.lock().unwrap();
+        let previous_options = options_guard.clone();
+        *options_guard = options.clone();
+        drop(options_guard);
+
+        if let Err(error) = self.reload() {
+            let mut options_guard = self.options.lock().unwrap();
+            *options_guard = previous_options;
+            Err(error)
+        } else {
+            Ok(())
         }
-        self.reload()
     }
 
     /// Reload the configuration from the rc_conf and rc.d paths provided as of the last


### PR DESCRIPTION
In exec_container, load and validate the service script from rc_d_path
before proceeding with execution. Resolve aliases and check that the
service entry both exists and parses without error, exiting early with
a diagnostic message on failure. The rc_d_path parameter was previously
ignored.

In Pid1::reconfigure, save the previous options before applying new
ones. If reload() fails, restore the previous options to maintain a
consistent state rather than leaving partially-applied configuration.

Co-authored-by: AI
