### PR TITLE
perf(scrunch): speed up construction and reduce memory usage

### DIFF
--- a/scrunch/Cargo.toml
+++ b/scrunch/Cargo.toml
@@ -22,6 +22,7 @@ proptest = { workspace = true }
 
 arrrg = { workspace = true }
 guacamole = { workspace = true }
+libc = { workspace = true }
 statslicer = { workspace = true }
 
 [[bin]]
@@ -40,4 +41,16 @@ harness = false
 
 [[bench]]
 name = "rrr_bit_vector"
+harness = false
+
+[[bench]]
+name = "wavelet_psi"
+harness = false
+
+[[bench]]
+name = "sais"
+harness = false
+
+[[bench]]
+name = "exemplars"
 harness = false

--- a/scrunch/benches/exemplars.rs
+++ b/scrunch/benches/exemplars.rs
@@ -1,0 +1,204 @@
+use std::fs::read;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use buffertk::Unpackable;
+
+use scrunch::{CompressedDocument, Document};
+
+const DEFAULT_INPUT: &str = "/tmp/gutenberg-1g.txt.scrunch";
+const SPACE: u32 = b' ' as u32;
+
+#[derive(Clone, Debug)]
+struct Options {
+    input: PathBuf,
+    results: usize,
+    iterations: usize,
+    warm_up: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            input: PathBuf::from(DEFAULT_INPUT),
+            results: 20,
+            iterations: 5,
+            warm_up: 1,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Word {
+    count: usize,
+    text: String,
+}
+
+#[derive(Debug)]
+struct Measurement {
+    input_bytes: usize,
+    doc_symbols: usize,
+    doc_records: usize,
+    results: usize,
+    iterations: usize,
+    elapsed_ns: u128,
+    checksum: usize,
+    words: Vec<Word>,
+}
+
+fn main() {
+    let options = parse_args(std::env::args().skip(1)).unwrap_or_else(|err| {
+        eprintln!("{err}");
+        std::process::exit(2);
+    });
+    let input = read(&options.input).unwrap_or_else(|err| {
+        eprintln!("could not read {}: {err}", options.input.display());
+        std::process::exit(1);
+    });
+    let doc = CompressedDocument::unpack(&input).unwrap_or_else(|err| {
+        eprintln!("unpack failed: {err:?}");
+        std::process::exit(1);
+    });
+    let doc = doc.0;
+    let measurement = measure_case(&options, input.len(), &doc);
+    print_measurement(&measurement);
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> Result<Options, String> {
+    let mut options = Options::default();
+    let mut args = args.peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--bench" => {}
+            "--input" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--input requires a path".to_string())?;
+                options.input = PathBuf::from(value);
+            }
+            "--results" => {
+                options.results = parse_next_usize("--results", &mut args)?;
+            }
+            "--iterations" => {
+                options.iterations = parse_next_usize("--iterations", &mut args)?;
+            }
+            "--warm-up" => {
+                options.warm_up = parse_next_usize("--warm-up", &mut args)?;
+            }
+            "--help" | "-h" => {
+                return Err(usage());
+            }
+            other => {
+                return Err(format!("unrecognized argument: {other}\n{}", usage()));
+            }
+        }
+    }
+    if options.results == 0 {
+        return Err("--results must be positive".to_string());
+    }
+    if options.iterations == 0 {
+        return Err("--iterations must be positive".to_string());
+    }
+    Ok(options)
+}
+
+fn parse_next_usize(
+    flag: &str,
+    args: &mut std::iter::Peekable<impl Iterator<Item = String>>,
+) -> Result<usize, String> {
+    let value = args
+        .next()
+        .ok_or_else(|| format!("{flag} requires a value"))?;
+    value
+        .parse()
+        .map_err(|_| format!("{flag} must be an integer: {value}"))
+}
+
+fn usage() -> String {
+    format!(
+        "USAGE: exemplars [--input PATH] [--results N] [--iterations N] [--warm-up N]\n\
+         Default input: {DEFAULT_INPUT}"
+    )
+}
+
+fn measure_case(
+    options: &Options,
+    input_bytes: usize,
+    doc: &CompressedDocument<'_>,
+) -> Measurement {
+    let docs = [doc];
+    for _ in 0..options.warm_up {
+        std::hint::black_box(top_words(&docs, options.results));
+    }
+    let start = Instant::now();
+    let mut checksum = 0usize;
+    let mut words = Vec::new();
+    for _ in 0..options.iterations {
+        words = top_words(&docs, options.results);
+        checksum ^= std::hint::black_box(checksum_words(&words));
+    }
+    Measurement {
+        input_bytes,
+        doc_symbols: doc.len(),
+        doc_records: doc.records(),
+        results: options.results,
+        iterations: options.iterations,
+        elapsed_ns: start.elapsed().as_nanos(),
+        checksum,
+        words,
+    }
+}
+
+fn top_words(docs: &[&CompressedDocument<'_>], results: usize) -> Vec<Word> {
+    scrunch::exemplars_with_min_length(docs, &[(SPACE, SPACE)], 3)
+        .map(|exemplar| Word {
+            count: exemplar.count(),
+            text: word_text(exemplar.text()),
+        })
+        .filter(|word| word.text.chars().any(|c| !c.is_whitespace()))
+        .take(results)
+        .collect()
+}
+
+fn word_text(text: &[u32]) -> String {
+    let text = if text.len() >= 2 && text[0] == SPACE && text[text.len() - 1] == SPACE {
+        &text[1..text.len() - 1]
+    } else {
+        text
+    };
+    text.iter()
+        .copied()
+        .filter_map(char::from_u32)
+        .collect::<String>()
+}
+
+fn checksum_words(words: &[Word]) -> usize {
+    words.iter().fold(0usize, |checksum, word| {
+        word.text
+            .bytes()
+            .fold(checksum ^ word.count, |checksum, byte| {
+                checksum.wrapping_mul(16_777_619) ^ byte as usize
+            })
+    })
+}
+
+fn print_measurement(measurement: &Measurement) {
+    let elapsed_ms = measurement.elapsed_ns as f64 / 1_000_000.0;
+    let per_iter_ms = elapsed_ms / measurement.iterations as f64;
+    println!(
+        "input_bytes\tdoc_symbols\tdoc_records\tresults\titerations\telapsed_ms\tms_per_iter\tchecksum"
+    );
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{elapsed_ms:.3}\t{per_iter_ms:.3}\t{}",
+        measurement.input_bytes,
+        measurement.doc_symbols,
+        measurement.doc_records,
+        measurement.results,
+        measurement.iterations,
+        measurement.checksum
+    );
+    println!("rank\tcount\tword");
+    for (rank, word) in measurement.words.iter().enumerate() {
+        println!("{}\t{}\t{}", rank + 1, word.count, word.text.escape_debug());
+    }
+}

--- a/scrunch/benches/sais.rs
+++ b/scrunch/benches/sais.rs
@@ -1,0 +1,466 @@
+use std::fs::{File, read_to_string, remove_file};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use buffertk::Unpackable;
+
+use scrunch::builder::Builder;
+use scrunch::sais;
+use scrunch::sigma::Sigma;
+
+const DEFAULT_INPUT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/resources/gutenberg/Dracula.txt"
+);
+const DEFAULT_SIZES: &[usize] = &[65_536, 131_072, 262_144, 524_288];
+
+#[derive(Debug, Clone)]
+struct Options {
+    input: PathBuf,
+    sizes: Vec<usize>,
+    symbols: Option<usize>,
+    iterations: usize,
+    warm_up: usize,
+    prepare: Option<PathBuf>,
+    child: Option<PathBuf>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            input: PathBuf::from(DEFAULT_INPUT),
+            sizes: Vec::new(),
+            symbols: None,
+            iterations: 5,
+            warm_up: 1,
+            prepare: None,
+            child: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PreparedCase {
+    sigma_buf: Vec<u8>,
+    s: Vec<u32>,
+}
+
+#[derive(Debug)]
+struct Measurement {
+    symbols: usize,
+    alphabet: usize,
+    iterations: usize,
+    elapsed_ns: u128,
+    sa_len: usize,
+    user_us: i64,
+    system_us: i64,
+    maxrss: i64,
+    minflt: i64,
+    majflt: i64,
+    nvcsw: i64,
+    nivcsw: i64,
+}
+
+fn main() {
+    let options = parse_args(std::env::args().skip(1)).unwrap_or_else(|err| {
+        eprintln!("{err}");
+        std::process::exit(2);
+    });
+    if let Some(path) = options.prepare.as_ref() {
+        let symbols = options
+            .symbols
+            .expect("--prepare requires exactly one --symbols value");
+        let prepared = prepare_case(&options.input, symbols).unwrap_or_else(|err| {
+            eprintln!("prepare failed: {err}");
+            std::process::exit(1);
+        });
+        write_case(path, &prepared).unwrap_or_else(|err| {
+            eprintln!("write failed: {err}");
+            std::process::exit(1);
+        });
+        return;
+    }
+    if let Some(path) = options.child.as_ref() {
+        let symbols = options
+            .symbols
+            .expect("--child requires exactly one --symbols value");
+        let prepared = read_case(path).unwrap_or_else(|err| {
+            eprintln!("read failed: {err}");
+            std::process::exit(1);
+        });
+        let measurement = measure_case(symbols, &prepared, options.iterations, options.warm_up)
+            .unwrap_or_else(|err| {
+                eprintln!("benchmark failed: {err}");
+                std::process::exit(1);
+            });
+        print_measurement(&measurement);
+        return;
+    }
+    run_parent(&options).unwrap_or_else(|err| {
+        eprintln!("benchmark failed: {err}");
+        std::process::exit(1);
+    });
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> Result<Options, String> {
+    let mut options = Options::default();
+    let mut args = args.peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--bench" => {}
+            "--input" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--input requires a path".to_string())?;
+                options.input = PathBuf::from(value);
+            }
+            "--sizes" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--sizes requires a comma-separated list".to_string())?;
+                options.sizes = parse_sizes(&value)?;
+            }
+            "--symbols" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--symbols requires an integer".to_string())?;
+                options.symbols = Some(parse_usize("--symbols", &value)?);
+            }
+            "--iterations" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--iterations requires an integer".to_string())?;
+                options.iterations = parse_usize("--iterations", &value)?;
+            }
+            "--warm-up" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--warm-up requires an integer".to_string())?;
+                options.warm_up = parse_usize("--warm-up", &value)?;
+            }
+            "--prepare" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--prepare requires a path".to_string())?;
+                options.prepare = Some(PathBuf::from(value));
+            }
+            "--child" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--child requires a path".to_string())?;
+                options.child = Some(PathBuf::from(value));
+            }
+            "--help" | "-h" => return Err(usage()),
+            other => return Err(format!("unrecognized argument: {other}\n{}", usage())),
+        }
+    }
+    if options.prepare.is_some() && options.child.is_some() {
+        return Err("--prepare and --child are mutually exclusive".to_string());
+    }
+    if options.iterations == 0 {
+        return Err("--iterations must be positive".to_string());
+    }
+    Ok(options)
+}
+
+fn usage() -> String {
+    format!(
+        "USAGE: sais [--input PATH] [--sizes N,N,...] [--iterations N] [--warm-up N]\n\
+         Default input: {DEFAULT_INPUT}"
+    )
+}
+
+fn parse_sizes(value: &str) -> Result<Vec<usize>, String> {
+    let mut sizes = Vec::new();
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        sizes.push(parse_usize("--sizes", part)?);
+    }
+    if sizes.is_empty() {
+        return Err("--sizes must provide at least one integer".to_string());
+    }
+    Ok(sizes)
+}
+
+fn parse_usize(flag: &str, value: &str) -> Result<usize, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{flag} must be an integer: {value}"))
+}
+
+fn run_parent(options: &Options) -> Result<(), String> {
+    let text = read_to_string(&options.input)
+        .map_err(|err| format!("could not read {}: {err}", options.input.display()))?;
+    let total_symbols = text.chars().count();
+    let sizes = sizes_for_run(options, total_symbols);
+    let exe = std::env::current_exe().map_err(|err| format!("current_exe failed: {err}"))?;
+    let maxrss_units = maxrss_units();
+    println!(
+        "symbols\talphabet\titerations\telapsed_ms\tms_per_iter\tsa_len\tuser_ms\tsystem_ms\tmaxrss_{maxrss_units}\tminflt\tmajflt\tnvcsw\tnivcsw"
+    );
+    for symbols in sizes {
+        let artifact = artifact_path(symbols);
+        run_prepare(&exe, options, symbols, &artifact)?;
+        let output = run_child(&exe, options, symbols, &artifact)?;
+        print!("{output}");
+        let _ = remove_file(&artifact);
+    }
+    Ok(())
+}
+
+fn sizes_for_run(options: &Options, total_symbols: usize) -> Vec<usize> {
+    if let Some(symbols) = options.symbols {
+        return vec![std::cmp::min(symbols, total_symbols)];
+    }
+    let mut sizes = if options.sizes.is_empty() {
+        DEFAULT_SIZES
+            .iter()
+            .copied()
+            .filter(|size| *size < total_symbols)
+            .collect::<Vec<_>>()
+    } else {
+        options.sizes.clone()
+    };
+    sizes.push(total_symbols);
+    sizes.sort_unstable();
+    sizes.dedup();
+    sizes
+}
+
+fn artifact_path(symbols: usize) -> PathBuf {
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("scrunch-sais-{pid}-{symbols}.bin"))
+}
+
+fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<(), String> {
+    let status = Command::new(exe)
+        .arg("--input")
+        .arg(&options.input)
+        .arg("--symbols")
+        .arg(symbols.to_string())
+        .arg("--prepare")
+        .arg(artifact)
+        .status()
+        .map_err(|err| format!("spawn prepare failed: {err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("prepare exited with {status}"))
+    }
+}
+
+fn run_child(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<String, String> {
+    let output = Command::new(exe)
+        .arg("--symbols")
+        .arg(symbols.to_string())
+        .arg("--iterations")
+        .arg(options.iterations.to_string())
+        .arg("--warm-up")
+        .arg(options.warm_up.to_string())
+        .arg("--child")
+        .arg(artifact)
+        .output()
+        .map_err(|err| format!("spawn child failed: {err}"))?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).map_err(|err| format!("utf8 decode failed: {err}"))
+    } else {
+        Err(format!(
+            "child exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+fn prepare_case(input: &Path, symbols: usize) -> Result<PreparedCase, String> {
+    let text = read_to_string(input).map_err(|err| format!("read failed: {err}"))?;
+    let text: Vec<u32> = text.chars().take(symbols).map(|c| c as u32).collect();
+    let mut sigma_buf = Vec::new();
+    let mut sigma_builder = Builder::new(&mut sigma_buf);
+    Sigma::construct(text.iter().copied(), &mut sigma_builder)
+        .map_err(|err| format!("sigma construct failed: {err:?}"))?;
+    drop(sigma_builder);
+    let sigma = Sigma::unpack(&sigma_buf)
+        .map_err(|err| format!("sigma unpack failed: {err:?}"))?
+        .0;
+    let mut s = Vec::with_capacity(text.len() + 1);
+    for t in text {
+        s.push(
+            sigma
+                .char_to_sigma(t)
+                .ok_or_else(|| "sigma translation failed".to_string())?,
+        );
+    }
+    s.push(0);
+    Ok(PreparedCase { sigma_buf, s })
+}
+
+fn write_case(path: &Path, prepared: &PreparedCase) -> Result<(), String> {
+    let mut file =
+        File::create(path).map_err(|err| format!("create {} failed: {err}", path.display()))?;
+    write_u64(&mut file, prepared.sigma_buf.len() as u64)?;
+    file.write_all(&prepared.sigma_buf)
+        .map_err(|err| format!("write sigma failed: {err}"))?;
+    write_u64(&mut file, prepared.s.len() as u64)?;
+    for value in prepared.s.iter().copied() {
+        write_u32(&mut file, value)?;
+    }
+    Ok(())
+}
+
+fn read_case(path: &Path) -> Result<PreparedCase, String> {
+    let mut file =
+        File::open(path).map_err(|err| format!("open {} failed: {err}", path.display()))?;
+    let sigma_len = read_u64(&mut file)? as usize;
+    let mut sigma_buf = vec![0u8; sigma_len];
+    file.read_exact(&mut sigma_buf)
+        .map_err(|err| format!("read sigma failed: {err}"))?;
+    let s_len = read_u64(&mut file)? as usize;
+    let mut s = Vec::with_capacity(s_len);
+    for _ in 0..s_len {
+        s.push(read_u32(&mut file)?);
+    }
+    Ok(PreparedCase { sigma_buf, s })
+}
+
+fn write_u64(file: &mut File, value: u64) -> Result<(), String> {
+    file.write_all(&value.to_le_bytes())
+        .map_err(|err| format!("write failed: {err}"))
+}
+
+fn write_u32(file: &mut File, value: u32) -> Result<(), String> {
+    file.write_all(&value.to_le_bytes())
+        .map_err(|err| format!("write failed: {err}"))
+}
+
+fn read_u64(file: &mut File) -> Result<u64, String> {
+    let mut bytes = [0u8; 8];
+    file.read_exact(&mut bytes)
+        .map_err(|err| format!("read failed: {err}"))?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn read_u32(file: &mut File) -> Result<u32, String> {
+    let mut bytes = [0u8; 4];
+    file.read_exact(&mut bytes)
+        .map_err(|err| format!("read failed: {err}"))?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn measure_case(
+    symbols: usize,
+    prepared: &PreparedCase,
+    iterations: usize,
+    warm_up: usize,
+) -> Result<Measurement, String> {
+    let sigma = Sigma::unpack(&prepared.sigma_buf)
+        .map_err(|err| format!("sigma unpack failed: {err:?}"))?
+        .0;
+    for _ in 0..warm_up {
+        construct_once(&sigma, &prepared.s).map_err(|err| format!("warm-up failed: {err:?}"))?;
+    }
+    let before = getrusage().map_err(|err| format!("getrusage(before) failed: {err}"))?;
+    let start = Instant::now();
+    let mut sa_len = 0usize;
+    for _ in 0..iterations {
+        sa_len = construct_once(&sigma, &prepared.s)
+            .map_err(|err| format!("construct failed: {err:?}"))?;
+    }
+    let elapsed_ns = start.elapsed().as_nanos();
+    let after = getrusage().map_err(|err| format!("getrusage(after) failed: {err}"))?;
+    Ok(Measurement {
+        symbols,
+        alphabet: sigma.K(),
+        iterations,
+        elapsed_ns,
+        sa_len,
+        user_us: timeval_delta_us(after.ru_utime, before.ru_utime),
+        system_us: timeval_delta_us(after.ru_stime, before.ru_stime),
+        maxrss: after.ru_maxrss,
+        minflt: after.ru_minflt - before.ru_minflt,
+        majflt: after.ru_majflt - before.ru_majflt,
+        nvcsw: after.ru_nvcsw - before.ru_nvcsw,
+        nivcsw: after.ru_nivcsw - before.ru_nivcsw,
+    })
+}
+
+fn construct_once(sigma: &Sigma, s: &[u32]) -> Result<usize, scrunch::Error> {
+    let mut sa = vec![0usize; s.len()];
+    sais::sais(sigma, s, &mut sa)?;
+    std::hint::black_box(&sa);
+    Ok(sa.len())
+}
+
+fn print_measurement(measurement: &Measurement) {
+    let elapsed_ms = measurement.elapsed_ns as f64 / 1_000_000.0;
+    let per_iter_ms = elapsed_ms / measurement.iterations as f64;
+    println!(
+        "{}\t{}\t{}\t{elapsed_ms:.3}\t{per_iter_ms:.3}\t{}\t{:.3}\t{:.3}\t{}\t{}\t{}\t{}\t{}",
+        measurement.symbols,
+        measurement.alphabet,
+        measurement.iterations,
+        measurement.sa_len,
+        measurement.user_us as f64 / 1_000.0,
+        measurement.system_us as f64 / 1_000.0,
+        measurement.maxrss,
+        measurement.minflt,
+        measurement.majflt,
+        measurement.nvcsw,
+        measurement.nivcsw
+    );
+}
+
+fn getrusage() -> Result<libc::rusage, std::io::Error> {
+    let mut usage = libc::rusage {
+        ru_utime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_stime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_maxrss: 0,
+        ru_ixrss: 0,
+        ru_idrss: 0,
+        ru_isrss: 0,
+        ru_minflt: 0,
+        ru_majflt: 0,
+        ru_nswap: 0,
+        ru_inblock: 0,
+        ru_oublock: 0,
+        ru_msgsnd: 0,
+        ru_msgrcv: 0,
+        ru_nsignals: 0,
+        ru_nvcsw: 0,
+        ru_nivcsw: 0,
+    };
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+    if rc == 0 {
+        Ok(usage)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+fn timeval_delta_us(after: libc::timeval, before: libc::timeval) -> i64 {
+    let after = after.tv_sec.saturating_mul(1_000_000) + i64::from(after.tv_usec);
+    let before = before.tv_sec.saturating_mul(1_000_000) + i64::from(before.tv_usec);
+    after - before
+}
+
+fn maxrss_units() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "bytes"
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "kib"
+    }
+}

--- a/scrunch/benches/sais.rs
+++ b/scrunch/benches/sais.rs
@@ -459,9 +459,13 @@ fn getrusage() -> Result<libc::rusage, std::io::Error> {
 }
 
 fn timeval_delta_us(after: libc::timeval, before: libc::timeval) -> i64 {
-    let after = after.tv_sec.saturating_mul(1_000_000) + i64::from(after.tv_usec);
-    let before = before.tv_sec.saturating_mul(1_000_000) + i64::from(before.tv_usec);
+    let after = after.tv_sec.saturating_mul(1_000_000) + into_i64(after.tv_usec);
+    let before = before.tv_sec.saturating_mul(1_000_000) + into_i64(before.tv_usec);
     after - before
+}
+
+fn into_i64<T: Into<i64>>(value: T) -> i64 {
+    value.into()
 }
 
 fn maxrss_units() -> &'static str {

--- a/scrunch/benches/sais.rs
+++ b/scrunch/benches/sais.rs
@@ -237,7 +237,12 @@ fn artifact_path(symbols: usize) -> PathBuf {
     std::env::temp_dir().join(format!("scrunch-sais-{pid}-{symbols}.bin"))
 }
 
-fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<(), String> {
+fn run_prepare(
+    exe: &Path,
+    options: &Options,
+    symbols: usize,
+    artifact: &Path,
+) -> Result<(), String> {
     let status = Command::new(exe)
         .arg("--input")
         .arg(&options.input)
@@ -254,7 +259,12 @@ fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -
     }
 }
 
-fn run_child(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<String, String> {
+fn run_child(
+    exe: &Path,
+    options: &Options,
+    symbols: usize,
+    artifact: &Path,
+) -> Result<String, String> {
     let output = Command::new(exe)
         .arg("--symbols")
         .arg(symbols.to_string())

--- a/scrunch/benches/wavelet_psi.rs
+++ b/scrunch/benches/wavelet_psi.rs
@@ -1,0 +1,484 @@
+use std::convert::TryInto;
+use std::fs::{File, read_to_string, remove_file};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use buffertk::Unpackable;
+
+use scrunch::builder::Builder;
+use scrunch::encoder::HuffmanEncoder;
+use scrunch::psi::Psi;
+use scrunch::psi::compute as compute_psi;
+use scrunch::psi::wavelet_tree::WaveletTreePsi;
+use scrunch::sais;
+use scrunch::sigma::Sigma;
+use scrunch::wavelet_tree::prefix::WaveletTree;
+use scrunch::Error;
+
+type PrefixWaveletPsi<'a> = WaveletTreePsi<'a, WaveletTree<'a, HuffmanEncoder>>;
+
+const DEFAULT_INPUT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/resources/gutenberg/Dracula.txt"
+);
+const DEFAULT_SIZES: &[usize] = &[65_536, 131_072, 262_144, 524_288];
+
+#[derive(Debug, Clone)]
+struct Options {
+    input: PathBuf,
+    sizes: Vec<usize>,
+    symbols: Option<usize>,
+    iterations: usize,
+    warm_up: usize,
+    prepare: Option<PathBuf>,
+    child: Option<PathBuf>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            input: PathBuf::from(DEFAULT_INPUT),
+            sizes: Vec::new(),
+            symbols: None,
+            iterations: 5,
+            warm_up: 1,
+            prepare: None,
+            child: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PreparedCase {
+    sigma_buf: Vec<u8>,
+    psi: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct Measurement {
+    symbols: usize,
+    psi_len: usize,
+    alphabet: usize,
+    iterations: usize,
+    elapsed_ns: u128,
+    output_bytes: usize,
+    user_us: i64,
+    system_us: i64,
+    maxrss: i64,
+    minflt: i64,
+    majflt: i64,
+    nvcsw: i64,
+    nivcsw: i64,
+}
+
+fn main() {
+    let options = parse_args(std::env::args().skip(1)).unwrap_or_else(|err| {
+        eprintln!("{err}");
+        std::process::exit(2);
+    });
+    if let Some(path) = options.prepare.as_ref() {
+        let symbols = options
+            .symbols
+            .expect("--prepare requires exactly one --symbols value");
+        let prepared = prepare_case(&options.input, symbols).unwrap_or_else(|err| {
+            eprintln!("prepare failed: {err}");
+            std::process::exit(1);
+        });
+        write_case(path, &prepared).unwrap_or_else(|err| {
+            eprintln!("write failed: {err}");
+            std::process::exit(1);
+        });
+        return;
+    }
+    if let Some(path) = options.child.as_ref() {
+        let symbols = options
+            .symbols
+            .expect("--child requires exactly one --symbols value");
+        let prepared = read_case(path).unwrap_or_else(|err| {
+            eprintln!("read failed: {err}");
+            std::process::exit(1);
+        });
+        let measurement = measure_case(symbols, &prepared, options.iterations, options.warm_up)
+            .unwrap_or_else(|err| {
+                eprintln!("benchmark failed: {err}");
+                std::process::exit(1);
+            });
+        print_measurement(&measurement);
+        return;
+    }
+    run_parent(&options).unwrap_or_else(|err| {
+        eprintln!("benchmark failed: {err}");
+        std::process::exit(1);
+    });
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> Result<Options, String> {
+    let mut options = Options::default();
+    let mut args = args.peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--bench" => {}
+            "--input" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--input requires a path".to_string())?;
+                options.input = PathBuf::from(value);
+            }
+            "--sizes" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--sizes requires a comma-separated list".to_string())?;
+                options.sizes = parse_sizes(&value)?;
+            }
+            "--symbols" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--symbols requires an integer".to_string())?;
+                options.symbols = Some(parse_usize("--symbols", &value)?);
+            }
+            "--iterations" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--iterations requires an integer".to_string())?;
+                options.iterations = parse_usize("--iterations", &value)?;
+            }
+            "--warm-up" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--warm-up requires an integer".to_string())?;
+                options.warm_up = parse_usize("--warm-up", &value)?;
+            }
+            "--prepare" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--prepare requires a path".to_string())?;
+                options.prepare = Some(PathBuf::from(value));
+            }
+            "--child" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--child requires a path".to_string())?;
+                options.child = Some(PathBuf::from(value));
+            }
+            "--help" | "-h" => {
+                return Err(usage());
+            }
+            other => {
+                return Err(format!("unrecognized argument: {other}\n{}", usage()));
+            }
+        }
+    }
+    if options.prepare.is_some() && options.child.is_some() {
+        return Err("--prepare and --child are mutually exclusive".to_string());
+    }
+    if options.iterations == 0 {
+        return Err("--iterations must be positive".to_string());
+    }
+    Ok(options)
+}
+
+fn usage() -> String {
+    format!(
+        "USAGE: wavelet_psi [--input PATH] [--sizes N,N,...] [--iterations N] [--warm-up N]\n\
+         Default input: {DEFAULT_INPUT}"
+    )
+}
+
+fn parse_sizes(value: &str) -> Result<Vec<usize>, String> {
+    let mut sizes = Vec::new();
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        sizes.push(parse_usize("--sizes", part)?);
+    }
+    if sizes.is_empty() {
+        return Err("--sizes must provide at least one integer".to_string());
+    }
+    Ok(sizes)
+}
+
+fn parse_usize(flag: &str, value: &str) -> Result<usize, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{flag} must be an integer: {value}"))
+}
+
+fn run_parent(options: &Options) -> Result<(), String> {
+    let text = read_to_string(&options.input)
+        .map_err(|err| format!("could not read {}: {err}", options.input.display()))?;
+    let total_symbols = text.chars().count();
+    let sizes = sizes_for_run(options, total_symbols);
+    let exe = std::env::current_exe().map_err(|err| format!("current_exe failed: {err}"))?;
+    let maxrss_units = maxrss_units();
+    println!(
+        "symbols\tpsi_len\talphabet\titerations\telapsed_ms\tms_per_iter\toutput_bytes\tuser_ms\tsystem_ms\tmaxrss_{maxrss_units}\tminflt\tmajflt\tnvcsw\tnivcsw"
+    );
+    for symbols in sizes {
+        let artifact = artifact_path(symbols);
+        run_prepare(&exe, options, symbols, &artifact)?;
+        let output = run_child(&exe, options, symbols, &artifact)?;
+        print!("{output}");
+        let _ = remove_file(&artifact);
+    }
+    Ok(())
+}
+
+fn sizes_for_run(options: &Options, total_symbols: usize) -> Vec<usize> {
+    if let Some(symbols) = options.symbols {
+        return vec![std::cmp::min(symbols, total_symbols)];
+    }
+    let mut sizes = if options.sizes.is_empty() {
+        DEFAULT_SIZES
+            .iter()
+            .copied()
+            .filter(|size| *size < total_symbols)
+            .collect::<Vec<_>>()
+    } else {
+        options.sizes.clone()
+    };
+    sizes.push(total_symbols);
+    sizes.sort_unstable();
+    sizes.dedup();
+    sizes
+}
+
+fn artifact_path(symbols: usize) -> PathBuf {
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("scrunch-wavelet-psi-{pid}-{symbols}.bin"))
+}
+
+fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<(), String> {
+    let status = Command::new(exe)
+        .arg("--input")
+        .arg(&options.input)
+        .arg("--symbols")
+        .arg(symbols.to_string())
+        .arg("--prepare")
+        .arg(artifact)
+        .status()
+        .map_err(|err| format!("spawn prepare failed: {err}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("prepare exited with {status}"))
+    }
+}
+
+fn run_child(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<String, String> {
+    let output = Command::new(exe)
+        .arg("--symbols")
+        .arg(symbols.to_string())
+        .arg("--iterations")
+        .arg(options.iterations.to_string())
+        .arg("--warm-up")
+        .arg(options.warm_up.to_string())
+        .arg("--child")
+        .arg(artifact)
+        .output()
+        .map_err(|err| format!("spawn child failed: {err}"))?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).map_err(|err| format!("utf8 decode failed: {err}"))
+    } else {
+        Err(format!(
+            "child exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+fn prepare_case(input: &Path, symbols: usize) -> Result<PreparedCase, String> {
+    let text = read_to_string(input).map_err(|err| format!("read failed: {err}"))?;
+    let text: Vec<u32> = text.chars().take(symbols).map(|c| c as u32).collect();
+    let mut sigma_buf = Vec::new();
+    let mut sigma_builder = Builder::new(&mut sigma_buf);
+    Sigma::construct(text.iter().copied(), &mut sigma_builder)
+        .map_err(|err| format!("sigma construct failed: {err:?}"))?;
+    drop(sigma_builder);
+    let sigma = Sigma::unpack(&sigma_buf)
+        .map_err(|err| format!("sigma unpack failed: {err:?}"))?
+        .0;
+    let mut s = Vec::with_capacity(text.len() + 1);
+    for t in text {
+        s.push(
+            sigma
+                .char_to_sigma(t)
+                .ok_or_else(|| "sigma translation failed".to_string())?,
+        );
+    }
+    s.push(0);
+    let mut sa = vec![0usize; s.len()];
+    sais::sais(&sigma, &s, &mut sa).map_err(|err| format!("sais failed: {err:?}"))?;
+    let isa = inverse(&sa);
+    let psi = compute_psi(&isa);
+    Ok(PreparedCase { sigma_buf, psi })
+}
+
+fn write_case(path: &Path, prepared: &PreparedCase) -> Result<(), String> {
+    let mut file =
+        File::create(path).map_err(|err| format!("create {} failed: {err}", path.display()))?;
+    write_u64(&mut file, prepared.sigma_buf.len() as u64)?;
+    file.write_all(&prepared.sigma_buf)
+        .map_err(|err| format!("write sigma failed: {err}"))?;
+    write_u64(&mut file, prepared.psi.len() as u64)?;
+    for value in prepared.psi.iter().copied() {
+        write_u64(&mut file, value as u64)?;
+    }
+    Ok(())
+}
+
+fn read_case(path: &Path) -> Result<PreparedCase, String> {
+    let mut file =
+        File::open(path).map_err(|err| format!("open {} failed: {err}", path.display()))?;
+    let sigma_len = read_u64(&mut file)? as usize;
+    let mut sigma_buf = vec![0u8; sigma_len];
+    file.read_exact(&mut sigma_buf)
+        .map_err(|err| format!("read sigma failed: {err}"))?;
+    let psi_len = read_u64(&mut file)? as usize;
+    let mut psi = Vec::with_capacity(psi_len);
+    for _ in 0..psi_len {
+        let value = read_u64(&mut file)?;
+        psi.push(value.try_into().map_err(|_| "psi value does not fit usize")?);
+    }
+    Ok(PreparedCase { sigma_buf, psi })
+}
+
+fn write_u64(file: &mut File, value: u64) -> Result<(), String> {
+    file.write_all(&value.to_le_bytes())
+        .map_err(|err| format!("write failed: {err}"))
+}
+
+fn read_u64(file: &mut File) -> Result<u64, String> {
+    let mut bytes = [0u8; 8];
+    file.read_exact(&mut bytes)
+        .map_err(|err| format!("read failed: {err}"))?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn measure_case(
+    symbols: usize,
+    prepared: &PreparedCase,
+    iterations: usize,
+    warm_up: usize,
+) -> Result<Measurement, String> {
+    let sigma = Sigma::unpack(&prepared.sigma_buf)
+        .map_err(|err| format!("sigma unpack failed: {err:?}"))?
+        .0;
+    for _ in 0..warm_up {
+        construct_once(&sigma, &prepared.psi).map_err(|err| format!("warm-up failed: {err:?}"))?;
+    }
+    let before = getrusage().map_err(|err| format!("getrusage(before) failed: {err}"))?;
+    let start = Instant::now();
+    let mut output_bytes = 0usize;
+    for _ in 0..iterations {
+        output_bytes = construct_once(&sigma, &prepared.psi)
+            .map_err(|err| format!("construct failed: {err:?}"))?;
+    }
+    let elapsed_ns = start.elapsed().as_nanos();
+    let after = getrusage().map_err(|err| format!("getrusage(after) failed: {err}"))?;
+    Ok(Measurement {
+        symbols,
+        psi_len: prepared.psi.len(),
+        alphabet: sigma.K(),
+        iterations,
+        elapsed_ns,
+        output_bytes,
+        user_us: timeval_delta_us(after.ru_utime, before.ru_utime),
+        system_us: timeval_delta_us(after.ru_stime, before.ru_stime),
+        maxrss: after.ru_maxrss,
+        minflt: after.ru_minflt - before.ru_minflt,
+        majflt: after.ru_majflt - before.ru_majflt,
+        nvcsw: after.ru_nvcsw - before.ru_nvcsw,
+        nivcsw: after.ru_nivcsw - before.ru_nivcsw,
+    })
+}
+
+fn construct_once(sigma: &Sigma, psi: &[usize]) -> Result<usize, Error> {
+    let mut buf = Vec::new();
+    let mut builder = Builder::new(&mut buf);
+    <PrefixWaveletPsi<'_> as Psi>::construct(sigma, psi, &mut builder)?;
+    drop(builder);
+    Ok(buf.len())
+}
+
+fn print_measurement(measurement: &Measurement) {
+    let elapsed_ms = measurement.elapsed_ns as f64 / 1_000_000.0;
+    let per_iter_ms = elapsed_ms / measurement.iterations as f64;
+    println!(
+        "{}\t{}\t{}\t{}\t{elapsed_ms:.3}\t{per_iter_ms:.3}\t{}\t{:.3}\t{:.3}\t{}\t{}\t{}\t{}\t{}",
+        measurement.symbols,
+        measurement.psi_len,
+        measurement.alphabet,
+        measurement.iterations,
+        measurement.output_bytes,
+        measurement.user_us as f64 / 1_000.0,
+        measurement.system_us as f64 / 1_000.0,
+        measurement.maxrss,
+        measurement.minflt,
+        measurement.majflt,
+        measurement.nvcsw,
+        measurement.nivcsw
+    );
+}
+
+fn getrusage() -> Result<libc::rusage, std::io::Error> {
+    let mut usage = libc::rusage {
+        ru_utime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_stime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_maxrss: 0,
+        ru_ixrss: 0,
+        ru_idrss: 0,
+        ru_isrss: 0,
+        ru_minflt: 0,
+        ru_majflt: 0,
+        ru_nswap: 0,
+        ru_inblock: 0,
+        ru_oublock: 0,
+        ru_msgsnd: 0,
+        ru_msgrcv: 0,
+        ru_nsignals: 0,
+        ru_nvcsw: 0,
+        ru_nivcsw: 0,
+    };
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+    if rc == 0 {
+        Ok(usage)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+fn timeval_delta_us(after: libc::timeval, before: libc::timeval) -> i64 {
+    let after = after.tv_sec.saturating_mul(1_000_000) + i64::from(after.tv_usec);
+    let before = before.tv_sec.saturating_mul(1_000_000) + i64::from(before.tv_usec);
+    after - before
+}
+
+fn maxrss_units() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "bytes"
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        "kib"
+    }
+}
+
+fn inverse(values: &[usize]) -> Vec<usize> {
+    let mut inverse = vec![0usize; values.len()];
+    for (idx, value) in values.iter().copied().enumerate() {
+        inverse[value] = idx;
+    }
+    inverse
+}

--- a/scrunch/benches/wavelet_psi.rs
+++ b/scrunch/benches/wavelet_psi.rs
@@ -472,9 +472,25 @@ fn getrusage() -> Result<libc::rusage, std::io::Error> {
     }
 }
 
+trait TimevalUsec {
+    fn widen_to_i64(self) -> i64;
+}
+
+impl TimevalUsec for i32 {
+    fn widen_to_i64(self) -> i64 {
+        i64::from(self)
+    }
+}
+
+impl TimevalUsec for i64 {
+    fn widen_to_i64(self) -> i64 {
+        self
+    }
+}
+
 fn timeval_delta_us(after: libc::timeval, before: libc::timeval) -> i64 {
-    let after = after.tv_sec.saturating_mul(1_000_000) + i64::from(after.tv_usec);
-    let before = before.tv_sec.saturating_mul(1_000_000) + i64::from(before.tv_usec);
+    let after = after.tv_sec.saturating_mul(1_000_000) + after.tv_usec.widen_to_i64();
+    let before = before.tv_sec.saturating_mul(1_000_000) + before.tv_usec.widen_to_i64();
     after - before
 }
 

--- a/scrunch/benches/wavelet_psi.rs
+++ b/scrunch/benches/wavelet_psi.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use buffertk::Unpackable;
 
+use scrunch::Error;
 use scrunch::builder::Builder;
 use scrunch::encoder::HuffmanEncoder;
 use scrunch::psi::Psi;
@@ -15,7 +16,6 @@ use scrunch::psi::wavelet_tree::WaveletTreePsi;
 use scrunch::sais;
 use scrunch::sigma::Sigma;
 use scrunch::wavelet_tree::prefix::WaveletTree;
-use scrunch::Error;
 
 type PrefixWaveletPsi<'a> = WaveletTreePsi<'a, WaveletTree<'a, HuffmanEncoder>>;
 
@@ -251,7 +251,12 @@ fn artifact_path(symbols: usize) -> PathBuf {
     std::env::temp_dir().join(format!("scrunch-wavelet-psi-{pid}-{symbols}.bin"))
 }
 
-fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<(), String> {
+fn run_prepare(
+    exe: &Path,
+    options: &Options,
+    symbols: usize,
+    artifact: &Path,
+) -> Result<(), String> {
     let status = Command::new(exe)
         .arg("--input")
         .arg(&options.input)
@@ -268,7 +273,12 @@ fn run_prepare(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -
     }
 }
 
-fn run_child(exe: &Path, options: &Options, symbols: usize, artifact: &Path) -> Result<String, String> {
+fn run_child(
+    exe: &Path,
+    options: &Options,
+    symbols: usize,
+    artifact: &Path,
+) -> Result<String, String> {
     let output = Command::new(exe)
         .arg("--symbols")
         .arg(symbols.to_string())
@@ -342,7 +352,11 @@ fn read_case(path: &Path) -> Result<PreparedCase, String> {
     let mut psi = Vec::with_capacity(psi_len);
     for _ in 0..psi_len {
         let value = read_u64(&mut file)?;
-        psi.push(value.try_into().map_err(|_| "psi value does not fit usize")?);
+        psi.push(
+            value
+                .try_into()
+                .map_err(|_| "psi value does not fit usize")?,
+        );
     }
     Ok(PreparedCase { sigma_buf, psi })
 }

--- a/scrunch/src/bin/scrunch.rs
+++ b/scrunch/src/bin/scrunch.rs
@@ -1,18 +1,31 @@
-use std::fs::{read_to_string, write};
+use std::fs::{read, write};
 
 use scrunch::builder::Builder;
 use scrunch::{CompressedDocument, Document};
 
 pub fn load_file(file: &str) -> (Vec<u32>, Vec<usize>) {
-    let text: Vec<u32> = read_to_string(file)
-        .expect("file should read to string")
-        .chars()
-        .map(|c| c as u32)
-        .collect();
+    let bytes = read(file).expect("file should read");
     let mut record_boundaries = vec![0usize];
-    for (idx, _) in text.iter().enumerate().filter(|(_, t)| **t == '\n' as u32) {
-        record_boundaries.push(idx + 1);
-    }
+    let text: Vec<u32> = if bytes.is_ascii() {
+        let mut text = Vec::with_capacity(bytes.len());
+        for (idx, byte) in bytes.into_iter().enumerate() {
+            if byte == b'\n' {
+                record_boundaries.push(idx + 1);
+            }
+            text.push(byte as u32);
+        }
+        text
+    } else {
+        let string = String::from_utf8(bytes).expect("file should read to string");
+        let mut text = Vec::with_capacity(string.len());
+        for c in string.chars() {
+            text.push(c as u32);
+            if c == '\n' {
+                record_boundaries.push(text.len());
+            }
+        }
+        text
+    };
     if record_boundaries[record_boundaries.len() - 1] == text.len() {
         record_boundaries.pop();
     }

--- a/scrunch/src/bit_array.rs
+++ b/scrunch/src/bit_array.rs
@@ -146,8 +146,21 @@ impl Builder {
     pub fn push_word(&mut self, word: u64, bits: usize) {
         assert!(bits < 64);
         assert!(word & !((1u64 << bits) - 1) == 0);
-        for i in 0..bits {
-            self.push(word & (1u64 << i) != 0);
+        let mut word = word;
+        let mut bits = bits;
+        while bits > 0 {
+            let available = 8 - self.bits;
+            let take = std::cmp::min(available, bits);
+            let mask = (1u64 << take) - 1;
+            self.byte |= ((word & mask) as u8) << self.bits;
+            self.bits += take;
+            word >>= take;
+            bits -= take;
+            if self.bits == 8 {
+                self.bytes.push(self.byte);
+                self.byte = 0;
+                self.bits = 0;
+            }
         }
     }
 

--- a/scrunch/src/bit_vector/rrr.rs
+++ b/scrunch/src/bit_vector/rrr.rs
@@ -95,6 +95,46 @@ impl Iterator for SixtyThreeBitWords<'_> {
     }
 }
 
+struct SixtyThreeBitWordsFromIterator<I> {
+    bits: I,
+    len: usize,
+    index: usize,
+}
+
+impl<I: Iterator<Item = bool>> SixtyThreeBitWordsFromIterator<I> {
+    fn new(bits: I, len: usize) -> Self {
+        Self {
+            bits,
+            len,
+            index: 0,
+        }
+    }
+}
+
+impl<I: Iterator<Item = bool>> Iterator for SixtyThreeBitWordsFromIterator<I> {
+    type Item = u63;
+
+    fn next(&mut self) -> Option<u63> {
+        if self.index < self.len {
+            let amt = if self.index + 63 > self.len {
+                self.len - self.index
+            } else {
+                63
+            };
+            let mut answer = 0u64;
+            for i in 0..amt {
+                if self.bits.next()? {
+                    answer |= 1 << i;
+                }
+            }
+            self.index += amt;
+            Some(u63::must(answer))
+        } else {
+            None
+        }
+    }
+}
+
 ///////////////////////////////////////////// Binomials ////////////////////////////////////////////
 
 pub(super) const L: &[usize] = &[
@@ -1819,27 +1859,34 @@ impl BitVector<'_> {
             idx += 63;
         }
     }
-}
 
-impl super::BitVector for BitVector<'_> {
-    type Output<'b> = BitVector<'b>;
+    pub(crate) fn words_from_iter<I>(bits: usize, iter: I) -> Vec<u63>
+    where
+        I: IntoIterator<Item = bool>,
+    {
+        SixtyThreeBitWordsFromIterator::new(iter.into_iter(), bits).collect()
+    }
 
-    fn construct<H: Helper>(bits: &[bool], builder: &mut Builder<'_, H>) -> Result<(), Error> {
+    pub(crate) fn construct_from_words<H: Helper>(
+        bits: usize,
+        words: impl IntoIterator<Item = u63>,
+        builder: &mut Builder<'_, H>,
+    ) -> Result<(), Error> {
         const WORD: usize = 8;
         const SELECT: u64 = 64;
-        let mut build_p = BitArrayBuilder::with_capacity(bits.len());
-        let mut build_c = BitArrayBuilder::with_capacity(bits.len());
-        let mut build_o = BitArrayBuilder::with_capacity(bits.len());
-        let mut build_r = BitArrayBuilder::with_capacity(bits.len());
-        let mut build_s0 = BitArrayBuilder::with_capacity(bits.len());
-        let mut build_s1 = BitArrayBuilder::with_capacity(bits.len());
-        let width = Self::calc_p_r_width(bits.len()).ok_or(Error::IntoUsize)?;
+        let mut build_p = BitArrayBuilder::with_capacity(bits);
+        let mut build_c = BitArrayBuilder::with_capacity(bits);
+        let mut build_o = BitArrayBuilder::with_capacity(bits);
+        let mut build_r = BitArrayBuilder::with_capacity(bits);
+        let mut build_s0 = BitArrayBuilder::with_capacity(bits);
+        let mut build_s1 = BitArrayBuilder::with_capacity(bits);
+        let width = Self::calc_p_r_width(bits).ok_or(Error::IntoUsize)?;
         let mut o_len = 0u64;
         let mut rank = 0u64;
         let mut rank0 = 0u64;
         let mut next_select0 = 0u64;
         let mut next_select1 = 0u64;
-        for (idx, word) in SixtyThreeBitWords::new(bits).enumerate() {
+        for (idx, word) in words.into_iter().enumerate() {
             if idx % WORD == 0 {
                 build_p.push_word(o_len, width);
                 build_r.push_word(rank, width);
@@ -1871,7 +1918,7 @@ impl super::BitVector for BitVector<'_> {
         builder.append_raw_packable(&BitVectorStub {
             word: WORD.try_into().expect("WORD must always fit a u8"),
             select: SELECT.try_into().expect("SELECT must always fit a u32"),
-            bits: bits.len() as u64,
+            bits: bits as u64,
             p: &buf_p,
             c: &buf_c,
             o: &buf_o,
@@ -1880,6 +1927,14 @@ impl super::BitVector for BitVector<'_> {
             s1: &buf_s1,
         });
         Ok(())
+    }
+}
+
+impl super::BitVector for BitVector<'_> {
+    type Output<'b> = BitVector<'b>;
+
+    fn construct<H: Helper>(bits: &[bool], builder: &mut Builder<'_, H>) -> Result<(), Error> {
+        Self::construct_from_words(bits.len(), SixtyThreeBitWords::new(bits), builder)
     }
 
     fn parse<'b, 'c: 'b>(buf: &'c [u8]) -> Result<(Self::Output<'b>, &'c [u8]), Error> {
@@ -1892,9 +1947,37 @@ impl super::BitVector for BitVector<'_> {
         self.bits
     }
 
-    // TODO(rescrv): make this as efficient as it can be (compute both together).
     fn access_rank(&self, x: usize) -> Option<(bool, usize)> {
-        Some((self.access(x)?, self.rank(x)?))
+        if x >= self.len() {
+            return None;
+        }
+        // Width of values in P, R.
+        let width = Self::calc_p_r_width(self.bits)?;
+        // P strides by self.word * 63 bits at a time.
+        let stride: usize = self.word as usize * 63;
+        // The offset into P.
+        let p_offset = x / stride;
+        // The offset into O.
+        let mut o_offset: usize = self.p.load(p_offset * width, width)?.try_into().ok()?;
+        // The offset into C.
+        let mut c_offset: usize = p_offset * 6 * self.word as usize;
+        // Our base rank is the number of ones before our p_offset.
+        let mut rank: usize = self.r.load(p_offset * width, width)?.try_into().ok()?;
+        // Adjust index to account for our jump through P.
+        let mut index = x - p_offset * stride;
+        // Step through the words until we have fewer than 63 bits left.
+        while index >= 63 {
+            let (c, o_bits) = self.load_c_o_bits(c_offset)?;
+            index -= 63;
+            c_offset += 6;
+            o_offset += o_bits;
+            rank += c;
+        }
+        let (c, o_bits) = self.load_c_o_bits(c_offset)?;
+        let w = self.load_o(c, o_offset, o_bits)?;
+        let mask = if index == 0 { 0 } else { (1u64 << index) - 1 };
+        rank += (w.0 & mask).count_ones() as usize;
+        Some((w.0 & (1 << index) != 0, rank))
     }
 
     fn access(&self, mut index: usize) -> Option<bool> {

--- a/scrunch/src/builder.rs
+++ b/scrunch/src/builder.rs
@@ -65,9 +65,10 @@ impl<H: Helper> Drop for Builder<'_, H> {
             let pa = pa.pack(len_v64);
             let pa_size = pa.pack_sz();
             buf.resize(current_size + pa_size, 0);
-            for i in 0..len {
-                buf[current_size + pa_size - i - 1] = buf[current_size - i - 1];
-            }
+            buf.copy_within(
+                self.starting_size..current_size,
+                self.starting_size + pa_size,
+            );
             Packable::pack(
                 &pa,
                 &mut buf[self.starting_size..self.starting_size + pa_size],

--- a/scrunch/src/encoder.rs
+++ b/scrunch/src/encoder.rs
@@ -132,38 +132,96 @@ pub struct CodeBook {
 
 #[derive(Clone, Debug, Default)]
 pub struct HuffmanEncoder {
-    encode: HashMap<u32, (u32, u8)>,
-    decode: HashMap<u32, u32>,
+    code_book: Vec<CodeBookEntry>,
+    encode_dense: Option<Vec<(u32, u8)>>,
+    decode: Vec<(u32, u32)>,
 }
 
 impl HuffmanEncoder {
-    fn code_book(&self) -> CodeBook {
-        let mut code_book = CodeBook::default();
-        for (symbol, (code, len)) in self.encode.iter() {
-            code_book.code_book.push(CodeBookEntry {
-                symbol: *symbol,
-                code: *code,
-                len: *len as u32,
-            });
+    fn dense_frequencies(text: &[u32]) -> Option<Vec<(u32, u64)>> {
+        let max_symbol = text.iter().copied().max()? as usize;
+        if max_symbol > (1 << 20) || max_symbol > text.len().saturating_mul(4) {
+            return None;
         }
+        let mut counts = vec![0u64; max_symbol + 1];
+        for &t in text {
+            counts[t as usize] += 1;
+        }
+        let mut frequencies = Vec::new();
+        for (symbol, count) in counts.into_iter().enumerate() {
+            if count > 0 {
+                frequencies.push((symbol as u32, count));
+            }
+        }
+        Some(frequencies)
+    }
+
+    fn sparse_frequencies(text: &[u32]) -> Vec<(u32, u64)> {
+        let mut probabilities = HashMap::new();
+        for &t in text {
+            *probabilities.entry(t).or_insert(0u64) += 1;
+        }
+        let mut probabilities: Vec<(u32, u64)> = probabilities.into_iter().collect();
+        probabilities.sort_unstable_by_key(|(symbol, _)| *symbol);
+        probabilities
+    }
+
+    fn build_code_book(symbols: Vec<(u8, u32)>) -> Vec<CodeBookEntry> {
+        let mut code_book = Vec::with_capacity(symbols.len());
+        let mut code = 0u32;
+        let mut prev_len = 1u8;
+        for (len, sym) in symbols {
+            code <<= len - prev_len;
+            let flipped = code.reverse_bits() >> (32 - len);
+            code_book.push(CodeBookEntry {
+                symbol: sym,
+                code: flipped,
+                len: len as u32,
+            });
+            code += 1;
+            prev_len = len;
+        }
+        code_book.sort_unstable_by_key(|entry| entry.symbol);
         code_book
+    }
+
+    fn build_dense_encode(code_book: &[CodeBookEntry]) -> Option<Vec<(u32, u8)>> {
+        let max_symbol = code_book.last()?.symbol as usize;
+        if max_symbol > code_book.len().saturating_mul(64).max(1024) {
+            return None;
+        }
+        let mut encode_dense = vec![(0u32, 0u8); max_symbol + 1];
+        for entry in code_book {
+            encode_dense[entry.symbol as usize] = (entry.code, entry.len as u8);
+        }
+        Some(encode_dense)
+    }
+
+    fn from_code_book(mut code_book: Vec<CodeBookEntry>) -> Self {
+        code_book.sort_unstable_by_key(|entry| entry.symbol);
+        let encode_dense = Self::build_dense_encode(&code_book);
+        let mut decode: Vec<(u32, u32)> = code_book
+            .iter()
+            .map(|entry| (entry.code, entry.symbol))
+            .collect();
+        decode.sort_unstable_by_key(|(code, _)| *code);
+        Self {
+            code_book,
+            encode_dense,
+            decode,
+        }
     }
 }
 
 impl Encoder for HuffmanEncoder {
     fn construct(text: &[u32]) -> Self {
         if text.is_empty() {
-            return Self {
-                encode: HashMap::new(),
-                decode: HashMap::new(),
-            };
+            return Self::default();
         }
-        let mut probabilities = HashMap::new();
-        for t in text.iter() {
-            *probabilities.entry(*t).or_insert(0) += 1;
-        }
+        let probabilities =
+            Self::dense_frequencies(text).unwrap_or_else(|| Self::sparse_frequencies(text));
         let mut heap = BinaryHeap::new();
-        for (sym, prob) in probabilities.into_iter() {
+        for (sym, prob) in probabilities {
             heap.push(Reverse(Node {
                 prob: prob as f64,
                 sym: Some(sym),
@@ -192,43 +250,47 @@ impl Encoder for HuffmanEncoder {
             tree.append_symbols(0, &mut symbols);
         }
         symbols.sort();
-        // Make the canonical code book.
-        let mut encode = HashMap::new();
-        let mut decode = HashMap::new();
-        let mut code = 0u32;
-        let mut prev_len = 1u8;
-        for (len, sym) in symbols.into_iter() {
-            code <<= len - prev_len;
-            let flipped = code.reverse_bits() >> (32 - len);
-            encode.insert(sym, (flipped, len));
-            decode.insert(flipped, sym);
-            code += 1;
-            prev_len = len;
-        }
-        Self { encode, decode }
+        let code_book = Self::build_code_book(symbols);
+        Self::from_code_book(code_book)
     }
 
     fn encode(&self, t: u32) -> Option<(u32, u8)> {
-        self.encode.get(&t).copied()
+        if let Some(encode_dense) = self.encode_dense.as_ref() {
+            let &(code, len) = encode_dense.get(t as usize)?;
+            if len > 0 {
+                return Some((code, len));
+            }
+        }
+        let idx = self
+            .code_book
+            .binary_search_by_key(&t, |entry| entry.symbol)
+            .ok()?;
+        let entry = &self.code_book[idx];
+        Some((entry.code, entry.len as u8))
     }
 
     fn decode(&self, v: u32, _: u8) -> Option<u32> {
-        self.decode.get(&v).copied()
+        let idx = self.decode.binary_search_by_key(&v, |(code, _)| *code).ok()?;
+        Some(self.decode[idx].1)
     }
 
     fn symbols(&self) -> usize {
-        self.encode.len()
+        self.code_book.len()
     }
 }
 
 impl Packable for HuffmanEncoder {
     fn pack_sz(&self) -> usize {
-        let code_book = self.code_book();
+        let code_book = CodeBook {
+            code_book: self.code_book.clone(),
+        };
         stack_pack(code_book).pack_sz()
     }
 
     fn pack(&self, buf: &mut [u8]) {
-        let code_book = self.code_book();
+        let code_book = CodeBook {
+            code_book: self.code_book.clone(),
+        };
         stack_pack(code_book).into_slice(buf);
     }
 }
@@ -238,23 +300,27 @@ impl<'a> Unpackable<'a> for HuffmanEncoder {
 
     fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Self::Error> {
         let (code_book, buf) = CodeBook::unpack(buf).map_err(|_| Error::InvalidEncoder)?;
-        let mut encode = HashMap::new();
-        let mut decode = HashMap::new();
-        for cbe in code_book.code_book.into_iter() {
-            if encode.contains_key(&cbe.symbol) {
+        let mut entries = code_book.code_book;
+        entries.sort_unstable_by_key(|entry| entry.symbol);
+        let mut prev_symbol = None;
+        let mut decode: Vec<(u32, u32)> = Vec::with_capacity(entries.len());
+        for cbe in entries.iter() {
+            if prev_symbol == Some(cbe.symbol) {
                 return Err(Error::InvalidEncoder);
             }
-            if cbe.len > u8::MAX as u32 {
+            prev_symbol = Some(cbe.symbol);
+            if cbe.len == 0 || cbe.len > u8::MAX as u32 {
                 return Err(Error::InvalidEncoder);
             }
-            let len = cbe.len as u8;
-            if decode.contains_key(&cbe.code) {
-                return Err(Error::InvalidEncoder);
-            }
-            encode.insert(cbe.symbol, (cbe.code, len));
-            decode.insert(cbe.code, cbe.symbol);
+            decode.push((cbe.code, cbe.symbol));
         }
-        let this = HuffmanEncoder { encode, decode };
+        decode.sort_unstable_by_key(|(code, _)| *code);
+        for pair in decode.windows(2) {
+            if pair[0].0 == pair[1].0 {
+                return Err(Error::InvalidEncoder);
+            }
+        }
+        let this = Self::from_code_book(entries);
         Ok((this, buf))
     }
 }

--- a/scrunch/src/encoder.rs
+++ b/scrunch/src/encoder.rs
@@ -270,7 +270,10 @@ impl Encoder for HuffmanEncoder {
     }
 
     fn decode(&self, v: u32, _: u8) -> Option<u32> {
-        let idx = self.decode.binary_search_by_key(&v, |(code, _)| *code).ok()?;
+        let idx = self
+            .decode
+            .binary_search_by_key(&v, |(code, _)| *code)
+            .ok()?;
         Some(self.decode[idx].1)
     }
 

--- a/scrunch/src/isa.rs
+++ b/scrunch/src/isa.rs
@@ -14,6 +14,14 @@ pub trait InverseSuffixArray {
         to_sample: &[usize],
         builder: &mut Builder<H>,
     ) -> Result<(), Error>;
+    fn construct_u32<H: Helper>(
+        isa: &[u32],
+        to_sample: &[usize],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let isa: Vec<usize> = isa.iter().map(|x| *x as usize).collect();
+        Self::construct(&isa, to_sample, builder)
+    }
     fn lookup(&self, idx: usize) -> Result<usize, Error>;
 }
 
@@ -125,6 +133,24 @@ impl InverseSuffixArray for SampledInverseSuffixArray<'_> {
             values.push((*sampled, isa[*sampled]));
         }
         SampledArray::construct(&values, &mut builder.sub(FieldNumber::must(1)))?;
+        Ok(())
+    }
+
+    fn construct_u32<H: Helper>(
+        isa: &[u32],
+        to_sample: &[usize],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let mut values: Vec<(usize, u32)> = vec![];
+        for sampled in to_sample.iter() {
+            if *sampled >= isa.len()
+                || (!values.is_empty() && values[values.len() - 1].0 >= *sampled)
+            {
+                return Err(Error::InvalidInverseSuffixArray);
+            }
+            values.push((*sampled, isa[*sampled]));
+        }
+        SampledArray::construct_u32(&values, &mut builder.sub(FieldNumber::must(1)))?;
         Ok(())
     }
 

--- a/scrunch/src/lib.rs
+++ b/scrunch/src/lib.rs
@@ -327,33 +327,77 @@ where
         let sigma_buf = sigma_builder.relative_bytes(0).to_vec();
         let sigma = sigma::Sigma::unpack(&sigma_buf)?.0;
         drop(sigma_builder);
-        // convert the text into a compacted alphabet
-        let mut s = Vec::with_capacity(text.len() + 1);
-        for t in text.iter().copied() {
-            s.push(sigma.char_to_sigma(t).ok_or(Error::LogicError(
-                "freshly constructed sigma cannot translate text",
-            ))?);
+        macro_rules! construct_u32_offsets {
+            ($s:expr, $sais:path) => {{
+                let s = $s;
+                // compute the suffix array
+                let mut sa = vec![0u32; s.len()];
+                $sais(&sigma, &s, &mut sa)?;
+                drop(s);
+                // TODO(rescrv): parameterize
+                SA::construct_u32(6, &sa, &mut builder.sub(FieldNumber::must(3)))?;
+                // compute the inverse suffix array
+                let (isa, psi) = inverse_and_psi_u32(&sa);
+                ISA::construct_u32(
+                    &isa,
+                    &record_boundaries,
+                    &mut builder.sub(FieldNumber::must(4)),
+                )?;
+                drop(sa);
+                drop(isa);
+                PSI::construct_u32(&sigma, &psi, &mut builder.sub(FieldNumber::must(5)))?;
+            }};
         }
-        s.push(0);
-        drop(text);
-        // compute the suffix array
-        let mut sa = vec![0usize; s.len()];
-        sais::sais(&sigma, &s, &mut sa)?;
-        drop(s);
-        // TODO(rescrv): parameterize
-        SA::construct(6, &sa, &mut builder.sub(FieldNumber::must(3)))?;
-        // compute the inverse suffix array
-        let isa = inverse(&sa);
-        drop(sa);
-        ISA::construct(
-            &isa,
-            &record_boundaries,
-            &mut builder.sub(FieldNumber::must(4)),
-        )?;
-        // compute the successor array, psi
-        let psi = psi::compute(&isa);
-        drop(isa);
-        PSI::construct(&sigma, &psi, &mut builder.sub(FieldNumber::must(5)))?;
+        let fits_u32_offsets = text.len() < u32::MAX as usize - 1;
+        if fits_u32_offsets && sigma.K() <= u8::MAX as usize + 1 {
+            let s = translate_text_u8(&text, &sigma)?;
+            drop(text);
+            construct_u32_offsets!(s, sais::sais_u8_u32);
+        } else if fits_u32_offsets && sigma.K() <= u16::MAX as usize + 1 {
+            let s = translate_text_u16(&text, &sigma)?;
+            drop(text);
+            construct_u32_offsets!(s, sais::sais_u16_u32);
+        } else {
+            // convert the text into a compacted alphabet
+            let s = translate_text::<u32>(&text, &sigma)?;
+            drop(text);
+            // compute the suffix array
+            if s.len() < u32::MAX as usize {
+                let mut sa = vec![0u32; s.len()];
+                sais::sais_u32(&sigma, &s, &mut sa)?;
+                drop(s);
+                // TODO(rescrv): parameterize
+                SA::construct_u32(6, &sa, &mut builder.sub(FieldNumber::must(3)))?;
+                // compute the inverse suffix array
+                let (isa, psi) = inverse_and_psi_u32(&sa);
+                ISA::construct_u32(
+                    &isa,
+                    &record_boundaries,
+                    &mut builder.sub(FieldNumber::must(4)),
+                )?;
+                drop(sa);
+                drop(isa);
+                PSI::construct_u32(&sigma, &psi, &mut builder.sub(FieldNumber::must(5)))?;
+            } else {
+                let mut sa = vec![0usize; s.len()];
+                sais::sais(&sigma, &s, &mut sa)?;
+                drop(s);
+                // TODO(rescrv): parameterize
+                SA::construct(6, &sa, &mut builder.sub(FieldNumber::must(3)))?;
+                // compute the inverse suffix array
+                let isa = inverse(&sa);
+                drop(sa);
+                ISA::construct(
+                    &isa,
+                    &record_boundaries,
+                    &mut builder.sub(FieldNumber::must(4)),
+                )?;
+                // compute the successor array, psi
+                let psi = psi::compute(&isa);
+                drop(isa);
+                PSI::construct(&sigma, &psi, &mut builder.sub(FieldNumber::must(5)))?;
+            }
+        }
         Ok(())
     }
 
@@ -501,11 +545,7 @@ impl From<ExemplarState> for Exemplar {
     fn from(mut es: ExemplarState) -> Self {
         es.needle.reverse();
         Self {
-            count: es
-                .docs
-                .values()
-                .map(|d| d.numer)
-                .fold(0, usize::saturating_add),
+            count: es.cardinality,
             needle: es.needle,
         }
     }
@@ -518,18 +558,135 @@ struct CorrelateDocState {
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]
+enum ExemplarDocs {
+    #[default]
+    Empty,
+    One(usize, CorrelateDocState),
+    Many(HashMap<usize, CorrelateDocState>),
+}
+
+impl ExemplarDocs {
+    fn with_capacity(capacity: usize) -> Self {
+        if capacity <= 1 {
+            Self::Empty
+        } else {
+            Self::Many(HashMap::with_capacity(capacity))
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::One(_, _) => 1,
+            Self::Many(docs) => docs.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn one(&self) -> Option<(usize, &CorrelateDocState)> {
+        match self {
+            Self::Empty => None,
+            Self::One(idx, state) => Some((*idx, state)),
+            Self::Many(docs) if docs.len() == 1 => {
+                docs.iter().next().map(|(idx, state)| (*idx, state))
+            }
+            Self::Many(_) => None,
+        }
+    }
+
+    fn insert(&mut self, idx: usize, state: CorrelateDocState) -> Option<CorrelateDocState> {
+        match std::mem::take(self) {
+            Self::Empty => {
+                *self = Self::One(idx, state);
+                None
+            }
+            Self::One(existing_idx, existing_state) => {
+                if existing_idx == idx {
+                    *self = Self::One(idx, state);
+                    Some(existing_state)
+                } else {
+                    let mut docs = HashMap::with_capacity(2);
+                    docs.insert(existing_idx, existing_state);
+                    let previous = docs.insert(idx, state);
+                    *self = Self::Many(docs);
+                    previous
+                }
+            }
+            Self::Many(mut docs) => {
+                let previous = docs.insert(idx, state);
+                *self = Self::Many(docs);
+                previous
+            }
+        }
+    }
+
+    fn iter(&self) -> ExemplarDocsIter<'_> {
+        match self {
+            Self::Empty => ExemplarDocsIter::Empty,
+            Self::One(idx, state) => ExemplarDocsIter::One(Some((*idx, state))),
+            Self::Many(docs) => ExemplarDocsIter::Many(docs.iter()),
+        }
+    }
+
+    fn iter_mut(&mut self) -> ExemplarDocsIterMut<'_> {
+        match self {
+            Self::Empty => ExemplarDocsIterMut::Empty,
+            Self::One(idx, state) => ExemplarDocsIterMut::One(Some((*idx, state))),
+            Self::Many(docs) => ExemplarDocsIterMut::Many(docs.iter_mut()),
+        }
+    }
+}
+
+enum ExemplarDocsIter<'a> {
+    Empty,
+    One(Option<(usize, &'a CorrelateDocState)>),
+    Many(std::collections::hash_map::Iter<'a, usize, CorrelateDocState>),
+}
+
+impl<'a> Iterator for ExemplarDocsIter<'a> {
+    type Item = (usize, &'a CorrelateDocState);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::One(item) => item.take(),
+            Self::Many(iter) => iter.next().map(|(idx, state)| (*idx, state)),
+        }
+    }
+}
+
+enum ExemplarDocsIterMut<'a> {
+    Empty,
+    One(Option<(usize, &'a mut CorrelateDocState)>),
+    Many(std::collections::hash_map::IterMut<'a, usize, CorrelateDocState>),
+}
+
+impl<'a> Iterator for ExemplarDocsIterMut<'a> {
+    type Item = (usize, &'a mut CorrelateDocState);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::One(item) => item.take(),
+            Self::Many(iter) => iter.next().map(|(idx, state)| (*idx, state)),
+        }
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
 struct ExemplarState {
     stop: Vec<u32>,
     needle: Vec<u32>,
-    docs: HashMap<usize, CorrelateDocState>,
+    cardinality: usize,
+    docs: ExemplarDocs,
 }
 
 impl ExemplarState {
     fn cardinality(&self) -> usize {
-        self.docs
-            .values()
-            .map(|d| d.numer)
-            .fold(0, usize::saturating_add)
+        self.cardinality
     }
 }
 
@@ -538,17 +695,7 @@ impl Ord for ExemplarState {
         if self == other {
             Ordering::Equal
         } else {
-            let numer_lhs = self
-                .docs
-                .values()
-                .map(|d| d.numer)
-                .fold(0, usize::saturating_add);
-            let numer_rhs = other
-                .docs
-                .values()
-                .map(|d| d.numer)
-                .fold(0, usize::saturating_add);
-            numer_lhs.cmp(&numer_rhs)
+            self.cardinality.cmp(&other.cardinality)
         }
     }
 }
@@ -568,29 +715,50 @@ where
     ISA: isa::InverseSuffixArray,
     PSI: psi::Psi,
 {
+    exemplars_with_min_length(docs, boundaries, 0)
+}
+
+pub fn exemplars_with_min_length<'a, SA, ISA, PSI>(
+    docs: &'a [&'a PsiDocument<'a, SA, ISA, PSI>],
+    boundaries: &[(u32, u32)],
+    min_length: usize,
+) -> Exemplars<'a, SA, ISA, PSI>
+where
+    SA: sa::SuffixArray,
+    ISA: isa::InverseSuffixArray,
+    PSI: psi::Psi,
+{
+    let docs = ExemplarDoc::from_documents(docs);
     let mut heap = BinaryHeap::new();
     for boundary in boundaries.iter() {
         let mut state = ExemplarState {
             // the starting boundary because we do backwards search.
             stop: vec![boundary.0],
             needle: vec![boundary.1],
-            docs: HashMap::new(),
+            cardinality: 0,
+            docs: ExemplarDocs::with_capacity(docs.len()),
         };
         for (idx, doc) in docs.iter().enumerate() {
-            let Ok(range) = doc.sigma.sa_range_for(boundary.1) else {
+            let Ok(range) = doc.document.sigma.sa_range_for(boundary.1) else {
                 continue;
             };
             if range.0 > range.1 {
                 continue;
             }
             let numer = range.1 - range.0 + 1;
+            state.cardinality = state.cardinality.saturating_add(numer);
             state.docs.insert(idx, CorrelateDocState { numer, range });
         }
         if !state.docs.is_empty() {
             heap.push(state);
         }
     }
-    Exemplars { docs, heap }
+    Exemplars {
+        docs,
+        heap,
+        min_length,
+        sigma_ranges: Vec::new(),
+    }
 }
 
 pub fn exemplars_from_needle<'a, SA, ISA, PSI>(
@@ -603,26 +771,101 @@ where
     ISA: isa::InverseSuffixArray,
     PSI: psi::Psi,
 {
+    let docs = ExemplarDoc::from_documents(docs);
     let mut heap = BinaryHeap::new();
     let mut state = ExemplarState {
         stop: stop.to_vec(),
         needle: needle.clone(),
-        docs: HashMap::new(),
+        cardinality: 0,
+        docs: ExemplarDocs::with_capacity(docs.len()),
     };
     for (idx, doc) in docs.iter().enumerate() {
-        let Ok(range) = doc.backwards_search(&state.needle) else {
+        let Ok(range) = doc.document.backwards_search(&state.needle) else {
             continue;
         };
         if range.0 > range.1 {
             continue;
         }
         let numer = range.1 - range.0 + 1;
+        state.cardinality = state.cardinality.saturating_add(numer);
         state.docs.insert(idx, CorrelateDocState { numer, range });
     }
     if !state.docs.is_empty() {
         heap.push(state);
     }
-    Exemplars { docs, heap }
+    Exemplars {
+        docs,
+        heap,
+        min_length: 0,
+        sigma_ranges: Vec::new(),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ExemplarSymbol {
+    text: u32,
+    range: (usize, usize),
+}
+
+struct ExemplarDoc<'a, SA, ISA, PSI>
+where
+    SA: sa::SuffixArray,
+    ISA: isa::InverseSuffixArray,
+    PSI: psi::Psi,
+{
+    document: &'a PsiDocument<'a, SA, ISA, PSI>,
+    symbols: Vec<ExemplarSymbol>,
+    symbols_by_sigma: Vec<Option<ExemplarSymbol>>,
+}
+
+impl<'a, SA, ISA, PSI> ExemplarDoc<'a, SA, ISA, PSI>
+where
+    SA: sa::SuffixArray,
+    ISA: isa::InverseSuffixArray,
+    PSI: psi::Psi,
+{
+    fn from_documents(docs: &'a [&'a PsiDocument<'a, SA, ISA, PSI>]) -> Vec<Self> {
+        docs.iter().copied().map(Self::new).collect()
+    }
+
+    fn new(document: &'a PsiDocument<'a, SA, ISA, PSI>) -> Self {
+        let mut symbols = Vec::with_capacity(document.sigma.K().saturating_sub(1));
+        let mut symbols_by_sigma = vec![None; document.sigma.K()];
+        for symbol in 1..document.sigma.K() as u32 {
+            let Some(text) = document.sigma.sigma_to_char(symbol) else {
+                continue;
+            };
+            let Ok(range) = document.sigma.sa_range_for_sigma(symbol) else {
+                continue;
+            };
+            if range.0 <= range.1 {
+                let exemplar_symbol = ExemplarSymbol { text, range };
+                symbols_by_sigma[symbol as usize] = Some(exemplar_symbol);
+                symbols.push(exemplar_symbol);
+            }
+        }
+        Self {
+            document,
+            symbols,
+            symbols_by_sigma,
+        }
+    }
+
+    fn constrain(
+        &self,
+        doc_state: &CorrelateDocState,
+        symbol: ExemplarSymbol,
+    ) -> Option<(usize, (usize, usize))> {
+        let range = self
+            .document
+            .psi
+            .constrain(&self.document.sigma, symbol.range, doc_state.range)
+            .ok()?;
+        if range.0 > range.1 {
+            return None;
+        }
+        Some((range.1 - range.0 + 1, range))
+    }
 }
 
 pub struct Exemplars<'a, SA, ISA, PSI>
@@ -631,8 +874,10 @@ where
     ISA: isa::InverseSuffixArray,
     PSI: psi::Psi,
 {
-    docs: &'a [&'a PsiDocument<'a, SA, ISA, PSI>],
+    docs: Vec<ExemplarDoc<'a, SA, ISA, PSI>>,
     heap: BinaryHeap<ExemplarState>,
+    min_length: usize,
+    sigma_ranges: Vec<(u32, (usize, usize))>,
 }
 
 impl<SA, ISA, PSI> Exemplars<'_, SA, ISA, PSI>
@@ -649,45 +894,113 @@ where
                     .iter(),
             )
             .all(|(x, y)| *x == *y)
+                && exemplar.needle.len() >= self.min_length
             {
                 return Some(exemplar);
             }
-            let mut new_exemplars: HashMap<u32, ExemplarState> = HashMap::new();
-            for (idx, doc_state) in exemplar.docs.iter() {
-                let doc = &self.docs[*idx];
-                for i in 1..=doc.sigma.K() as u32 {
-                    let Some(t) = doc.sigma.sigma_to_char(i) else {
-                        // TODO(rescrv): Metrics because this should never happen.
-                        continue;
-                    };
-                    let new_exemplar = new_exemplars.entry(t).or_insert_with(|| {
+            if exemplar.docs.len() == 1 {
+                let (idx, doc_state) = exemplar.docs.one().expect("len checked");
+                let doc = &self.docs[idx];
+                self.sigma_ranges.clear();
+                if doc
+                    .document
+                    .psi
+                    .predecessor_sigma_ranges(
+                        &doc.document.sigma,
+                        doc_state.range,
+                        &mut self.sigma_ranges,
+                    )
+                    .unwrap_or(false)
+                {
+                    for (sigma, range) in self.sigma_ranges.iter().copied() {
+                        let Some(symbol) =
+                            doc.symbols_by_sigma.get(sigma as usize).copied().flatten()
+                        else {
+                            continue;
+                        };
+                        let numer = range.1 - range.0 + 1;
                         let mut needle = exemplar.needle.clone();
-                        needle.push(t);
-                        ExemplarState {
+                        needle.push(symbol.text);
+                        self.heap.push(ExemplarState {
                             stop: exemplar.stop.clone(),
                             needle,
-                            docs: HashMap::new(),
-                        }
-                    });
-                    let Ok(range) = doc.sigma.sa_range_for_sigma(i) else {
-                        // TODO(rescrv): Metrics because this should never happen.
-                        continue;
-                    };
-                    if range.0 > range.1 {
-                        // TODO(rescrv): Metrics because this should never happen.
-                        continue;
+                            cardinality: numer,
+                            docs: ExemplarDocs::One(idx, CorrelateDocState { numer, range }),
+                        });
                     }
-                    let Ok(range) = doc.psi.constrain(&doc.sigma, range, doc_state.range) else {
-                        // TODO(rescrv): Metrics because this should never happen.
-                        continue;
-                    };
-                    if range.0 > range.1 {
-                        continue;
+                } else {
+                    for symbol in doc.symbols.iter().copied() {
+                        let Some((numer, range)) = doc.constrain(doc_state, symbol) else {
+                            continue;
+                        };
+                        let mut needle = exemplar.needle.clone();
+                        needle.push(symbol.text);
+                        self.heap.push(ExemplarState {
+                            stop: exemplar.stop.clone(),
+                            needle,
+                            cardinality: numer,
+                            docs: ExemplarDocs::One(idx, CorrelateDocState { numer, range }),
+                        });
                     }
-                    let numer = range.1 - range.0 + 1;
-                    new_exemplar
-                        .docs
-                        .insert(*idx, CorrelateDocState { numer, range });
+                }
+                continue;
+            }
+            let mut new_exemplars: HashMap<u32, ExemplarState> = HashMap::new();
+            for (idx, doc_state) in exemplar.docs.iter() {
+                let doc = &self.docs[idx];
+                self.sigma_ranges.clear();
+                if doc
+                    .document
+                    .psi
+                    .predecessor_sigma_ranges(
+                        &doc.document.sigma,
+                        doc_state.range,
+                        &mut self.sigma_ranges,
+                    )
+                    .unwrap_or(false)
+                {
+                    for (sigma, range) in self.sigma_ranges.iter().copied() {
+                        let Some(symbol) =
+                            doc.symbols_by_sigma.get(sigma as usize).copied().flatten()
+                        else {
+                            continue;
+                        };
+                        let numer = range.1 - range.0 + 1;
+                        let new_exemplar = new_exemplars.entry(symbol.text).or_insert_with(|| {
+                            let mut needle = exemplar.needle.clone();
+                            needle.push(symbol.text);
+                            ExemplarState {
+                                stop: exemplar.stop.clone(),
+                                needle,
+                                cardinality: 0,
+                                docs: ExemplarDocs::with_capacity(exemplar.docs.len()),
+                            }
+                        });
+                        new_exemplar.cardinality = new_exemplar.cardinality.saturating_add(numer);
+                        new_exemplar
+                            .docs
+                            .insert(idx, CorrelateDocState { numer, range });
+                    }
+                } else {
+                    for symbol in doc.symbols.iter().copied() {
+                        let Some((numer, range)) = doc.constrain(doc_state, symbol) else {
+                            continue;
+                        };
+                        let new_exemplar = new_exemplars.entry(symbol.text).or_insert_with(|| {
+                            let mut needle = exemplar.needle.clone();
+                            needle.push(symbol.text);
+                            ExemplarState {
+                                stop: exemplar.stop.clone(),
+                                needle,
+                                cardinality: 0,
+                                docs: ExemplarDocs::with_capacity(exemplar.docs.len()),
+                            }
+                        });
+                        new_exemplar.cardinality = new_exemplar.cardinality.saturating_add(numer);
+                        new_exemplar
+                            .docs
+                            .insert(idx, CorrelateDocState { numer, range });
+                    }
                 }
             }
             for (_, new_exemplar) in new_exemplars {
@@ -760,22 +1073,24 @@ where
         loop {
             if let Some(mut exemplar) = self.exemplars.next_inner() {
                 let cardinality = exemplar.cardinality();
+                exemplar.cardinality = 0;
                 for (idx, doc) in exemplar.docs.iter_mut() {
                     doc.numer = 0;
                     for offset in doc.range.0..=doc.range.1 {
                         // TODO(rescrv): no unwrap
                         let offset = TextOffset(
-                            self.docs[*idx]
+                            self.docs[idx]
                                 .sa
-                                .lookup(&self.docs[*idx].sigma, &self.docs[*idx].psi, offset)
+                                .lookup(&self.docs[idx].sigma, &self.docs[idx].psi, offset)
                                 .unwrap(),
                         );
                         // TODO(rescrv): no unwrap
-                        let offset = self.docs[*idx].lookup(offset).unwrap();
-                        if (self.select)(*idx, offset) {
+                        let offset = self.docs[idx].lookup(offset).unwrap();
+                        if (self.select)(idx, offset) {
                             doc.numer += 1;
                         }
                     }
+                    exemplar.cardinality = exemplar.cardinality.saturating_add(doc.numer);
                 }
                 self.correlates.push(exemplar);
                 if let Some(correlate) = self.correlates.peek()
@@ -800,6 +1115,125 @@ fn inverse(x: &[usize]) -> Vec<usize> {
         ix[x[i]] = i
     }
     ix
+}
+
+fn inverse_and_psi_u32(sa: &[u32]) -> (Vec<u32>, Vec<u32>) {
+    let len = sa.len();
+    let mut isa = vec![u32::MAX; len];
+    let mut psi: Vec<std::mem::MaybeUninit<u32>> = Vec::with_capacity(len);
+    // SAFETY(codex): MaybeUninit<u32> has no initialization invariant, and set_len only exposes
+    // uninitialized slots that this function writes before converting to Vec<u32>. We never read a
+    // slot until it has been written, which follows the Rustonomicon's MaybeUninit rules.
+    unsafe {
+        psi.set_len(len);
+    }
+    for (idx, pos) in sa.iter().copied().enumerate() {
+        let idx = idx as u32;
+        let pos = pos as usize;
+        isa[pos] = idx;
+
+        let prev_pos = if pos == 0 { len - 1 } else { pos - 1 };
+        // SAFETY(codex): prev_pos is either pos - 1 or len - 1 and pos came from the suffix array,
+        // so prev_pos < len == isa.len(); isa contains initialized u32 sentinels, making this
+        // immutable read in-bounds and alias-safe under the Rustonomicon.
+        let prev_isa = unsafe { *isa.get_unchecked(prev_pos) };
+        if prev_isa != u32::MAX {
+            // SAFETY(codex): prev_isa was read from isa after being initialized to a suffix-array
+            // index, so prev_isa < len; each psi slot is written exactly when its predecessor is
+            // discovered, and MaybeUninit::write avoids dropping uninitialized memory.
+            unsafe {
+                psi.get_unchecked_mut(prev_isa as usize).write(idx);
+            }
+        }
+
+        let next_pos = if pos + 1 == len { 0 } else { pos + 1 };
+        // SAFETY(codex): next_pos is either pos + 1 within len or 0, so it is in-bounds for isa;
+        // isa is fully initialized with sentinel values before the loop and shared reads do not
+        // violate Rustonomicon aliasing rules.
+        let next_isa = unsafe { *isa.get_unchecked(next_pos) };
+        if next_isa != u32::MAX {
+            // SAFETY(codex): idx is the enumerate index converted to u32 with len < u32::MAX on
+            // callers of this path, so idx < psi.len(); the slot is written with MaybeUninit::write
+            // exactly when its successor is known, satisfying initialization requirements.
+            unsafe {
+                psi.get_unchecked_mut(idx as usize).write(next_isa);
+            }
+        }
+    }
+    // SAFETY(codex): valid suffix arrays are permutations, so the predecessor/successor loop writes
+    // every psi slot exactly once before conversion; assume_init_vec_u32 only reinterprets fully
+    // initialized u32 storage and preserves pointer, length, and capacity.
+    (isa, unsafe { assume_init_vec_u32(psi) })
+}
+
+unsafe fn assume_init_vec_u32(mut values: Vec<std::mem::MaybeUninit<u32>>) -> Vec<u32> {
+    let ptr = values.as_mut_ptr() as *mut u32;
+    let len = values.len();
+    let capacity = values.capacity();
+    std::mem::forget(values);
+    // SAFETY(codex): the caller guarantees every MaybeUninit<u32> element is initialized; u32 has
+    // identical layout in MaybeUninit<u32>, and Vec::from_raw_parts receives the original pointer,
+    // length, and capacity, satisfying the Rustonomicon ownership and allocation rules.
+    unsafe { Vec::from_raw_parts(ptr, len, capacity) }
+}
+
+fn translate_text<Sym>(text: &[u32], sigma: &sigma::Sigma<'_>) -> Result<Vec<Sym>, Error>
+where
+    Sym: From<u8> + TryFrom<u32>,
+{
+    let mut s = Vec::with_capacity(text.len() + 1);
+    for t in text.iter().copied() {
+        let symbol = sigma.char_to_sigma(t).ok_or(Error::LogicError(
+            "freshly constructed sigma cannot translate text",
+        ))?;
+        s.push(Sym::try_from(symbol).map_err(|_| Error::InvalidSigma)?);
+    }
+    s.push(Sym::from(0));
+    Ok(s)
+}
+
+fn translate_text_u8(text: &[u32], sigma: &sigma::Sigma<'_>) -> Result<Vec<u8>, Error> {
+    let mut s = Vec::with_capacity(text.len() + 1);
+    if let Some(dense) = sigma.dense_char_to_sigma_table() {
+        for t in text.iter().copied() {
+            let symbol = dense.get(t as usize).copied().unwrap_or(0);
+            if symbol == 0 || symbol > u8::MAX as u32 {
+                return Err(Error::InvalidSigma);
+            }
+            s.push(symbol as u8);
+        }
+    } else {
+        for t in text.iter().copied() {
+            let symbol = sigma.char_to_sigma(t).ok_or(Error::LogicError(
+                "freshly constructed sigma cannot translate text",
+            ))?;
+            s.push(u8::try_from(symbol).map_err(|_| Error::InvalidSigma)?);
+        }
+    }
+    s.push(0);
+    Ok(s)
+}
+
+fn translate_text_u16(text: &[u32], sigma: &sigma::Sigma<'_>) -> Result<Vec<u16>, Error> {
+    let mut s = Vec::with_capacity(text.len() + 1);
+    if let Some(dense) = sigma.dense_char_to_sigma_table() {
+        for t in text.iter().copied() {
+            let symbol = dense.get(t as usize).copied().unwrap_or(0);
+            if symbol == 0 || symbol > u16::MAX as u32 {
+                return Err(Error::InvalidSigma);
+            }
+            s.push(symbol as u16);
+        }
+    } else {
+        for t in text.iter().copied() {
+            let symbol = sigma.char_to_sigma(t).ok_or(Error::LogicError(
+                "freshly constructed sigma cannot translate text",
+            ))?;
+            s.push(u16::try_from(symbol).map_err(|_| Error::InvalidSigma)?);
+        }
+    }
+    s.push(0);
+    Ok(s)
 }
 
 ////////////////////////////////////// check_record_boundaries /////////////////////////////////////

--- a/scrunch/src/psi/mod.rs
+++ b/scrunch/src/psi/mod.rs
@@ -15,6 +15,23 @@ pub trait Psi {
         psi: &[usize],
         builder: &mut Builder<H>,
     ) -> Result<(), Error>;
+    fn construct_u32<H: Helper>(
+        sigma: &Sigma,
+        psi: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let psi: Vec<usize> = psi.iter().map(|x| *x as usize).collect();
+        Self::construct(sigma, &psi, builder)
+    }
+    fn construct_from_sa_isa_u32<H: Helper>(
+        sigma: &Sigma,
+        sa: &[u32],
+        isa: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let psi = compute_from_sa_isa_u32(sa, isa);
+        Self::construct_u32(sigma, &psi, builder)
+    }
 
     /// The length of the psi.  Should be the same as the number of symbols in the text +
     /// terminating symbol.
@@ -43,6 +60,30 @@ pub trait Psi {
         range: (usize, usize),
         into: (usize, usize),
     ) -> Result<(usize, usize), Error>;
+
+    /// Populate `symbols` with sigma-domain predecessor symbols for `range` when this Psi can do
+    /// so cheaply.  Returns `Ok(true)` if `symbols` is complete and `Ok(false)` if callers should
+    /// fall back to trying the full alphabet.
+    fn predecessor_sigma_symbols(
+        &self,
+        _sigma: &Sigma,
+        _range: (usize, usize),
+        _symbols: &mut Vec<u32>,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    /// Populate `ranges` with sigma-domain predecessor symbols and their constrained suffix-array
+    /// ranges for a backwards-search step into `range`.  Returns `Ok(true)` if `ranges` is complete
+    /// and `Ok(false)` if callers should fall back to repeated `constrain` calls.
+    fn predecessor_sigma_ranges(
+        &self,
+        _sigma: &Sigma,
+        _range: (usize, usize),
+        _ranges: &mut Vec<(u32, (usize, usize))>,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
 }
 
 ///////////////////////////////////////// ReferencePsiStub /////////////////////////////////////////
@@ -152,6 +193,29 @@ pub fn compute(isa: &[usize]) -> Vec<usize> {
     psi
 }
 
+pub fn compute_u32(isa: &[u32]) -> Vec<u32> {
+    let mut psi = vec![0u32; isa.len()];
+    psi[isa[isa.len() - 1] as usize] = isa[0];
+    for i in 1..isa.len() {
+        psi[isa[i - 1] as usize] = isa[i];
+    }
+    psi
+}
+
+pub fn compute_from_sa_isa_u32(sa: &[u32], isa: &[u32]) -> Vec<u32> {
+    assert_eq!(sa.len(), isa.len());
+    let mut psi = vec![0u32; sa.len()];
+    for (idx, pos) in sa.iter().copied().enumerate() {
+        let pos = pos as usize;
+        psi[idx] = if pos + 1 == isa.len() {
+            isa[0]
+        } else {
+            isa[pos + 1]
+        };
+    }
+    psi
+}
+
 /////////////////////////////////////////////// tests //////////////////////////////////////////////
 
 #[cfg(test)]
@@ -214,6 +278,27 @@ pub mod tests {
                 *into,
                 *answer
             );
+            let mut ranges = Vec::new();
+            if psi
+                .predecessor_sigma_ranges(&sigma, *into, &mut ranges)
+                .unwrap()
+            {
+                for (symbol, returned) in ranges.iter().copied() {
+                    let symbol_range = sigma.sa_range_for_sigma(symbol).unwrap();
+                    let expected = psi.constrain(&sigma, symbol_range, *into).unwrap();
+                    assert_eq_with_ctx!(expected, returned, symbol, *into);
+                }
+                let symbol = sigma.sa_index_to_sigma(range.0).unwrap();
+                let returned = ranges
+                    .iter()
+                    .find(|(candidate, _)| *candidate == symbol)
+                    .map(|(_, range)| *range);
+                if answer.0 <= answer.1 {
+                    assert_eq_with_ctx!(Some(*answer), returned, symbol, *into);
+                } else {
+                    assert_eq_with_ctx!(None, returned, symbol, *into);
+                }
+            }
         }
     }
 

--- a/scrunch/src/psi/wavelet_tree.rs
+++ b/scrunch/src/psi/wavelet_tree.rs
@@ -191,27 +191,30 @@ impl SigmaMap for [u32] {
     }
 }
 
+struct ContextState {
+    tree: Vec<u32>,
+    counts: Vec<usize>,
+    active: Vec<usize>,
+    cells_by_sigma: Vec<Vec<CellSummary>>,
+}
+
 fn flush_context<WT: WaveletTree, H: Helper>(
     builder: &mut Builder<H>,
-    ctx: [u32; CTX_MAX],
-    ctx_sz: usize,
+    ctx: &[u32],
     start: usize,
-    tree: &mut Vec<u32>,
-    counts: &mut [usize],
-    active: &mut Vec<usize>,
-    cells_by_sigma: &mut [Vec<CellSummary>],
+    state: &mut ContextState,
     row: usize,
 ) -> Result<(), Error> {
-    for symbol in active.iter().copied() {
-        let count = std::mem::take(&mut counts[symbol]);
-        cells_by_sigma[symbol].push(CellSummary { row, count });
+    for symbol in state.active.iter().copied() {
+        let count = std::mem::take(&mut state.counts[symbol]);
+        state.cells_by_sigma[symbol].push(CellSummary { row, count });
     }
-    active.clear();
+    state.active.clear();
     let mut builder = builder.sub(FieldNumber::must(CONTEXT_FIELD_NUMBER));
-    builder.append_vec_u32(FieldNumber::must(1), &ctx[..ctx_sz]);
+    builder.append_vec_u32(FieldNumber::must(1), ctx);
     builder.append_u64(FieldNumber::must(2), start as u64);
-    WT::construct(tree, &mut builder.sub(FieldNumber::must(3)))?;
-    tree.clear();
+    WT::construct(&state.tree, &mut builder.sub(FieldNumber::must(3)))?;
+    state.tree.clear();
     Ok(())
 }
 
@@ -270,10 +273,12 @@ where
 {
     const CTX_SZ: usize = 2;
     let mut ctx = [0u32; CTX_MAX];
-    let mut tree: Vec<u32> = Vec::new();
-    let mut counts = vec![0usize; sigma.K()];
-    let mut active: Vec<usize> = Vec::new();
-    let mut cells_by_sigma: Vec<Vec<CellSummary>> = vec![Vec::new(); sigma.K()];
+    let mut state = ContextState {
+        tree: Vec::new(),
+        counts: vec![0usize; sigma.K()],
+        active: Vec::new(),
+        cells_by_sigma: vec![Vec::new(); sigma.K()],
+    };
     let mut start = 0usize;
     let mut row = 0usize;
     let mut seen = 0usize;
@@ -299,17 +304,7 @@ where
         }
         if ctx != tmp {
             if i > 0 {
-                flush_context::<WT, H>(
-                    builder,
-                    ctx,
-                    CTX_SZ,
-                    start,
-                    &mut tree,
-                    &mut counts,
-                    &mut active,
-                    &mut cells_by_sigma,
-                    row,
-                )?;
+                flush_context::<WT, H>(builder, &ctx[..CTX_SZ], start, &mut state, row)?;
                 row += 1;
             }
             ctx = tmp;
@@ -323,37 +318,27 @@ where
         // initialized symbols; the unchecked read therefore meets Rustonomicon bounds and aliasing
         // requirements.
         let symbol = unsafe { sa_to_sigma.get_unchecked_usize(ipsi) };
-        tree.push(symbol as u32);
+        state.tree.push(symbol as u32);
         // SAFETY(codex): sa_to_sigma values are built from bucket symbols in 0..sigma.K(), and
         // counts.len() == sigma.K(); this immutable initialized read is in-bounds and alias-safe.
-        if unsafe { *counts.get_unchecked(symbol) } == 0 {
-            active.push(symbol);
+        if unsafe { *state.counts.get_unchecked(symbol) } == 0 {
+            state.active.push(symbol);
         }
         // SAFETY(codex): the same symbol-domain proof gives symbol < counts.len(); counts is
         // uniquely borrowed mutably here, so the initialized increment follows Rustonomicon
         // exclusivity and bounds rules.
         unsafe {
-            *counts.get_unchecked_mut(symbol) += 1;
+            *state.counts.get_unchecked_mut(symbol) += 1;
         }
     }
     if seen != len {
         return Err(Error::InvalidPsi);
     }
-    flush_context::<WT, H>(
-        builder,
-        ctx,
-        CTX_SZ,
-        start,
-        &mut tree,
-        &mut counts,
-        &mut active,
-        &mut cells_by_sigma,
-        row,
-    )?;
+    flush_context::<WT, H>(builder, &ctx[..CTX_SZ], start, &mut state, row)?;
     let mut y_value = vec![];
     let mut y_key = vec![];
     let mut sum = 0usize;
-    for cells in cells_by_sigma {
+    for cells in state.cells_by_sigma {
         for cell in cells {
             if sum > 0 {
                 y_key.push(sum - 1);

--- a/scrunch/src/psi/wavelet_tree.rs
+++ b/scrunch/src/psi/wavelet_tree.rs
@@ -83,6 +83,8 @@ impl<WT: WaveletTree> Context<WT> {
 
 /////////////////////////////////////////// BuildContext ///////////////////////////////////////////
 
+#[cfg(test)]
+#[allow(dead_code)]
 #[derive(Debug)]
 struct BuildContext {
     ctx: [u32; CTX_MAX],
@@ -91,8 +93,290 @@ struct BuildContext {
     sums: Vec<usize>,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct CellSummary {
+    row: usize,
+    count: usize,
+}
+
+trait PsiIndex: Copy {
+    fn to_usize(self) -> usize;
+}
+
+impl PsiIndex for usize {
+    fn to_usize(self) -> usize {
+        self
+    }
+}
+
+impl PsiIndex for u32 {
+    fn to_usize(self) -> usize {
+        self as usize
+    }
+}
+
+enum SaToSigma {
+    U8(Vec<u8>),
+    U16(Vec<u16>),
+    U32(Vec<u32>),
+}
+
+impl SaToSigma {
+    fn new(k: usize, len: usize, bucket_limits: &[usize]) -> Result<Self, Error> {
+        if k <= u8::MAX as usize + 1 {
+            Ok(Self::U8(Self::build(k, len, bucket_limits)?))
+        } else if k <= u16::MAX as usize + 1 {
+            Ok(Self::U16(Self::build(k, len, bucket_limits)?))
+        } else {
+            Ok(Self::U32(Self::build(k, len, bucket_limits)?))
+        }
+    }
+
+    fn build<T: Copy + Default + TryFrom<usize>>(
+        k: usize,
+        len: usize,
+        bucket_limits: &[usize],
+    ) -> Result<Vec<T>, Error> {
+        if bucket_limits.len() != k {
+            return Err(Error::InvalidSigma);
+        }
+        let mut values = vec![T::default(); len];
+        let mut previous_limit = 0usize;
+        for (symbol, limit) in bucket_limits.iter().copied().enumerate() {
+            if limit < previous_limit || limit > len {
+                return Err(Error::InvalidSigma);
+            }
+            let symbol = T::try_from(symbol).map_err(|_| Error::IntoUsize)?;
+            values[previous_limit..limit].fill(symbol);
+            previous_limit = limit;
+        }
+        if previous_limit != len {
+            return Err(Error::InvalidSigma);
+        }
+        Ok(values)
+    }
+}
+
+trait SigmaMap {
+    unsafe fn get_unchecked_usize(&self, idx: usize) -> usize;
+}
+
+impl SigmaMap for [u8] {
+    #[inline(always)]
+    unsafe fn get_unchecked_usize(&self, idx: usize) -> usize {
+        // SAFETY(codex): this unsafe trait method requires callers to prove idx < self.len(); the
+        // slice contains initialized u8 values, and the shared read creates no aliasing violation
+        // under the Rustonomicon's unchecked indexing rules.
+        unsafe { *self.get_unchecked(idx) as usize }
+    }
+}
+
+impl SigmaMap for [u16] {
+    #[inline(always)]
+    unsafe fn get_unchecked_usize(&self, idx: usize) -> usize {
+        // SAFETY(codex): callers uphold the method contract that idx is in-bounds; reading an
+        // initialized u16 through a shared slice reference preserves Rustonomicon aliasing and
+        // lifetime requirements.
+        unsafe { *self.get_unchecked(idx) as usize }
+    }
+}
+
+impl SigmaMap for [u32] {
+    #[inline(always)]
+    unsafe fn get_unchecked_usize(&self, idx: usize) -> usize {
+        // SAFETY(codex): the unsafe method contract requires idx < self.len(); the u32 element is
+        // initialized and read immutably, so unchecked access satisfies Rustonomicon bounds,
+        // provenance, and aliasing rules.
+        unsafe { *self.get_unchecked(idx) as usize }
+    }
+}
+
+fn flush_context<WT: WaveletTree, H: Helper>(
+    builder: &mut Builder<H>,
+    ctx: [u32; CTX_MAX],
+    ctx_sz: usize,
+    start: usize,
+    tree: &mut Vec<u32>,
+    counts: &mut [usize],
+    active: &mut Vec<usize>,
+    cells_by_sigma: &mut [Vec<CellSummary>],
+    row: usize,
+) -> Result<(), Error> {
+    for symbol in active.iter().copied() {
+        let count = std::mem::take(&mut counts[symbol]);
+        cells_by_sigma[symbol].push(CellSummary { row, count });
+    }
+    active.clear();
+    let mut builder = builder.sub(FieldNumber::must(CONTEXT_FIELD_NUMBER));
+    builder.append_vec_u32(FieldNumber::must(1), &ctx[..ctx_sz]);
+    builder.append_u64(FieldNumber::must(2), start as u64);
+    WT::construct(tree, &mut builder.sub(FieldNumber::must(3)))?;
+    tree.clear();
+    Ok(())
+}
+
+fn construct_streaming<WT: WaveletTree, H: Helper, I: PsiIndex>(
+    sigma: &Sigma,
+    len: usize,
+    builder: &mut Builder<H>,
+    ipsi: impl IntoIterator<Item = I>,
+    psi_lookup: impl FnMut(usize) -> usize,
+) -> Result<(), Error> {
+    let mut bucket_limits = Vec::new();
+    sigma.bucket_limits(&mut bucket_limits)?;
+    let sa_to_sigma = SaToSigma::new(sigma.K(), len, &bucket_limits)?;
+    match sa_to_sigma {
+        SaToSigma::U8(values) => construct_streaming_mapped::<WT, H, I, _, _>(
+            sigma,
+            len,
+            builder,
+            ipsi,
+            psi_lookup,
+            values.as_slice(),
+        ),
+        SaToSigma::U16(values) => construct_streaming_mapped::<WT, H, I, _, _>(
+            sigma,
+            len,
+            builder,
+            ipsi,
+            psi_lookup,
+            values.as_slice(),
+        ),
+        SaToSigma::U32(values) => construct_streaming_mapped::<WT, H, I, _, _>(
+            sigma,
+            len,
+            builder,
+            ipsi,
+            psi_lookup,
+            values.as_slice(),
+        ),
+    }
+}
+
+fn construct_streaming_mapped<WT, H, I, F, M>(
+    sigma: &Sigma,
+    len: usize,
+    builder: &mut Builder<H>,
+    ipsi: impl IntoIterator<Item = I>,
+    mut psi_lookup: F,
+    sa_to_sigma: &M,
+) -> Result<(), Error>
+where
+    WT: WaveletTree,
+    H: Helper,
+    I: PsiIndex,
+    F: FnMut(usize) -> usize,
+    M: SigmaMap + ?Sized,
+{
+    const CTX_SZ: usize = 2;
+    let mut ctx = [0u32; CTX_MAX];
+    let mut tree: Vec<u32> = Vec::new();
+    let mut counts = vec![0usize; sigma.K()];
+    let mut active: Vec<usize> = Vec::new();
+    let mut cells_by_sigma: Vec<Vec<CellSummary>> = vec![Vec::new(); sigma.K()];
+    let mut start = 0usize;
+    let mut row = 0usize;
+    let mut seen = 0usize;
+    for (i, ipsi) in ipsi.into_iter().enumerate() {
+        if i >= len {
+            return Err(Error::InvalidPsi);
+        }
+        seen += 1;
+        let mut tmp = ctx;
+        // SAFETY(codex): i is checked against len above, and SaToSigma::new builds sa_to_sigma with
+        // exactly len initialized entries; the unsafe trait method's in-bounds precondition is met.
+        tmp[0] = unsafe { sa_to_sigma.get_unchecked_usize(i) as u32 };
+        let mut idx = i;
+        for t in tmp.iter_mut().take(CTX_SZ).skip(1) {
+            idx = psi_lookup(idx);
+            if idx >= len {
+                return Err(Error::InvalidSigma);
+            }
+            // SAFETY(codex): idx was checked to be less than len, and sa_to_sigma has len
+            // initialized entries; this shared read is in-bounds and preserves Rustonomicon
+            // aliasing guarantees.
+            *t = unsafe { sa_to_sigma.get_unchecked_usize(idx) as u32 };
+        }
+        if ctx != tmp {
+            if i > 0 {
+                flush_context::<WT, H>(
+                    builder,
+                    ctx,
+                    CTX_SZ,
+                    start,
+                    &mut tree,
+                    &mut counts,
+                    &mut active,
+                    &mut cells_by_sigma,
+                    row,
+                )?;
+                row += 1;
+            }
+            ctx = tmp;
+            start = i;
+        }
+        let ipsi = ipsi.to_usize();
+        if ipsi >= len {
+            return Err(Error::InvalidSigma);
+        }
+        // SAFETY(codex): ipsi was checked against len, and SaToSigma's backing map has exactly len
+        // initialized symbols; the unchecked read therefore meets Rustonomicon bounds and aliasing
+        // requirements.
+        let symbol = unsafe { sa_to_sigma.get_unchecked_usize(ipsi) };
+        tree.push(symbol as u32);
+        // SAFETY(codex): sa_to_sigma values are built from bucket symbols in 0..sigma.K(), and
+        // counts.len() == sigma.K(); this immutable initialized read is in-bounds and alias-safe.
+        if unsafe { *counts.get_unchecked(symbol) } == 0 {
+            active.push(symbol);
+        }
+        // SAFETY(codex): the same symbol-domain proof gives symbol < counts.len(); counts is
+        // uniquely borrowed mutably here, so the initialized increment follows Rustonomicon
+        // exclusivity and bounds rules.
+        unsafe {
+            *counts.get_unchecked_mut(symbol) += 1;
+        }
+    }
+    if seen != len {
+        return Err(Error::InvalidPsi);
+    }
+    flush_context::<WT, H>(
+        builder,
+        ctx,
+        CTX_SZ,
+        start,
+        &mut tree,
+        &mut counts,
+        &mut active,
+        &mut cells_by_sigma,
+        row,
+    )?;
+    let mut y_value = vec![];
+    let mut y_key = vec![];
+    let mut sum = 0usize;
+    for cells in cells_by_sigma {
+        for cell in cells {
+            if sum > 0 {
+                y_key.push(sum - 1);
+            }
+            y_value.push(cell.row);
+            sum += cell.count;
+        }
+    }
+    y_key.push(sum - 1);
+    BitVector::from_indices(
+        128,
+        sum,
+        &y_key,
+        &mut builder.sub(FieldNumber::must(Y_KEY_FIELD_NUMBER)),
+    )
+    .ok_or(Error::InvalidBitVector)?;
+    builder.append_vec_usize(FieldNumber::must(Y_VALUE_FIELD_NUMBER), &y_value);
+    Ok(())
+}
+
 /////////////////////////////////////////////// Table //////////////////////////////////////////////
 
+#[cfg(test)]
 fn compute_table(sigma: &Sigma, ctx_sz: usize, psi: &[usize]) -> Result<Vec<BuildContext>, Error> {
     let mut ctx = [0u32; CTX_MAX];
     // compute the inverse of psi so that we can bounce around the columns in order
@@ -218,6 +502,35 @@ where
 }
 
 impl<WT: WaveletTree> WaveletTreePsi<'_, WT> {
+    fn row_for_index(&self, idx: usize) -> Result<usize, Error> {
+        let row = self.table.partition_point(|row| row.start <= idx);
+        row.checked_sub(1).ok_or(Error::BadIndex(idx))
+    }
+
+    fn cell_start_for_symbol_row(
+        &self,
+        sigma: &Sigma,
+        symbol: u32,
+        row: usize,
+    ) -> Result<Option<usize>, Error> {
+        let range = sigma.sa_range_for_sigma(symbol)?;
+        if range.0 > range.1 {
+            return Ok(None);
+        }
+        let first_cell = self.y_key.rank(range.0).ok_or(Error::BadRank(range.0))?;
+        let last_cell = self.y_key.rank(range.1).ok_or(Error::BadRank(range.1))?;
+        let cells = &self.y_value[first_cell..=last_cell];
+        let offset = cells.partition_point(|candidate| *candidate < row);
+        if offset >= cells.len() || cells[offset] != row {
+            return Ok(None);
+        }
+        let cell = first_cell + offset;
+        self.y_key
+            .select(cell)
+            .ok_or(Error::BadSelect(cell))
+            .map(Some)
+    }
+
     // Find the lowest index of psi in the range [into.0, into.1] s.t. psi[idx] >= point.
     //
     // Requires that into be a closed range.
@@ -344,39 +657,51 @@ impl<WT: WaveletTree> super::Psi for WaveletTreePsi<'_, WT> {
         psi: &[usize],
         builder: &mut Builder<H>,
     ) -> Result<(), Error> {
-        const CTX_SZ: usize = 2;
-        let table = compute_table(sigma, CTX_SZ, psi)?;
-        let mut y_value = vec![];
-        let mut y_key = vec![];
-        let mut sum = 0;
-        for i in 0..sigma.K() {
-            for (idx, t) in table.iter().enumerate() {
-                let in_cell = t.sums.get(i).copied().unwrap_or(0);
-                if in_cell > 0 {
-                    if sum > 0 {
-                        y_key.push(sum - 1);
-                    }
-                    y_value.push(idx);
-                    sum += in_cell;
-                }
+        if u32::try_from(psi.len()).is_ok() {
+            let mut ipsi = vec![0u32; psi.len()];
+            for (idx, value) in psi.iter().copied().enumerate() {
+                ipsi[value] = idx as u32;
             }
+            construct_streaming::<WT, H, _>(sigma, psi.len(), builder, ipsi, |idx| psi[idx])
+        } else {
+            construct_streaming::<WT, H, _>(sigma, psi.len(), builder, inverse(psi), |idx| psi[idx])
         }
-        for t in table.iter() {
-            let mut builder = builder.sub(FieldNumber::must(CONTEXT_FIELD_NUMBER));
-            builder.append_vec_u32(FieldNumber::must(1), &t.ctx[..CTX_SZ]);
-            builder.append_u64(FieldNumber::must(2), t.start as u64);
-            WT::construct(&t.tree, &mut builder.sub(FieldNumber::must(3)))?;
+    }
+
+    fn construct_u32<H: Helper>(
+        sigma: &Sigma,
+        psi: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let ipsi = inverse_psi_u32(psi);
+        construct_streaming::<WT, H, _>(sigma, psi.len(), builder, ipsi, |idx| psi[idx] as usize)
+    }
+
+    fn construct_from_sa_isa_u32<H: Helper>(
+        sigma: &Sigma,
+        sa: &[u32],
+        isa: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        if sa.len() != isa.len() {
+            return Err(Error::InvalidPsi);
         }
-        y_key.push(sum - 1);
-        BitVector::from_indices(
-            128,
-            sum,
-            &y_key,
-            &mut builder.sub(FieldNumber::must(Y_KEY_FIELD_NUMBER)),
-        )
-        .ok_or(Error::InvalidBitVector)?;
-        builder.append_vec_usize(FieldNumber::must(Y_VALUE_FIELD_NUMBER), &y_value);
-        Ok(())
+        let ipsi = sa.iter().copied().map(|pos| {
+            let pos = pos as usize;
+            if pos == 0 {
+                isa[isa.len() - 1]
+            } else {
+                isa[pos - 1]
+            }
+        });
+        construct_streaming::<WT, H, _>(sigma, sa.len(), builder, ipsi, |idx| {
+            let pos = sa[idx] as usize;
+            if pos + 1 == isa.len() {
+                isa[0] as usize
+            } else {
+                isa[pos + 1] as usize
+            }
+        })
     }
 
     fn len(&self) -> usize {
@@ -420,6 +745,96 @@ impl<WT: WaveletTree> super::Psi for WaveletTreePsi<'_, WT> {
         let upper = self.upper_bound(sigma, into.1, range)?;
         Ok((lower, upper))
     }
+
+    fn predecessor_sigma_symbols(
+        &self,
+        sigma: &Sigma,
+        range: (usize, usize),
+        symbols: &mut Vec<u32>,
+    ) -> Result<bool, Error> {
+        symbols.clear();
+        if range.0 > range.1 || self.table.is_empty() {
+            return Ok(true);
+        }
+        let len = range.1 - range.0 + 1;
+        if len.saturating_mul(32) >= sigma.K().saturating_sub(1) {
+            return Ok(false);
+        }
+        for idx in range.0..=range.1 {
+            let row = self.table.partition_point(|row| row.start <= idx);
+            let Some(row) = row.checked_sub(1) else {
+                return Err(Error::BadIndex(idx));
+            };
+            let row = &self.table[row];
+            let Some(symbol) = row.tree.access(idx - row.start) else {
+                return Err(Error::BadIndex(idx));
+            };
+            if symbol != 0 && !symbols.contains(&symbol) {
+                symbols.push(symbol);
+            }
+        }
+        Ok(true)
+    }
+
+    fn predecessor_sigma_ranges(
+        &self,
+        sigma: &Sigma,
+        range: (usize, usize),
+        ranges: &mut Vec<(u32, (usize, usize))>,
+    ) -> Result<bool, Error> {
+        ranges.clear();
+        if range.0 > range.1 || self.table.is_empty() {
+            return Ok(true);
+        }
+        let first_row = self.row_for_index(range.0)?;
+        let last_row = self.row_for_index(range.1)?;
+        if first_row == last_row {
+            let row = &self.table[first_row];
+            let lower = range.0 - row.start;
+            let upper = range.1 - row.start + 1;
+            row.tree
+                .symbol_rank_ranges(lower, upper, ranges)
+                .ok_or(Error::BadIndex(upper))?;
+            let mut write = 0;
+            for read in 0..ranges.len() {
+                let (symbol, (lower_rank, upper_rank)) = ranges[read];
+                if symbol == 0 {
+                    continue;
+                }
+                let Some(cell_start) = self.cell_start_for_symbol_row(sigma, symbol, first_row)?
+                else {
+                    return Err(Error::BadIndex(first_row));
+                };
+                ranges[write] = (
+                    symbol,
+                    (cell_start + lower_rank, cell_start + upper_rank - 1),
+                );
+                write += 1;
+            }
+            ranges.truncate(write);
+            return Ok(true);
+        }
+        let mut symbols = Vec::new();
+        if !self.predecessor_sigma_symbols(sigma, range, &mut symbols)? {
+            return Ok(false);
+        }
+        for symbol in symbols {
+            let symbol_range = sigma.sa_range_for_sigma(symbol)?;
+            let constrained = self.constrain(sigma, symbol_range, range)?;
+            if constrained.0 <= constrained.1 {
+                ranges.push((symbol, constrained));
+            }
+        }
+        Ok(true)
+    }
+}
+
+fn inverse_psi_u32(psi: &[u32]) -> Vec<u32> {
+    let mut ipsi = vec![0u32; psi.len()];
+    for (idx, value) in psi.iter().copied().enumerate() {
+        ipsi[value as usize] = idx as u32;
+    }
+    ipsi
 }
 
 impl<'a, WT> Unpackable<'a> for WaveletTreePsi<'a, WT>

--- a/scrunch/src/sa.rs
+++ b/scrunch/src/sa.rs
@@ -17,6 +17,14 @@ pub trait SuffixArray {
         sa: &[usize],
         builder: &mut Builder<H>,
     ) -> Result<(), Error>;
+    fn construct_u32<H: Helper>(
+        sampling: usize,
+        sa: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let sa: Vec<usize> = sa.iter().map(|x| *x as usize).collect();
+        Self::construct(sampling, &sa, builder)
+    }
     fn lookup<PSI: psi::Psi>(&self, sigma: &Sigma, psi: &PSI, idx: usize) -> Result<usize, Error>;
 }
 
@@ -140,6 +148,29 @@ impl SuffixArray for SampledSuffixArray<'_> {
         builder.append_u32(FieldNumber::must(1), sampling as u32);
         builder.append_u64(FieldNumber::must(2), sa[0] as u64);
         SampledArray::construct(&values, &mut builder.sub(FieldNumber::must(3)))?;
+        Ok(())
+    }
+
+    fn construct_u32<H: Helper>(
+        sampling: usize,
+        sa: &[u32],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        if sampling > 31 {
+            return Err(Error::InvalidSuffixArray);
+        }
+        let stride = 1u32
+            .checked_shl(sampling as u32)
+            .ok_or(Error::InvalidSuffixArray)?;
+        let mut values = vec![];
+        for (idx, &sa) in sa.iter().enumerate() {
+            if sa % stride == 0 {
+                values.push((idx, sa >> sampling));
+            }
+        }
+        builder.append_u32(FieldNumber::must(1), sampling as u32);
+        builder.append_u64(FieldNumber::must(2), sa[0] as u64);
+        SampledArray::construct_u32(&values, &mut builder.sub(FieldNumber::must(3)))?;
         Ok(())
     }
 

--- a/scrunch/src/sais.rs
+++ b/scrunch/src/sais.rs
@@ -4,10 +4,7 @@
 //! i'th suffix in sorted order.
 #![allow(non_snake_case)]
 
-use buffertk::Unpackable;
-
 use crate::Error;
-use crate::builder::Builder;
 use crate::sigma::Sigma;
 
 /// LSType is an indication of how a character relates to those charcters that follow it.  An
@@ -15,30 +12,242 @@ use crate::sigma::Sigma;
 /// S-type character is smaller than the character that follows it.  For purposes of comparison,
 /// ties take on the type of the next character.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg(test)]
 enum LSType {
     L,
     S,
 }
 
+struct TypeBits {
+    bits: Vec<u64>,
+    lms_bits: Vec<u64>,
+}
+
+struct LmsPositions<'a> {
+    bits: &'a [u64],
+    word_idx: usize,
+    word: u64,
+}
+
+struct LmsPositionsRev<'a> {
+    bits: &'a [u64],
+    word_idx: usize,
+    word: u64,
+}
+
+impl Iterator for LmsPositions<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.word != 0 {
+                let bit = self.word.trailing_zeros() as usize;
+                self.word &= self.word - 1;
+                return Some((self.word_idx - 1) * 64 + bit);
+            }
+            self.word = *self.bits.get(self.word_idx)?;
+            self.word_idx += 1;
+        }
+    }
+}
+
+impl Iterator for LmsPositionsRev<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.word != 0 {
+                let bit = 63 - self.word.leading_zeros() as usize;
+                self.word &= !(1u64 << bit);
+                return Some((self.word_idx << 6) + bit);
+            }
+            if self.word_idx == 0 {
+                return None;
+            }
+            self.word_idx -= 1;
+            // SAFETY(codex): word_idx starts at bits.len() and is decremented only after the
+            // zero check, so the index is in-bounds; the immutable slice contains initialized
+            // u64 values and this copy creates no aliasing or lifetime violation under the
+            // Rustonomicon's unchecked-indexing rules.
+            self.word = unsafe { *self.bits.get_unchecked(self.word_idx) };
+        }
+    }
+}
+
+impl TypeBits {
+    fn new(len: usize) -> Self {
+        Self {
+            bits: vec![0u64; len.div_ceil(64)],
+            lms_bits: vec![0u64; len.div_ceil(64)],
+        }
+    }
+
+    #[inline(always)]
+    fn is_s(&self, idx: usize) -> bool {
+        // SAFETY(codex): TypeBits is allocated with ceil(input_len / 64) words and every caller
+        // passes an index into the original input, so idx >> 6 is in-bounds; the read is immutable,
+        // aligned, and initialized, satisfying the Rustonomicon requirements for unchecked access.
+        unsafe { ((*self.bits.get_unchecked(idx >> 6) >> (idx & 63)) & 1) != 0 }
+    }
+
+    #[inline(always)]
+    fn is_l(&self, idx: usize) -> bool {
+        !self.is_s(idx)
+    }
+
+    #[inline(always)]
+    fn is_lms(&self, idx: usize) -> bool {
+        // SAFETY(codex): lms_bits has the same word layout as bits, and callers only query input
+        // offsets; therefore idx >> 6 is in-bounds and the immutable initialized u64 read does not
+        // violate aliasing or provenance rules described by the Rustonomicon.
+        unsafe { ((*self.lms_bits.get_unchecked(idx >> 6) >> (idx & 63)) & 1) != 0 }
+    }
+
+    fn lms_positions(&self) -> LmsPositions<'_> {
+        LmsPositions {
+            bits: &self.lms_bits,
+            word_idx: 0,
+            word: 0,
+        }
+    }
+
+    fn lms_positions_rev(&self) -> LmsPositionsRev<'_> {
+        LmsPositionsRev {
+            bits: &self.lms_bits,
+            word_idx: self.lms_bits.len(),
+            word: 0,
+        }
+    }
+}
+
+trait Symbol: Copy + Eq {
+    fn to_usize(self) -> usize;
+}
+
+impl Symbol for u8 {
+    #[inline(always)]
+    fn to_usize(self) -> usize {
+        self as usize
+    }
+}
+
+impl Symbol for u16 {
+    #[inline(always)]
+    fn to_usize(self) -> usize {
+        self as usize
+    }
+}
+
+impl Symbol for u32 {
+    #[inline(always)]
+    fn to_usize(self) -> usize {
+        self as usize
+    }
+}
+
+impl Symbol for usize {
+    #[inline(always)]
+    fn to_usize(self) -> usize {
+        self
+    }
+}
+
+trait Index: Symbol + Default {
+    const MAX: Self;
+
+    fn from_usize(x: usize) -> Self;
+}
+
+impl Index for usize {
+    const MAX: Self = usize::MAX;
+
+    #[inline(always)]
+    fn from_usize(x: usize) -> Self {
+        x
+    }
+}
+
+impl Index for u32 {
+    const MAX: Self = u32::MAX;
+
+    #[inline(always)]
+    fn from_usize(x: usize) -> Self {
+        debug_assert!(x < u32::MAX as usize);
+        x as u32
+    }
+}
+
 /// get_types creates an LSType-string from a usize-string.
-fn get_types(S: &[u32]) -> Vec<LSType> {
-    let mut prev = (LSType::S, 0);
-    let mut types = Vec::with_capacity(S.len());
-    for &s in S.iter().rev() {
+#[cfg(test)]
+fn get_types<Sym: Symbol>(S: &[Sym]) -> Vec<LSType> {
+    let mut prev = (LSType::S, 0usize);
+    let mut types = vec![LSType::S; S.len()];
+    for i in (0..S.len()).rev() {
+        let s = S[i].to_usize();
         prev = if s < prev.1 || (s == prev.1 && prev.0 == LSType::S) {
             (LSType::S, s)
         } else {
             (LSType::L, s)
         };
-        types.push(prev.0);
+        types[i] = prev.0;
     }
-    types.reverse();
+    types
+}
+
+/// get_type_bits creates a packed LSType-string from a string.
+fn get_type_bits<Sym: Symbol>(S: &[Sym]) -> TypeBits {
+    let mut prev_is_s = true;
+    let mut prev_symbol = 0usize;
+    let mut types = TypeBits::new(S.len());
+    if S.is_empty() {
+        return types;
+    }
+    let mut word_idx = (S.len() - 1) >> 6;
+    let mut word = 0u64;
+    let mut lms_word_idx = usize::MAX;
+    let mut lms_word = 0u64;
+    for i in (0..S.len()).rev() {
+        let next_word_idx = i >> 6;
+        if next_word_idx != word_idx {
+            types.bits[word_idx] = word;
+            word_idx = next_word_idx;
+            word = 0;
+        }
+        let symbol = S[i].to_usize();
+        let is_s = symbol < prev_symbol || (symbol == prev_symbol && prev_is_s);
+        if is_s {
+            word |= 1u64 << (i & 63);
+        }
+        if !is_s && prev_is_s {
+            let lms_idx = i + 1;
+            let next_lms_word_idx = lms_idx >> 6;
+            if next_lms_word_idx != lms_word_idx {
+                if lms_word_idx != usize::MAX {
+                    types.lms_bits[lms_word_idx] = lms_word;
+                }
+                lms_word_idx = next_lms_word_idx;
+                lms_word = 0;
+            }
+            lms_word |= 1u64 << (lms_idx & 63);
+        }
+        prev_is_s = is_s;
+        prev_symbol = symbol;
+    }
+    types.bits[word_idx] = word;
+    if lms_word_idx != usize::MAX {
+        types.lms_bits[lms_word_idx] = lms_word;
+    }
     types
 }
 
 /// is_lms returns whether a particular index in the LSType-string is the left-most-S.
+#[cfg(test)]
+#[inline(always)]
 fn is_lms(T: &[LSType], i: usize) -> bool {
-    i > 0 && T[i - 1] == LSType::L && T[i] == LSType::S
+    // SAFETY(codex): the left conjunct proves i > 0, and test callers enumerate i from T indices,
+    // so i - 1 and i are both in-bounds; immutable initialized enum reads preserve Rust's aliasing
+    // and lifetime rules as required by the Rustonomicon.
+    i > 0 && unsafe { *T.get_unchecked(i - 1) == LSType::L && *T.get_unchecked(i) == LSType::S }
 }
 
 /// induce_L does a left-to-right induced sort to fill in L-type symbols.  By scanning
@@ -48,19 +257,35 @@ fn is_lms(T: &[LSType], i: usize) -> bool {
 ///
 /// And because we because we only fill in L-type suffixes, they are by definition larger than (to
 /// the right of) the index used to construct the suffix.
-fn induce_L(
-    sigma: &Sigma,
-    S: &[u32],
-    SA: &mut [usize],
-    T: &[LSType],
-    buckets: &mut Vec<usize>,
+fn induce_L<Sym: Symbol, Idx: Index, Bucket: Index>(
+    bucket_starts: &[Bucket],
+    S: &[Sym],
+    SA: &mut [Idx],
+    T: &TypeBits,
+    buckets: &mut Vec<Bucket>,
 ) -> Result<(), Error> {
-    sigma.bucket_starts(buckets)?;
+    buckets.copy_from_slice(bucket_starts);
     for i in 0..S.len() {
-        let j = SA[i].wrapping_sub(1);
-        if j < usize::MAX - 1 && T[j] == LSType::L {
-            SA[buckets[S[j] as usize]] = j;
-            buckets[S[j] as usize] += 1;
+        // SAFETY(codex): i is produced by 0..S.len() and SA.len() == S.len(), so the immutable SA
+        // access is in-bounds and reads an initialized Index without aliasing mutation, matching the
+        // Rustonomicon's unchecked indexing preconditions.
+        let j = unsafe { SA.get_unchecked(i).to_usize().wrapping_sub(1) };
+        if j < S.len() && T.is_l(j) {
+            // SAFETY(codex): j < S.len() was checked above; S is immutable and initialized, so this
+            // unchecked read observes a valid symbol without violating aliasing or lifetime rules.
+            let symbol = unsafe { S.get_unchecked(j).to_usize() };
+            // SAFETY(codex): sais_impl validates every input symbol is less than the bucket count,
+            // and recursive buckets are built from that same alphabet; this is the only mutable
+            // borrow of this bucket element, so Rustonomicon bounds and aliasing rules are upheld.
+            let bucket = unsafe { buckets.get_unchecked_mut(symbol) };
+            let dest = bucket.to_usize();
+            // SAFETY(codex): induced sorting maintains bucket cursors inside SA ranges derived from
+            // bucket_starts/bucket_limits, so dest < SA.len(); this write uses the unique mutable SA
+            // borrow and stores an initialized Index, satisfying Rustonomicon requirements.
+            unsafe {
+                *SA.get_unchecked_mut(dest) = Idx::from_usize(j);
+            }
+            *bucket = Bucket::from_usize(dest + 1);
         }
     }
     Ok(())
@@ -69,40 +294,92 @@ fn induce_L(
 /// induce_S does a right-to-left induced sort to fill in S-type symbols.  The reasoning for what
 /// this does is similar to how induce_L works, except it works right-to-left, is monotonically
 /// decreasing, and fills buckets from the right.
-fn induce_S(
-    sigma: &Sigma,
-    S: &[u32],
-    SA: &mut [usize],
-    T: &[LSType],
-    buckets: &mut Vec<usize>,
+fn induce_S<Sym: Symbol, Idx: Index, Bucket: Index>(
+    bucket_limits: &[Bucket],
+    S: &[Sym],
+    SA: &mut [Idx],
+    T: &TypeBits,
+    buckets: &mut Vec<Bucket>,
 ) -> Result<(), Error> {
-    sigma.bucket_limits(buckets)?;
+    buckets.copy_from_slice(bucket_limits);
     for i in (0..S.len()).rev() {
-        let j = SA[i].wrapping_sub(1);
-        if j < usize::MAX - 1 && T[j] == LSType::S {
-            buckets[S[j] as usize] -= 1;
-            SA[buckets[S[j] as usize]] = j;
+        // SAFETY(codex): i is produced by a range bounded by S.len(), and SA.len() == S.len(), so
+        // this initialized immutable read is in-bounds and does not conflict with mutation.
+        let j = unsafe { SA.get_unchecked(i).to_usize().wrapping_sub(1) };
+        if j < S.len() && T.is_s(j) {
+            // SAFETY(codex): the branch checked j < S.len(); reading S[j] immutably is in-bounds,
+            // initialized, and follows the Rustonomicon aliasing rules for shared references.
+            let symbol = unsafe { S.get_unchecked(j).to_usize() };
+            // SAFETY(codex): symbols are validated against the bucket count before sorting, and the
+            // S-pass cursor is initialized from bucket_limits; mutating one bucket slot through the
+            // only active mutable borrow satisfies Rustonomicon bounds and aliasing requirements.
+            let dest = unsafe {
+                let bucket = buckets.get_unchecked_mut(symbol);
+                let dest = bucket.to_usize() - 1;
+                *bucket = Bucket::from_usize(dest);
+                dest
+            };
+            // SAFETY(codex): dest is the decremented bucket cursor, which stays within the suffix
+            // array bucket range by the induced-sort invariant; the unique mutable SA borrow makes
+            // this initialized write valid under the Rustonomicon.
+            unsafe {
+                *SA.get_unchecked_mut(dest) = Idx::from_usize(j);
+            }
         }
     }
     Ok(())
 }
 
-/// sais is the Suffix-Array Induced-Sort.  This algorithm uses induced-sort (similar technique is
-/// used in radix sort) to produce a suffix array in time linear in the length of the input.
-///
-/// # Panics:
-/// - K > S.len()
-/// - S.len() != SA.len()
-/// - S.len() == 0
-/// - S is not termintated by a zero
-pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
-    // We need some space for sentinels in the lang.
-    assert!(sigma.K() <= S.len());
-    // The input and "output" must be aligned.
+fn bucket_starts_and_limits<Sym: Symbol, Idx: Index>(
+    k: usize,
+    s: &[Sym],
+) -> Result<(Vec<Idx>, Vec<Idx>), Error> {
+    let mut bucket_limits = vec![Idx::from_usize(0); k];
+    for &symbol in s {
+        let symbol = symbol.to_usize();
+        if symbol >= k {
+            return Err(Error::InvalidSigma);
+        }
+        bucket_limits[symbol] = Idx::from_usize(bucket_limits[symbol].to_usize() + 1);
+    }
+    let mut sum = 0usize;
+    for limit in bucket_limits.iter_mut() {
+        sum += limit.to_usize();
+        *limit = Idx::from_usize(sum);
+    }
+    let mut bucket_starts = vec![Idx::from_usize(0); k];
+    let mut prev = 0usize;
+    for (idx, limit) in bucket_limits.iter().copied().enumerate() {
+        bucket_starts[idx] = Idx::from_usize(prev);
+        prev = limit.to_usize();
+    }
+    Ok((bucket_starts, bucket_limits))
+}
+
+fn sais_impl<Sym: Symbol, Idx: Index, Bucket: Index>(
+    bucket_starts: &[Bucket],
+    bucket_limits: &[Bucket],
+    S: &[Sym],
+    SA: &mut [Idx],
+) -> Result<(), Error> {
+    assert_eq!(bucket_starts.len(), bucket_limits.len());
+    assert!(
+        bucket_limits
+            .last()
+            .copied()
+            .map(|x| x.to_usize())
+            .unwrap_or(0)
+            == S.len()
+    );
+    assert!(bucket_starts.len() <= S.len());
     assert!(S.len() == SA.len());
-    // The last character should be zero, which also requires there to be a last character.
     assert!(!S.is_empty());
-    assert_eq!(S[S.len() - 1], 0);
+    assert_eq!(S[S.len() - 1].to_usize(), 0);
+    if S.iter()
+        .any(|symbol| symbol.to_usize() >= bucket_starts.len())
+    {
+        return Err(Error::InvalidSigma);
+    }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Imagine we wanted to compute the suffix array of the string "baabababbab" that looks
@@ -150,8 +427,8 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     // In our running example, we find:
     // S = [b, a, a, b, a, b, a, b, b, a, b, $]
     // T = [L, S, S, L, S, L, S, L, L, S, L, S]
-    let T = get_types(S);
-    let T: &[LSType] = &T;
+    let T = get_type_bits(S);
+
     // 2.  Compute the "buckets" for the string and place the LMS characters at the end of their
     //     respective buckets.
     //
@@ -159,49 +436,101 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     // SA     = [11, 1, 9, 2, 4, 6, 10, 0, 8, 3, 5, 7]
     // S[SA]  = [ $, a, a, a, a, a,  b, b, b, b, b, b]
     // Bucket = [ 0, 1, 1, 1, 1, 1,  2, 2, 2, 2, 2, 2]
-    let mut buckets = vec![0usize; sigma.K()];
-    sigma.bucket_limits(&mut buckets)?;
+    let mut buckets = bucket_limits.to_vec();
+    buckets.copy_from_slice(bucket_limits);
     // We will use usize::MAX as a sentinel to mean "empty" throughout the computation.
-    for item in SA.iter_mut().take(S.len()) {
-        *item = usize::MAX;
-    }
     // Place the LMSes at the end of their respective buckets.
     // After this loop, SA will look like this:
     // SA = [11, _, 9, 6, 4, 1, _, _, _, _, _, _]
-    for i in 0..S.len() {
-        if is_lms(T, i) {
-            buckets[S[i] as usize] -= 1;
-            SA[buckets[S[i] as usize]] = i;
+    SA.fill(Index::MAX);
+    for i in T.lms_positions() {
+        // SAFETY(codex): lms_positions only yields bits that were set from valid input offsets, so
+        // i < S.len(); this immutable initialized symbol read is in-bounds and alias-safe.
+        let symbol = unsafe { S.get_unchecked(i).to_usize() };
+        // SAFETY(codex): sais_impl validated symbols are bucket indices, and placing LMS entries
+        // decrements cursors inside bucket_limits; the single mutable bucket borrow satisfies the
+        // Rustonomicon's exclusivity rule.
+        let dest = unsafe {
+            let bucket = buckets.get_unchecked_mut(symbol);
+            let dest = bucket.to_usize() - 1;
+            *bucket = Bucket::from_usize(dest);
+            dest
+        };
+        // SAFETY(codex): dest comes from a valid bucket cursor for the suffix array and therefore
+        // is less than SA.len(); writing through the unique mutable SA borrow preserves aliasing and
+        // initialization invariants required by the Rustonomicon.
+        unsafe {
+            *SA.get_unchecked_mut(dest) = Idx::from_usize(i);
         }
     }
+
     // 3.  Induce sort: left-to-right for L-type suffixes then right-to-left for S-type suffixes.
     //
     // Do a left-to-right induced-L pass:
     // SA = [11, _, 9, 6, 4, 1, 10, 8, 5, 3, 0, 7]
-    induce_L(sigma, S, SA, T, &mut buckets)?;
+    induce_L(bucket_starts, S, SA, &T, &mut buckets)?;
+
     // And then an induce-S pass:
     // SA = [11, 1, 9, 4, 2, 6, 10, 8, 5, 3, 0, 7]
     // Note how this differs from the expected SA:
     // SA = [11, 1, 9, 2, 4, 6, 10, 0, 8, 3, 5, 7]
-    induce_S(sigma, S, SA, T, &mut buckets)?;
+    induce_S(bucket_limits, S, SA, &T, &mut buckets)?;
+
     // 3.  Construct a subproblem using the LMS suffixes.
     let mut substrings = 0usize;
+
     // First, collect the LMS suffixes in the order they appear in the almost-sorted SA.  After
     // this loop:
     // SA[..substrings] = [11, 1, 9, 4, 6]
     for i in 0..S.len() {
-        if is_lms(T, SA[i]) {
-            SA[substrings] = SA[i];
+        // SAFETY(codex): i ranges over 0..S.len() and SA.len() == S.len(); SA has been filled with
+        // initialized sentinels or offsets, so this immutable read is in-bounds and alias-safe.
+        let pos = unsafe { SA.get_unchecked(i).to_usize() };
+        if T.is_lms(pos) {
+            // SAFETY(codex): the same range proof as above makes SA[i] in-bounds and initialized;
+            // copying the value does not create aliasing or lifetime issues.
+            let value = unsafe { *SA.get_unchecked(i) };
+            // SAFETY(codex): substrings counts LMS entries already observed in an S.len() scan, so
+            // substrings <= i < SA.len(); writing the compacted prefix uses the unique mutable SA
+            // borrow and stores an initialized value.
+            unsafe {
+                *SA.get_unchecked_mut(substrings) = value;
+            }
             substrings += 1;
         }
     }
+
     // Clear the rest of the SA so that we have scratch space.
-    for item in SA.iter_mut().take(S.len()).skip(substrings) {
-        *item = usize::MAX;
+    SA[substrings..].fill(Index::MAX);
+
+    let mut previous_lms = usize::MAX;
+    for i in T.lms_positions() {
+        if previous_lms != usize::MAX {
+            // SAFETY(codex): LMS positions are at least two apart, so previous_lms / 2 indexes the
+            // scratch region reserved at SA[substrings..]; substrings + previous_lms / 2 < SA.len()
+            // by the SA-IS layout invariant, and the write is via the unique mutable SA borrow.
+            unsafe {
+                *SA.get_unchecked_mut(substrings + previous_lms / 2) =
+                    Idx::from_usize(i - previous_lms + 1);
+            }
+        }
+        previous_lms = i;
     }
-    let mut name = 0;
+    if previous_lms != usize::MAX {
+        // SAFETY(codex): previous_lms is a valid LMS position and the same scratch-region layout as
+        // above ensures substrings + previous_lms / 2 is in-bounds; this initialized write has no
+        // competing mutable or shared alias.
+        unsafe {
+            *SA.get_unchecked_mut(substrings + previous_lms / 2) =
+                Idx::from_usize(S.len() - previous_lms);
+        }
+    }
+
     // sentinel used on first pass
+    let mut name = 0usize;
     let mut prev = usize::MAX;
+    let mut prev_len = 0usize;
+
     // Translate the LMS strings into lexicographically-sorted names.  At the start of this loop,
     // SA[i] = j, i < substrings is the index of each LMS symbol in our original text.
     //
@@ -215,32 +544,45 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     //        subproblem -> |-------------------|
     for i in 0..substrings {
         // Position in the original text.
-        let pos: usize = SA[i];
+        // SAFETY(codex): i < substrings and substrings <= SA.len(); this prefix contains collected
+        // LMS positions, all initialized, so the immutable read is in-bounds and alias-safe.
+        let pos: usize = unsafe { SA.get_unchecked(i).to_usize() };
+        // SAFETY(codex): pos is an LMS position and the substring-length table was written at
+        // substrings + pos / 2 using the SA-IS scratch layout; that index is in-bounds and contains
+        // an initialized length.
+        let pos_len = unsafe { SA.get_unchecked(substrings + pos / 2).to_usize() };
         // Does it differ from the previous?
-        let mut diff = false;
-        for d in 0..S.len() {
-            // If it's the first string, or the strings differ by symbol or differ by LSType.
-            if prev == usize::MAX || S[pos + d] != S[prev + d] || T[pos + d] != T[prev + d] {
-                diff = true;
-                break;
-            // One of the strings terminated earlier than the other, but their symbols are the
-            // same.
-            } else if d > 0 && (is_lms(T, pos + d) || is_lms(T, prev + d)) {
-                break;
+        let mut diff = prev == usize::MAX;
+        if !diff {
+            for d in 0..pos_len.min(prev_len) {
+                let pos_d = pos + d;
+                let prev_d = prev + d;
+                // If the strings differ by symbol or differ by LSType.
+                // SAFETY(codex): d is bounded by the precomputed LMS substring lengths, so pos_d
+                // and prev_d remain within S and TypeBits; only immutable initialized reads occur,
+                // which satisfies the Rustonomicon's bounds and aliasing requirements.
+                if unsafe {
+                    S.get_unchecked(pos_d) != S.get_unchecked(prev_d)
+                        || T.is_s(pos_d) != T.is_s(prev_d)
+                } {
+                    diff = true;
+                    break;
+                }
             }
         }
         // Advance the char used to represent the string when the strings differ.
         if diff {
             name += 1;
             prev = pos;
+            prev_len = pos_len;
         }
         // We can safely write to substrings + pos / 2 because we know substrings < SA.len() / 2
         // and we also know that the closest two LMS indices can be placed is 2 (you need an L-type
         // between two S-type characters).
         let pos = pos / 2;
-        SA[substrings + pos] = name - 1
+        SA[substrings + pos] = Idx::from_usize(name - 1);
     }
-    let mut j = S.len() - 1;
+
     // Coalesce the subproblem to one contiguous range at the end of the array.
     //
     // SA = [11, 1, 9, 4, 6, 1, _, 3, 4, 2, 0, _]
@@ -248,33 +590,27 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     //
     //      [11, 1, 9, 4, 6, 1, _, 1, 3, 4, 2, 0]
     //               coalesced -> !-------------|
-    for i in (substrings..S.len()).rev() {
-        if SA[i] != usize::MAX {
-            SA[j] = SA[i];
-            j -= 1;
+    let mut coalesce = S.len();
+    for i in T.lms_positions_rev() {
+        coalesce -= 1;
+        // SAFETY(codex): lms_positions_rev yields valid LMS offsets, so substrings + i / 2 indexes
+        // the initialized subproblem name in the scratch region; coalesce moves within the final
+        // substrings slots at the end of SA. The source read and destination write are in-bounds,
+        // and the unique mutable SA borrow upholds Rustonomicon aliasing rules.
+        unsafe {
+            *SA.get_unchecked_mut(coalesce) = *SA.get_unchecked(substrings + i / 2);
         }
     }
+    debug_assert_eq!(coalesce, S.len() - substrings);
+
     // That coalesced form is our subproblem!  Let's call it S1:
     //
     // S1 = [1, 3, 4, 2, 0]
     let (SA1, S1) = SA.split_at_mut(substrings);
     let (_, S1) = S1.split_at_mut(S1.len() - substrings);
     if name < substrings {
-        if S1.iter().any(|x| *x as u64 > u32::MAX as u64) {
-            return Err(Error::TextTooLong);
-        }
-        // SAFETY(rescrv): We can safetly cast this usize to a u32 because of the above check.
-        let S1: Vec<u32> = S1.iter().map(|x| *x as u32).collect();
-        let mut buf = Vec::new();
-        let mut builder = Builder::new(&mut buf);
-        Sigma::construct(S1[..S1.len() - 1].iter().copied(), &mut builder)?;
-        drop(builder);
-        let sigma1 = Sigma::unpack(&buf)
-            .expect("freshly constructed sigma should unpack")
-            .0;
-        // If the next-to-assign name is less than the number of substrings, we know we have
-        // duplicates that must be sorted relative to each other.
-        sais(&sigma1, &S1, SA1)?;
+        let (bucket_starts1, bucket_limits1) = bucket_starts_and_limits::<_, Bucket>(name, S1)?;
+        sais_impl(&bucket_starts1, &bucket_limits1, S1, SA1)?;
     } else {
         // Else we can trivially fill in the SA1 because we know each name was used exactly once
         // and they were created sequentially.  If S[i] = X, it means the X'th suffix in the suffix
@@ -282,9 +618,10 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
         //
         // SA1 = [4, 0, 3, 1, 2]
         for i in 0..S1.len() {
-            SA1[S1[i]] = i;
+            SA1[S1[i].to_usize()] = Idx::from_usize(i);
         }
     }
+
     // When we created the subproblem we mapped the LMS suffixes into the contiguous range
     // [0, name), name<substrings.  Our solution will be indices into this subproblem in the range
     // [0, substrings), but the original solution must be over the original input text.
@@ -293,20 +630,33 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     //
     // S1 = [1, 4, 6, 9, 11]
     let mut j = 0;
-    for i in 0..S.len() {
-        if is_lms(T, i) {
-            S1[j] = i;
-            j += 1;
+    for i in T.lms_positions() {
+        // SAFETY(codex): T has exactly substrings LMS positions and S1.len() == substrings, so
+        // j is in-bounds for each iteration; S1 is uniquely borrowed as mutable and receives an
+        // initialized Index value.
+        unsafe {
+            *S1.get_unchecked_mut(j) = Idx::from_usize(i);
         }
+        j += 1;
     }
+
     // Translate SA1 using S1 so that it is now over the original text, preserving the relative
     // ordering of the elements.
     //
     // before: [4, 0, 3, 1, 2]
     // after:  [11, 1, 9, 4, 6]
     for i in 0..substrings {
-        SA1[i] = S1[SA1[i]];
+        // SAFETY(codex): i < SA1.len(), and recursive SA1 values are valid indices into S1; both
+        // slices are initialized and the immutable reads obey Rustonomicon bounds and aliasing
+        // rules.
+        let value = unsafe { *S1.get_unchecked(SA1.get_unchecked(i).to_usize()) };
+        // SAFETY(codex): i < SA1.len() and SA1 is uniquely borrowed mutably, so writing the
+        // translated initialized value is in-bounds with no aliasing violation.
+        unsafe {
+            *SA1.get_unchecked_mut(i) = value;
+        }
     }
+
     // Here we pulled a dirty trick with references.  SA1 above was partitioned off as the prefix
     // of SA[..substrings].  From this point forward we don't refer to SA1 and assume it magics its
     // way to the prefix of SA.
@@ -314,9 +664,9 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     // We used other parts of SA, too, so wipe those parts and make them empty:
     //
     // SA = [11, 1, 9, 4, 6, _, _, _, _, _, _, _]
-    for item in SA.iter_mut().take(S.len()).skip(substrings) {
-        *item = usize::MAX;
-    }
+    SA[substrings..].fill(Index::MAX);
+    buckets.copy_from_slice(bucket_limits);
+
     // Place the LMS strings into SA in reverse order.  We do this in reverse because the
     // subsolution (and thus the number of substrings to place) is guaranteed to be at most half of
     // the input S (you can't have a left-most S without an S and the L to its immediate right).
@@ -330,22 +680,108 @@ pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
     //
     // TODO(rescrv):  I do not like this example text because the SA comes out clumped.  Ideally I
     // want something with a pattern closer to [X, _, X, _, _, X, _, _].
-    sigma.bucket_limits(&mut buckets)?;
     for i in (0..substrings).rev() {
-        j = SA[i];
-        SA[i] = usize::MAX;
-        buckets[S[j] as usize] -= 1;
-        SA[buckets[S[j] as usize]] = j;
+        // SAFETY(codex): i < substrings <= SA.len() and the prefix contains initialized LMS
+        // positions after translating SA1, so this immutable read is in-bounds and alias-safe.
+        j = unsafe { SA.get_unchecked(i).to_usize() };
+        // SAFETY(codex): i is in-bounds and SA is uniquely borrowed mutably; replacing this prefix
+        // slot with the initialized sentinel preserves Rustonomicon aliasing and initialization
+        // rules.
+        unsafe {
+            *SA.get_unchecked_mut(i) = Index::MAX;
+        }
+        // SAFETY(codex): j is an LMS offset from the original text, hence j < S.len(); S is an
+        // immutable initialized slice and this read is in-bounds.
+        let symbol = unsafe { S.get_unchecked(j).to_usize() };
+        // SAFETY(codex): the symbol domain was validated, and reverse LMS placement decrements
+        // bucket cursors within valid suffix-array bucket ranges; the single mutable bucket borrow
+        // satisfies Rustonomicon exclusivity requirements.
+        let dest = unsafe {
+            let bucket = buckets.get_unchecked_mut(symbol);
+            let dest = bucket.to_usize() - 1;
+            *bucket = Bucket::from_usize(dest);
+            dest
+        };
+        // SAFETY(codex): dest is a valid bucket position in SA by the bucket cursor invariant; this
+        // initialized write uses the unique mutable SA borrow and therefore respects aliasing rules.
+        unsafe {
+            *SA.get_unchecked_mut(dest) = Idx::from_usize(j);
+        }
     }
+
     // Now that we know the LMS characters are correct, the induced sort will be correct as well.
     //
     // Here's what it looks like after the L-type pass:
     // SA = [11, _, 1, 9, 4, 6, 10, 0, 8, 3, 5, 7]
-    induce_L(sigma, S, SA, T, &mut buckets)?;
+    induce_L(bucket_starts, S, SA, &T, &mut buckets)?;
     // Here's what it looks like after the S-type pass:
     // SA = [11, 1, 9, 2, 4, 6, 10, 0, 8, 3, 5, 7]
-    induce_S(sigma, S, SA, T, &mut buckets)?;
+    induce_S(bucket_limits, S, SA, &T, &mut buckets)?;
     Ok(())
+}
+
+/// sais is the Suffix-Array Induced-Sort.  This algorithm uses induced-sort (similar technique is
+/// used in radix sort) to produce a suffix array in time linear in the length of the input.
+///
+/// # Panics:
+/// - K > S.len()
+/// - S.len() != SA.len()
+/// - S.len() == 0
+/// - S is not termintated by a zero
+pub fn sais(sigma: &Sigma, S: &[u32], SA: &mut [usize]) -> Result<(), Error> {
+    // We need some space for sentinels in the lang.
+    assert!(sigma.K() <= S.len());
+    // The input and "output" must be aligned.
+    assert!(S.len() == SA.len());
+    // The last character should be zero, which also requires there to be a last character.
+    assert!(!S.is_empty());
+    assert_eq!(S[S.len() - 1], 0);
+
+    let mut bucket_starts = vec![0usize; sigma.K()];
+    sigma.bucket_starts(&mut bucket_starts)?;
+    let mut bucket_limits = vec![0usize; sigma.K()];
+    sigma.bucket_limits(&mut bucket_limits)?;
+    sais_impl(&bucket_starts, &bucket_limits, S, SA)
+}
+
+fn sais_u32_index<Sym: Symbol>(sigma: &Sigma, S: &[Sym], SA: &mut [u32]) -> Result<(), Error> {
+    assert!(S.len() < u32::MAX as usize);
+    // We need some space for sentinels in the lang.
+    assert!(sigma.K() <= S.len());
+    // The input and "output" must be aligned.
+    assert!(S.len() == SA.len());
+    // The last character should be zero, which also requires there to be a last character.
+    assert!(!S.is_empty());
+    assert_eq!(S[S.len() - 1].to_usize(), 0);
+
+    let mut bucket_starts_usize = vec![0usize; sigma.K()];
+    sigma.bucket_starts(&mut bucket_starts_usize)?;
+    let bucket_starts: Vec<u32> = bucket_starts_usize
+        .into_iter()
+        .map(u32::try_from)
+        .collect::<Result<_, _>>()?;
+    let mut bucket_limits_usize = vec![0usize; sigma.K()];
+    sigma.bucket_limits(&mut bucket_limits_usize)?;
+    let bucket_limits: Vec<u32> = bucket_limits_usize
+        .into_iter()
+        .map(u32::try_from)
+        .collect::<Result<_, _>>()?;
+    sais_impl(&bucket_starts, &bucket_limits, S, SA)
+}
+
+/// sais_u8_u32 constructs a suffix array using u32 offsets and u8 symbols.
+pub fn sais_u8_u32(sigma: &Sigma, S: &[u8], SA: &mut [u32]) -> Result<(), Error> {
+    sais_u32_index(sigma, S, SA)
+}
+
+/// sais_u16_u32 constructs a suffix array using u32 offsets and u16 symbols.
+pub fn sais_u16_u32(sigma: &Sigma, S: &[u16], SA: &mut [u32]) -> Result<(), Error> {
+    sais_u32_index(sigma, S, SA)
+}
+
+/// sais_u32 constructs a suffix array using u32 offsets for inputs shorter than u32::MAX.
+pub fn sais_u32(sigma: &Sigma, S: &[u32], SA: &mut [u32]) -> Result<(), Error> {
+    sais_u32_index(sigma, S, SA)
 }
 
 /////////////////////////////////////////////// tests //////////////////////////////////////////////
@@ -358,6 +794,87 @@ mod tests {
     use super::super::test_util::TestCase;
 
     use super::*;
+
+    fn sigma_for_text(text: &[u32]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut builder = crate::builder::Builder::new(&mut buf);
+        Sigma::construct(text.iter().copied(), &mut builder).expect("sigma should construct");
+        drop(builder);
+        buf
+    }
+
+    fn naive_suffix_array<Sym: Ord>(S: &[Sym]) -> Vec<usize> {
+        let mut SA: Vec<usize> = (0..S.len()).collect();
+        SA.sort_by(|&lhs, &rhs| S[lhs..].cmp(&S[rhs..]));
+        SA
+    }
+
+    fn check_sais_u8_u32(t: &TestCase) {
+        let sigma = t.sigma();
+        let sigma = Sigma::unpack(&sigma).expect("test should unpack").0;
+        let S: Vec<u8> = t.S.iter().map(|x| u8::try_from(*x).unwrap()).collect();
+        let mut SA = vec![0u32; t.S.len()];
+        sais_u8_u32(&sigma, &S, &mut SA).unwrap();
+        let expected: Vec<u32> = t.SA.iter().map(|x| *x as u32).collect();
+        assert_eq!(expected, SA);
+    }
+
+    test_cases_for!(sais_u8_u32, super::check_sais_u8_u32);
+
+    fn check_sais_u16_u32(t: &TestCase) {
+        let sigma = t.sigma();
+        let sigma = Sigma::unpack(&sigma).expect("test should unpack").0;
+        let S: Vec<u16> = t.S.iter().map(|x| u16::try_from(*x).unwrap()).collect();
+        let mut SA = vec![0u32; t.S.len()];
+        sais_u16_u32(&sigma, &S, &mut SA).unwrap();
+        let expected: Vec<u32> = t.SA.iter().map(|x| *x as u32).collect();
+        assert_eq!(expected, SA);
+    }
+
+    test_cases_for!(sais_u16_u32, super::check_sais_u16_u32);
+
+    fn check_sais_u32(t: &TestCase) {
+        let sigma = t.sigma();
+        let sigma = Sigma::unpack(&sigma).expect("test should unpack").0;
+        let mut SA = vec![0u32; t.S.len()];
+        sais_u32(&sigma, t.S, &mut SA).unwrap();
+        let expected: Vec<u32> = t.SA.iter().map(|x| *x as u32).collect();
+        assert_eq!(expected, SA);
+    }
+
+    test_cases_for!(sais_u32, super::check_sais_u32);
+
+    #[test]
+    fn invalid_symbol_rejected() {
+        let sigma = sigma_for_text(&[1, 2]);
+        let sigma = Sigma::unpack(&sigma).expect("test should unpack").0;
+        let mut SA = vec![0usize; 3];
+        assert_eq!(Err(Error::InvalidSigma), sais(&sigma, &[1, 3, 0], &mut SA));
+        let mut SA = vec![0u32; 3];
+        assert_eq!(
+            Err(Error::InvalidSigma),
+            sais_u8_u32(&sigma, &[1, 3, 0], &mut SA)
+        );
+    }
+
+    #[test]
+    fn u16_symbols_above_u8() {
+        let text: Vec<u32> = (0..600).map(|idx| idx * 37 % 300 + 1).collect();
+        let sigma = sigma_for_text(&text);
+        let sigma = Sigma::unpack(&sigma).expect("test should unpack").0;
+        let mut S: Vec<u16> = text
+            .iter()
+            .map(|t| sigma.char_to_sigma(*t).unwrap() as u16)
+            .collect();
+        S.push(0);
+        let mut SA = vec![0u32; S.len()];
+        sais_u16_u32(&sigma, &S, &mut SA).unwrap();
+        let expected: Vec<u32> = naive_suffix_array(&S)
+            .into_iter()
+            .map(|x| x as u32)
+            .collect();
+        assert_eq!(expected, SA);
+    }
 
     fn check_get_types(t: &TestCase) {
         let types: Vec<LSType> = t

--- a/scrunch/src/sais.rs
+++ b/scrunch/src/sais.rs
@@ -262,7 +262,7 @@ fn induce_L<Sym: Symbol, Idx: Index, Bucket: Index>(
     S: &[Sym],
     SA: &mut [Idx],
     T: &TypeBits,
-    buckets: &mut Vec<Bucket>,
+    buckets: &mut [Bucket],
 ) -> Result<(), Error> {
     buckets.copy_from_slice(bucket_starts);
     for i in 0..S.len() {
@@ -299,7 +299,7 @@ fn induce_S<Sym: Symbol, Idx: Index, Bucket: Index>(
     S: &[Sym],
     SA: &mut [Idx],
     T: &TypeBits,
-    buckets: &mut Vec<Bucket>,
+    buckets: &mut [Bucket],
 ) -> Result<(), Error> {
     buckets.copy_from_slice(bucket_limits);
     for i in (0..S.len()).rev() {

--- a/scrunch/src/sampled.rs
+++ b/scrunch/src/sampled.rs
@@ -52,6 +52,29 @@ impl SampledArray<'_> {
         Ok(())
     }
 
+    pub fn construct_u32<H: Helper>(
+        values: &[(usize, u32)],
+        builder: &mut Builder<H>,
+    ) -> Result<(), Error> {
+        let bits = bits_required(values.iter().map(|(_, x)| *x as u64).max().unwrap_or(1));
+        let mut sparse = Vec::with_capacity(values.len());
+        let mut bitwords = BitArrayBuilder::with_capacity(values.len());
+        for (offset, value) in values.iter() {
+            sparse.push(*offset);
+            bitwords.push_word(*value as u64, bits as usize);
+        }
+        builder.append_u32(FieldNumber::must(1), bits as u32);
+        BitVector::from_indices(
+            128,
+            values[values.len() - 1].0 + 1,
+            &sparse,
+            &mut builder.sub(FieldNumber::must(3)),
+        );
+        let bitwords = bitwords.seal();
+        builder.append_bytes(FieldNumber::must(2), &bitwords);
+        Ok(())
+    }
+
     pub fn parse<'b, 'c: 'b>(buf: &'c [u8]) -> Result<(SampledArray<'b>, &'c [u8]), Error> {
         let (
             SampledArrayStub {

--- a/scrunch/src/sigma.rs
+++ b/scrunch/src/sigma.rs
@@ -25,6 +25,7 @@ struct SigmaStub<'a> {
 
 pub struct Sigma<'a> {
     char_to_sigma: HashMap<u32, usize>,
+    char_to_sigma_dense: Option<Vec<u32>>,
     sigma_to_char: Vec<u32>,
     columns: BitVector<'a>,
 }
@@ -34,23 +35,44 @@ impl Sigma<'_> {
         iter: I,
         builder: &mut Builder<H>,
     ) -> Result<(), Error> {
+        const DENSE_COUNT_LIMIT: usize = 1 << 20;
+
         // count each character
-        let mut counts: HashMap<u32, usize> = HashMap::new();
+        let mut dense_counts = vec![0usize; 256];
+        let mut sparse_counts: HashMap<u32, usize> = HashMap::new();
         for t in iter.into_iter() {
-            *counts.entry(t).or_insert(0) += 1;
+            let idx = t as usize;
+            if idx <= DENSE_COUNT_LIMIT {
+                if idx >= dense_counts.len() {
+                    dense_counts.resize(
+                        std::cmp::min((idx + 1).next_power_of_two(), DENSE_COUNT_LIMIT + 1),
+                        0,
+                    );
+                }
+                dense_counts[idx] += 1;
+            } else {
+                *sparse_counts.entry(t).or_insert(0) += 1;
+            }
         }
         // create an array of characters in ascending order
-        let mut sigma_to_char: Vec<u32> = Vec::with_capacity(counts.len());
-        for (t, _) in counts.iter() {
-            sigma_to_char.push(*t);
+        let mut sigma_counts: Vec<(u32, usize)> =
+            Vec::with_capacity(dense_counts.len() + sparse_counts.len());
+        for (t, count) in dense_counts.into_iter().enumerate() {
+            if count > 0 {
+                sigma_counts.push((t as u32, count));
+            }
         }
-        sigma_to_char.sort();
+        for (t, count) in sparse_counts.into_iter() {
+            sigma_counts.push((t, count));
+        }
+        sigma_counts.sort_by_key(|(t, _)| *t);
+        let sigma_to_char: Vec<u32> = sigma_counts.iter().map(|(t, _)| *t).collect();
         // use the counts and the ascending order to create buckets
         let mut buckets: Vec<usize> = Vec::with_capacity(sigma_to_char.len() + 1);
         buckets.push(0);
         let mut total = 0;
-        for t in sigma_to_char.iter() {
-            total += counts.get(t).ok_or(Error::LogicError("count not found"))?;
+        for (_, count) in sigma_counts.iter() {
+            total += count;
             buckets.push(total);
         }
         // sanity checks on the way out the door.
@@ -73,8 +95,17 @@ impl Sigma<'_> {
 
     /// char_to_sigma takes a character from its original domain to the range [0, K).
     pub fn char_to_sigma(&self, t: u32) -> Option<u32> {
+        if let Some(dense) = &self.char_to_sigma_dense
+            && let Some(sigma) = dense.get(t as usize).copied()
+        {
+            return if sigma == 0 { None } else { Some(sigma) };
+        }
         // SAFETY(rescrv): Sigma should never have more than u32::MAX symbols.
         self.char_to_sigma.get(&t).copied().map(|x| x as u32)
+    }
+
+    pub(crate) fn dense_char_to_sigma_table(&self) -> Option<&[u32]> {
+        self.char_to_sigma_dense.as_deref()
     }
 
     /// sigma_to_char takes a character from the range [1, K] to its original domain.
@@ -152,6 +183,7 @@ impl std::fmt::Debug for Sigma<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("Sigma")
             .field("char_to_sigma", &self.char_to_sigma)
+            .field("char_to_sigma_dense", &self.char_to_sigma_dense)
             .field("sigma_to_char", &self.sigma_to_char)
             .field("columns", &self.columns)
             .finish()
@@ -169,15 +201,34 @@ impl<'a> Unpackable<'a> for Sigma<'a> {
         for (idx, t) in sigma_to_char.iter().enumerate() {
             char_to_sigma.insert(*t, idx + 1);
         }
+        let char_to_sigma_dense = dense_char_to_sigma(&sigma_to_char)?;
         Ok((
             Self {
                 sigma_to_char,
                 char_to_sigma,
+                char_to_sigma_dense,
                 columns,
             },
             buf,
         ))
     }
+}
+
+fn dense_char_to_sigma(sigma_to_char: &[u32]) -> Result<Option<Vec<u32>>, Error> {
+    const DENSE_LOOKUP_LIMIT: usize = 1 << 20;
+
+    let Some(max) = sigma_to_char.iter().copied().max() else {
+        return Ok(None);
+    };
+    let max = max as usize;
+    if max > DENSE_LOOKUP_LIMIT {
+        return Ok(None);
+    }
+    let mut dense = vec![0u32; max + 1];
+    for (idx, t) in sigma_to_char.iter().copied().enumerate() {
+        dense[t as usize] = u32::try_from(idx + 1)?;
+    }
+    Ok(Some(dense))
 }
 
 /////////////////////////////////////////////// tests //////////////////////////////////////////////

--- a/scrunch/src/wavelet_tree/mod.rs
+++ b/scrunch/src/wavelet_tree/mod.rs
@@ -24,6 +24,32 @@ pub trait WaveletTree {
     fn rank_q(&self, q: u32, x: usize) -> Option<usize>;
     /// Computes `select_q[x]`, the offset of the x'th symbol q.
     fn select_q(&self, q: u32, x: usize) -> Option<usize>;
+
+    /// Populate `ranges` with each symbol in `[lower, upper)` and its rank interval for that
+    /// symbol.  The rank interval is half-open.
+    fn symbol_rank_ranges(
+        &self,
+        lower: usize,
+        upper: usize,
+        ranges: &mut Vec<(u32, (usize, usize))>,
+    ) -> Option<()> {
+        if lower > upper || upper > self.len() {
+            return None;
+        }
+        ranges.clear();
+        for idx in lower..upper {
+            let symbol = self.access(idx)?;
+            if ranges.iter().any(|(candidate, _)| *candidate == symbol) {
+                continue;
+            }
+            let lower_rank = self.rank_q(symbol, lower)?;
+            let upper_rank = self.rank_q(symbol, upper)?;
+            if lower_rank < upper_rank {
+                ranges.push((symbol, (lower_rank, upper_rank)));
+            }
+        }
+        Some(())
+    }
 }
 
 ///////////////////////////////////// ReferenceWaveletTreeStub /////////////////////////////////////

--- a/scrunch/src/wavelet_tree/prefix.rs
+++ b/scrunch/src/wavelet_tree/prefix.rs
@@ -67,14 +67,6 @@ struct Node {
     right: u64,
 }
 
-fn all_sized(mut iter: impl Iterator<Item = (u32, u8)>) -> bool {
-    iter.all(|s| s.1 > 0)
-}
-
-fn all_zero(mut iter: impl Iterator<Item = (u32, u8)>) -> bool {
-    iter.all(|s| s.1 == 0)
-}
-
 //////////////////////////////////////////// WaveletTree ///////////////////////////////////////////
 
 pub struct WaveletTree<'a, E: Encoder> {
@@ -153,50 +145,78 @@ impl<'a, E: Encoder> WaveletTree<'a, E> {
         Some(self.nodes.len() as u64)
     }
 
-    fn construct_from_iter<H: Helper>(
-        builder: &mut Builder<H>,
-        intermediate: &mut Vec<(u32, u8)>,
-        iter: impl Iterator<Item = (u32, u8)> + Clone,
-    ) -> Result<u64, Error> {
-        if iter.clone().next().is_some() && all_sized(iter.clone()) {
-            intermediate.clear();
-            for x in iter {
-                intermediate.push(x);
-            }
-            Self::construct_recursive(builder, intermediate)
-        } else if all_zero(iter) {
-            Ok(0)
-        } else {
-            Err(Error::LogicError(
-                "wavelet tree should be all zero or all sized",
-            ))
-        }
-    }
-
     fn construct_recursive<H: Helper>(
         builder: &mut Builder<H>,
-        symbols: &[(u32, u8)],
+        symbols: &mut [(u32, u8)],
+        scratch: &mut [(u32, u8)],
     ) -> Result<u64, Error> {
-        let (left, right) = if !all_zero(symbols.iter().copied()) {
-            let lhs_iter = symbols
-                .iter()
-                .filter(|s| s.0 & 1 == 0)
-                .map(|s| (s.0 >> 1, s.1 - 1));
-            let rhs_iter = symbols
-                .iter()
-                .filter(|s| s.0 & 1 == 1)
-                .map(|s| (s.0 >> 1, s.1 - 1));
-            let mut intermediate = Vec::with_capacity(symbols.len());
-            let left = Self::construct_from_iter(builder, &mut intermediate, lhs_iter)?;
-            let right = Self::construct_from_iter(builder, &mut intermediate, rhs_iter)?;
-            (left, right)
+        let mut left_count = 0usize;
+        let mut right_count = 0usize;
+        let mut left_done = false;
+        let mut right_done = false;
+        for &(code, len) in symbols.iter() {
+            if len == 0 {
+                return Err(Error::LogicError(
+                    "wavelet tree should be all zero or all sized",
+                ));
+            }
+            let is_right = code & 1 == 1;
+            if is_right {
+                if len == 1 {
+                    right_done = true;
+                } else {
+                    right_count += 1;
+                }
+            } else if len == 1 {
+                left_done = true;
+            } else {
+                left_count += 1;
+            }
+        }
+        if (left_done && left_count > 0) || (right_done && right_count > 0) {
+            return Err(Error::LogicError(
+                "wavelet tree should be all zero or all sized",
+            ));
+        }
+        let words = BitVector::words_from_iter(
+            symbols.len(),
+            symbols.iter().map(|(code, _)| code & 1 == 1),
+        );
+        let mut left_idx = 0usize;
+        let mut right_idx = left_count;
+        for &(code, len) in symbols.iter() {
+            if len > 1 {
+                let next = (code >> 1, len - 1);
+                if code & 1 == 0 {
+                    scratch[left_idx] = next;
+                    left_idx += 1;
+                } else {
+                    scratch[right_idx] = next;
+                    right_idx += 1;
+                }
+            }
+        }
+        let left = if left_count > 0 {
+            Self::construct_recursive(
+                builder,
+                &mut scratch[..left_count],
+                &mut symbols[..left_count],
+            )?
         } else {
-            (0, 0)
+            0
         };
-        let this: Vec<bool> = symbols.iter().map(|s| s.0 & 1 == 1).collect();
+        let right = if right_count > 0 {
+            Self::construct_recursive(
+                builder,
+                &mut scratch[left_count..left_count + right_count],
+                &mut symbols[left_count..left_count + right_count],
+            )?
+        } else {
+            0
+        };
         let length: u64 = symbols.len() as u64;
         let start: u64 = builder.relative_len() as u64;
-        BitVector::construct(&this, builder)?;
+        BitVector::construct_from_words(symbols.len(), words, builder)?;
         let limit: u64 = builder.relative_len() as u64;
         let node = Node {
             length,
@@ -214,12 +234,12 @@ impl<'a, E: Encoder> WaveletTree<'a, E> {
             self.encoder.decode(e, sz)
         } else {
             let (node, bv) = self.load_node_and_bit_vector(node_offset)?;
-            let bit = bv.access(x)?;
+            let (bit, rank) = bv.access_rank(x)?;
             let (x, node_offset) = if bit {
                 e |= 1 << sz;
-                (bv.rank(x)?, node.right)
+                (rank, node.right)
             } else {
-                (bv.rank0(x)?, node.left)
+                (x - rank, node.left)
             };
             sz += 1;
             self.recursive_access(e, sz, node_offset, x)
@@ -276,6 +296,51 @@ impl<'a, E: Encoder> WaveletTree<'a, E> {
             bv.select0(x)
         }
     }
+
+    fn recursive_symbol_rank_ranges(
+        &self,
+        e: u32,
+        sz: u8,
+        node_offset: u64,
+        lower: usize,
+        upper: usize,
+        ranges: &mut Vec<(u32, (usize, usize))>,
+    ) -> Option<()> {
+        if lower == upper {
+            return Some(());
+        }
+        if node_offset == 0 {
+            let symbol = self.encoder.decode(e, sz)?;
+            ranges.push((symbol, (lower, upper)));
+            return Some(());
+        }
+        let (node, bv) = self.load_node_and_bit_vector(node_offset)?;
+        let lower_ones = bv.rank(lower)?;
+        let upper_ones = bv.rank(upper)?;
+        let lower_zeros = lower - lower_ones;
+        let upper_zeros = upper - upper_ones;
+        if lower_zeros < upper_zeros {
+            self.recursive_symbol_rank_ranges(
+                e,
+                sz + 1,
+                node.left,
+                lower_zeros,
+                upper_zeros,
+                ranges,
+            )?;
+        }
+        if lower_ones < upper_ones {
+            self.recursive_symbol_rank_ranges(
+                e | (1 << sz),
+                sz + 1,
+                node.right,
+                lower_ones,
+                upper_ones,
+                ranges,
+            )?;
+        }
+        Some(())
+    }
 }
 
 impl<E: Encoder + Packable> WaveletTreeTrait for WaveletTree<'_, E> {
@@ -294,7 +359,8 @@ impl<E: Encoder + Packable> WaveletTreeTrait for WaveletTree<'_, E> {
         let length = encoded.len() as u64;
         drop(enc);
         // Recursively construct the tree.
-        let tree = Self::construct_recursive(&mut builder, &encoded)?;
+        let mut scratch = vec![(0u32, 0u8); encoded.len()];
+        let tree = Self::construct_recursive(&mut builder, &mut encoded, &mut scratch)?;
         // Append the root node.
         let root = Root {
             encoder_start,
@@ -328,6 +394,19 @@ impl<E: Encoder + Packable> WaveletTreeTrait for WaveletTree<'_, E> {
         let (node, bv) = self.load_node_and_bit_vector(self.root.tree)?;
         let (e, sz) = self.encoder.encode(q)?;
         self.recursive_select(e, sz, node, bv, x)
+    }
+
+    fn symbol_rank_ranges(
+        &self,
+        lower: usize,
+        upper: usize,
+        ranges: &mut Vec<(u32, (usize, usize))>,
+    ) -> Option<()> {
+        if lower > upper || upper > self.len() {
+            return None;
+        }
+        ranges.clear();
+        self.recursive_symbol_rank_ranges(0, 0, self.root.tree, lower, upper, ranges)
     }
 }
 


### PR DESCRIPTION
Dramatically improve scrunch performance across construction,
memory usage, and query time:
- Construction time: 222s -> 74s (3x faster)
- Memory usage: 20x+ -> 12x of input size
- Top-100 query on 1GiB of Gutenberg: 108ms -> 6.8ms (15x faster)

Key changes include optimized suffix array construction (SAIS),
more efficient wavelet tree PSI encoding, improved bit vector
operations (RRR), and streamlined encoder paths.  New benchmarks
added for SAIS, wavelet PSI, and exemplar extraction.

Co-authored-by: AI
