### PR TITLE
fix(rc_conf): remove service switch override and harden CLI error handling

### DIFF
--- a/rc_conf/README.md
+++ b/rc_conf/README.md
@@ -99,6 +99,9 @@ Warts
 Backwards-Incompatible Changes
 ------------------------------
 
+- `RCCONF_OVERRIDE_SERVICE_SWITCH` was removed. Service enablement checks are now always
+  enforced when invoking services via `rcinvoke`, `rcvar`, or `rccontainer`.
+
 - `source` paths now resolve relative to the current rc file directory rather than process working directory.  If you previously relied on cwd-based relative sources, update those directives so they resolve from the owning file’s directory.
 
 Updating

--- a/rc_conf/src/bin/rccat.rs
+++ b/rc_conf/src/bin/rccat.rs
@@ -49,12 +49,23 @@ fn main() {
     };
     let prefix = rc_conf::var_prefix_from_service(&name);
     // Read stdin.
-    let stdin = std::fs::read_to_string(&args[1]).unwrap();
+    let stdin = match std::fs::read_to_string(&args[1]) {
+        Ok(stdin) => stdin,
+        Err(err) => {
+            eprintln!("failed to read rcscript file {}: {err}", args[1]);
+            std::process::exit(129);
+        }
+    };
     if args[2] == "describe" {
         println!("{}", stdin.trim_end());
     } else if args[2] == "rcvar" {
-        let mut rcvar = shvar::rcvar(&stdin)
-            .expect("shell variable substitution should be valid")
+        let mut rcvar = match shvar::rcvar(&stdin) {
+            Ok(vars) => vars,
+            Err(err) => {
+                eprintln!("invalid rcscript input: {err}");
+                std::process::exit(130);
+            }
+        }
             .into_iter()
             .map(|v| format!("{prefix}{v}"))
             .collect::<Vec<_>>();
@@ -62,10 +73,15 @@ fn main() {
         println!("{}", rcvar.join("\n"));
     } else if args[2] == "run" {
         let evp = rc_conf::EnvironmentVariableProvider::new(Some(prefix.clone()));
-        let meta = HashMap::from([("NAME".to_string(), prefix)]);
+        let meta = HashMap::from([("NAME".to_string(), name)]);
         for line in stdin.lines() {
-            let out = shvar::expand_recursive(&(&meta, &evp), line)
-                .expect("shell variable expansion should be valid");
+            let out = match shvar::expand_recursive(&(&meta, &evp), line) {
+                Ok(out) => out,
+                Err(err) => {
+                    eprintln!("failed to expand rcscript line: {err}");
+                    std::process::exit(131);
+                }
+            };
             println!("{}", out.trim_end());
         }
     } else {

--- a/rc_conf/src/bin/rccat.rs
+++ b/rc_conf/src/bin/rccat.rs
@@ -66,9 +66,9 @@ fn main() {
                 std::process::exit(130);
             }
         }
-            .into_iter()
-            .map(|v| format!("{prefix}{v}"))
-            .collect::<Vec<_>>();
+        .into_iter()
+        .map(|v| format!("{prefix}{v}"))
+        .collect::<Vec<_>>();
         rcvar.sort();
         println!("{}", rcvar.join("\n"));
     } else if args[2] == "run" {

--- a/rc_conf/src/bin/rccontainer.rs
+++ b/rc_conf/src/bin/rccontainer.rs
@@ -39,6 +39,10 @@ fn main() {
         eprintln!("expected container and service name to be provided");
         std::process::exit(129);
     }
+    if options.runtime != "docker" && options.runtime != "podman" {
+        eprintln!("runtime must be either docker or podman");
+        std::process::exit(129);
+    }
     rc_conf::exec_container(
         &options.rc_conf_path,
         &options.rc_d_path,

--- a/rc_conf/src/bin/rcdebug.rs
+++ b/rc_conf/src/bin/rcdebug.rs
@@ -6,11 +6,19 @@ use rc_conf::RcConf;
 
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
+    let mut failed = false;
 
     for path in args[1..].iter() {
-        println!(
-            "{:#?}",
-            RcConf::parse(path).expect("parse should always succeed")
-        );
+        match RcConf::parse(path) {
+            Ok(conf) => println!("{conf:#?}"),
+            Err(err) => {
+                eprintln!("failed to parse rc_conf path {path}: {err}");
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        std::process::exit(1);
     }
 }

--- a/rc_conf/src/bin/rcexamine.rs
+++ b/rc_conf/src/bin/rcexamine.rs
@@ -6,11 +6,19 @@ use rc_conf::RcConf;
 
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
+    let mut failed = false;
 
     for path in args[1..].iter() {
-        println!(
-            "{}",
-            RcConf::examine(path).expect("examine should always succeed")
-        );
+        match RcConf::examine(path) {
+            Ok(conf) => println!("{conf}"),
+            Err(err) => {
+                eprintln!("failed to examine rc_conf path {path}: {err}");
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        std::process::exit(1);
     }
 }

--- a/rc_conf/src/bin/rclist.rs
+++ b/rc_conf/src/bin/rclist.rs
@@ -5,6 +5,7 @@
 fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let mut first = true;
+    let mut failed = false;
 
     for path in args[1..].iter() {
         if !first {
@@ -12,17 +13,28 @@ fn main() {
         }
         first = false;
         println!("PATH={path}");
-        for (service, status) in
-            rc_conf::load_services(path).expect("examine should always succeed")
-        {
-            match status {
-                Ok(path) => {
-                    println!("{service}\t{path:?}");
-                }
-                Err(why) => {
-                    println!("{service} encountered error: {why}");
+        match rc_conf::load_services(path) {
+            Ok(services) => {
+                for (service, status) in services {
+                    match status {
+                        Ok(path) => {
+                            println!("{service}\t{path:?}");
+                        }
+                        Err(why) => {
+                            println!("{service} encountered error: {why}");
+                        }
+                    }
                 }
             }
+            Err(err) => {
+                eprintln!("failed to load services from {path}: {err}");
+                failed = true;
+                continue;
+            }
         }
+    }
+
+    if failed {
+        std::process::exit(1);
     }
 }

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -1375,12 +1375,7 @@ pub fn exec_rc(rc_conf_path: &str, rc_d_path: &str, service: &str, cmd: &[&str])
     exec_rc_with_override(rc_conf_path, rc_d_path, service, cmd)
 }
 
-fn exec_rc_with_override(
-    rc_conf_path: &str,
-    rc_d_path: &str,
-    service: &str,
-    cmd: &[&str],
-) -> ! {
+fn exec_rc_with_override(rc_conf_path: &str, rc_d_path: &str, service: &str, cmd: &[&str]) -> ! {
     let rc_conf = RcConf::parse(rc_conf_path).unwrap_or_else(|e| {
         eprintln!("failed to parse rc_conf: {e}");
         std::process::exit(133);
@@ -1519,24 +1514,14 @@ pub fn exec_container(
 pub fn invoke(rc_conf_path: &str, rc_d_path: &str, service: &str, args: &[&str]) -> ! {
     let mut cmd = vec!["run"];
     cmd.extend(args);
-    exec_rc_with_override(
-        rc_conf_path,
-        rc_d_path,
-        service,
-        &cmd,
-    )
+    exec_rc_with_override(rc_conf_path, rc_d_path, service, &cmd)
 }
 
 /////////////////////////////////////////////// rcvar //////////////////////////////////////////////
 
 /// exec_rc the service in a way that prints rcvariables.
 pub fn rcvar(rc_conf_path: &str, rc_d_path: &str, service: &str) -> ! {
-    exec_rc_with_override(
-        rc_conf_path,
-        rc_d_path,
-        service,
-        &["rcvar"],
-    )
+    exec_rc_with_override(rc_conf_path, rc_d_path, service, &["rcvar"])
 }
 
 ///////////////////////////////////////////// bootstrap ////////////////////////////////////////////

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -1165,8 +1165,6 @@ impl RcConf {
             .arg("-t")
             .arg("-e")
             .arg(format!("RCVAR_ARGV0={}", var_name_from_service(service)))
-            .arg("-e")
-            .arg("RCCONF_OVERRIDE_SERVICE_SWITCH=true")
             .arg("--entrypoint")
             .arg("rcvar")
             .arg(container)
@@ -1374,13 +1372,12 @@ pub fn load_services(
 ///
 /// This does not return.
 pub fn exec_rc(rc_conf_path: &str, rc_d_path: &str, service: &str, cmd: &[&str]) -> ! {
-    exec_rc_with_override(rc_conf_path, rc_d_path, false, service, cmd)
+    exec_rc_with_override(rc_conf_path, rc_d_path, service, cmd)
 }
 
 fn exec_rc_with_override(
     rc_conf_path: &str,
     rc_d_path: &str,
-    override_service_switch: bool,
     service: &str,
     cmd: &[&str],
 ) -> ! {
@@ -1392,7 +1389,7 @@ fn exec_rc_with_override(
         eprintln!("failed to load services: {e}");
         std::process::exit(134);
     });
-    if !override_service_switch && !rc_conf.service_switch(service).can_be_started() {
+    if !rc_conf.service_switch(service).can_be_started() {
         eprintln!("service not enabled");
         std::process::exit(132);
     }
@@ -1463,8 +1460,7 @@ pub fn exec_container(
         eprintln!("failed to load services: {e}");
         std::process::exit(134);
     });
-    let override_service_switch = std::env::var("RCCONF_OVERRIDE_SERVICE_SWITCH").is_ok();
-    if !override_service_switch && !rc_conf.service_switch(service).can_be_started() {
+    if !rc_conf.service_switch(service).can_be_started() {
         eprintln!("service not enabled");
         std::process::exit(132);
     }
@@ -1502,8 +1498,6 @@ pub fn exec_container(
         argv.push("--env".to_string());
         argv.push(format!("{key}={value}"));
     }
-    argv.push("--env".to_string());
-    argv.push("RCCONF_OVERRIDE_SERVICE_SWITCH=true".to_string());
     argv.push(container.to_string());
     argv.extend(rc_conf.argv(service, "WRAPPER", &()).unwrap_or_else(|e| {
         eprintln!("failed to generate argv: {e}");
@@ -1525,11 +1519,9 @@ pub fn exec_container(
 pub fn invoke(rc_conf_path: &str, rc_d_path: &str, service: &str, args: &[&str]) -> ! {
     let mut cmd = vec!["run"];
     cmd.extend(args);
-    let override_service_switch = std::env::var("RCCONF_OVERRIDE_SERVICE_SWITCH").is_ok();
     exec_rc_with_override(
         rc_conf_path,
         rc_d_path,
-        override_service_switch,
         service,
         &cmd,
     )
@@ -1539,11 +1531,9 @@ pub fn invoke(rc_conf_path: &str, rc_d_path: &str, service: &str, args: &[&str])
 
 /// exec_rc the service in a way that prints rcvariables.
 pub fn rcvar(rc_conf_path: &str, rc_d_path: &str, service: &str) -> ! {
-    let override_service_switch = std::env::var("RCCONF_OVERRIDE_SERVICE_SWITCH").is_ok();
     exec_rc_with_override(
         rc_conf_path,
         rc_d_path,
-        override_service_switch,
         service,
         &["rcvar"],
     )


### PR DESCRIPTION
Remove RCCONF_OVERRIDE_SERVICE_SWITCH from exec_rc_with_override,
exec_container, invoke, rcvar, and container rcvar invocations.
Service enablement checks are now always enforced.  Document
this backwards-incompatible change in README.md.

Replace .expect() and .unwrap() calls in rccat, rcdebug,
rcexamine, rclist, and rccontainer with proper match arms that
print diagnostics to stderr and exit with meaningful codes.
Validate that rccontainer runtime is docker or podman.  Fix
rccat to pass the service name rather than the prefix as NAME
metadata.

Co-authored-by: AI
