### PR TITLE
perf(scrunch): optimize bit vector select, encode/decode, and sparse construction

### DIFF
--- a/scrunch/benches/rrr_bit_vector.rs
+++ b/scrunch/benches/rrr_bit_vector.rs
@@ -88,7 +88,7 @@ fn bench_bit_vector_access(params: &RrrBitVectorParameters, b: &mut Bencher) {
     let accesses = Cycle::new(accesses).take(b.size());
     fn access(bv: &BitVector, accesses: impl Iterator<Item = usize>) {
         for access in accesses {
-            black_box(bv).access(black_box(access));
+            black_box(black_box(bv).access(black_box(access)));
         }
     }
     b.run(|| {
@@ -103,6 +103,40 @@ benchmark! {
         probability in BIT_PROBABILITY,
     }
     bench_bit_vector_access
+}
+
+//////////////////////////////////////////// access_rank ///////////////////////////////////////////
+
+fn bench_bit_vector_access_rank(params: &RrrBitVectorParameters, b: &mut Bencher) {
+    let mut guac = Guacamole::new(b.seed());
+    let mut buf = vec![];
+    let mut builder = Builder::new(&mut buf);
+    let vector = generate_bit_vector(params, &mut guac);
+    BitVector::construct(&vector, &mut builder).unwrap();
+    drop(builder);
+    let vector = BitVector::parse(&buf).unwrap().0;
+    let mut accesses = Vec::with_capacity(b.size());
+    for _ in 0..4096 {
+        accesses.push(range_to(vector.len())(&mut guac));
+    }
+    let accesses = Cycle::new(accesses).take(b.size());
+    fn access_rank(bv: &BitVector, accesses: impl Iterator<Item = usize>) {
+        for access in accesses {
+            black_box(black_box(bv).access_rank(black_box(access)));
+        }
+    }
+    b.run(|| {
+        access_rank(&vector, accesses);
+    });
+}
+
+benchmark! {
+    name = rrr_bit_vector_access_rank;
+    RrrBitVectorParameters {
+        vector_length in VECTOR_LENGTH,
+        probability in BIT_PROBABILITY,
+    }
+    bench_bit_vector_access_rank
 }
 
 /////////////////////////////////////////////// rank ///////////////////////////////////////////////
@@ -122,7 +156,7 @@ fn bench_bit_vector_rank(params: &RrrBitVectorParameters, b: &mut Bencher) {
     let ranks = Cycle::new(ranks).take(b.size());
     fn rank(bv: &BitVector, ranks: impl Iterator<Item = usize>) {
         for rank in ranks {
-            black_box(bv).rank(black_box(rank));
+            black_box(black_box(bv).rank(black_box(rank)));
         }
     }
     b.run(|| {
@@ -157,7 +191,7 @@ fn bench_bit_vector_select(params: &RrrBitVectorParameters, b: &mut Bencher) {
     let selects = Cycle::new(selects).take(b.size());
     fn select(bv: &BitVector, selects: impl Iterator<Item = usize>) {
         for select in selects {
-            black_box(bv).select(black_box(select));
+            black_box(black_box(bv).select(black_box(select)));
         }
     }
     b.run(|| {
@@ -179,6 +213,7 @@ benchmark! {
 statslicer_main! {
     rrr_bit_vector_new,
     rrr_bit_vector_access,
+    rrr_bit_vector_access_rank,
     rrr_bit_vector_rank,
     rrr_bit_vector_select,
 }

--- a/scrunch/src/bit_vector/rrr.rs
+++ b/scrunch/src/bit_vector/rrr.rs
@@ -15,6 +15,8 @@ use super::BitVector as BitVectorTrait;
 pub struct u63(pub(super) u64);
 
 impl u63 {
+    const MASK: u64 = (1u64 << 63) - 1;
+
     const fn must(x: u64) -> Self {
         match Self::new(x) {
             Some(x) => x,
@@ -31,24 +33,43 @@ impl u63 {
         Some(Self(x))
     }
 
-    fn select<F: FnMut(bool) -> bool>(&self, x: usize, mut f: F) -> Option<usize> {
-        let mut idx = 0;
-        let mut rank = 0;
-        let mut w = self.0;
-        while idx < 63 && rank < x {
-            rank += if f((w & 1) == 1) { 1 } else { 0 };
-            w >>= 1;
-            idx += 1;
+    fn select_word(mut word: u64, mut x: usize) -> Option<usize> {
+        if x == 0 {
+            return Some(0);
         }
-        if rank < x { None } else { Some(idx) }
+        if (word.count_ones() as usize) < x {
+            return None;
+        }
+        let mut idx = 0;
+        let lo = word & ((1u64 << 32) - 1);
+        let count = lo.count_ones() as usize;
+        if x > count {
+            x -= count;
+            idx += 32;
+            word >>= 32;
+        } else {
+            word = lo;
+        }
+        for shift in [16, 8, 4, 2, 1] {
+            let lo = word & ((1u64 << shift) - 1);
+            let count = lo.count_ones() as usize;
+            if x > count {
+                x -= count;
+                idx += shift;
+                word >>= shift;
+            } else {
+                word = lo;
+            }
+        }
+        Some(idx + 1)
     }
 
     pub(super) fn select1(&self, x: usize) -> Option<usize> {
-        self.select(x, |b| b)
+        Self::select_word(self.0, x)
     }
 
     pub(super) fn select0(&self, x: usize) -> Option<usize> {
-        self.select(x, |b| !b)
+        Self::select_word(!self.0 & Self::MASK, x)
     }
 }
 
@@ -1702,6 +1723,9 @@ pub(super) const K: &[&[u64]] = &[
 
 pub(super) fn encode(decoded: u63) -> (u64, usize) {
     let c: usize = decoded.0.count_ones() as usize;
+    if c == 0 || c == 63 {
+        return (0, c);
+    }
     let mut o = 0u64;
     let mut bits_remain = c;
     for bit in 0..63 {
@@ -1716,6 +1740,12 @@ pub(super) fn encode(decoded: u63) -> (u64, usize) {
 }
 
 pub(super) fn decode(mut o: u64, mut c: usize) -> Option<u63> {
+    if c == 0 {
+        return Some(u63(0));
+    }
+    if c == 63 {
+        return Some(u63(u63::MASK));
+    }
     let mut word = 0u64;
     o += c as u64;
     for bit in 0..63 {
@@ -1820,6 +1850,31 @@ impl BitVector<'_> {
     fn load_o(&self, c: usize, o_offset: usize, o_bits: usize) -> Option<u63> {
         let o: u64 = self.o.load(o_offset, o_bits)?;
         decode(o, c)
+    }
+
+    fn access_rank_at(&self, mut index: usize) -> Option<(bool, usize)> {
+        if index >= self.len() {
+            return None;
+        }
+        let width = Self::calc_p_r_width(self.bits)?;
+        let stride: usize = self.word as usize * 63;
+        let p_offset = index / stride;
+        let mut o_offset: usize = self.p.load(p_offset * width, width)?.try_into().ok()?;
+        let mut c_offset: usize = p_offset * 6 * self.word as usize;
+        let mut rank: usize = self.r.load(p_offset * width, width)?.try_into().ok()?;
+        index -= p_offset * stride;
+        while index >= 63 {
+            let (c, o_bits) = self.load_c_o_bits(c_offset)?;
+            index -= 63;
+            c_offset += 6;
+            o_offset += o_bits;
+            rank += c;
+        }
+        let (c, o_bits) = self.load_c_o_bits(c_offset)?;
+        let w = self.load_o(c, o_offset, o_bits)?;
+        rank += (w.0 & ((1u64 << index) - 1)).count_ones() as usize;
+        let access = w.0 & (1 << index) != 0;
+        Some((access, rank))
     }
 
     fn select_helper(
@@ -1948,36 +2003,7 @@ impl super::BitVector for BitVector<'_> {
     }
 
     fn access_rank(&self, x: usize) -> Option<(bool, usize)> {
-        if x >= self.len() {
-            return None;
-        }
-        // Width of values in P, R.
-        let width = Self::calc_p_r_width(self.bits)?;
-        // P strides by self.word * 63 bits at a time.
-        let stride: usize = self.word as usize * 63;
-        // The offset into P.
-        let p_offset = x / stride;
-        // The offset into O.
-        let mut o_offset: usize = self.p.load(p_offset * width, width)?.try_into().ok()?;
-        // The offset into C.
-        let mut c_offset: usize = p_offset * 6 * self.word as usize;
-        // Our base rank is the number of ones before our p_offset.
-        let mut rank: usize = self.r.load(p_offset * width, width)?.try_into().ok()?;
-        // Adjust index to account for our jump through P.
-        let mut index = x - p_offset * stride;
-        // Step through the words until we have fewer than 63 bits left.
-        while index >= 63 {
-            let (c, o_bits) = self.load_c_o_bits(c_offset)?;
-            index -= 63;
-            c_offset += 6;
-            o_offset += o_bits;
-            rank += c;
-        }
-        let (c, o_bits) = self.load_c_o_bits(c_offset)?;
-        let w = self.load_o(c, o_offset, o_bits)?;
-        let mask = if index == 0 { 0 } else { (1u64 << index) - 1 };
-        rank += (w.0 & mask).count_ones() as usize;
-        Some((w.0 & (1 << index) != 0, rank))
+        self.access_rank_at(x)
     }
 
     fn access(&self, mut index: usize) -> Option<bool> {
@@ -2028,11 +2054,11 @@ impl super::BitVector for BitVector<'_> {
         // The offset into P.
         let p_offset = index / stride;
         // The offset into O.
-        let mut o_offset: usize = self.p.load(p_offset * width, width)? as usize;
+        let mut o_offset: usize = self.p.load(p_offset * width, width)?.try_into().ok()?;
         // The offset into C
         let mut c_offset: usize = p_offset * 6 * self.word as usize;
         // Our base rank is the number of ones before our p_offset.
-        let mut rank: usize = self.r.load(p_offset * width, width)? as usize;
+        let mut rank: usize = self.r.load(p_offset * width, width)?.try_into().ok()?;
         // Adjust index to account for our jump through P.
         index -= p_offset * stride;
         // Step through the words until we have fewer than 63 bits left.

--- a/scrunch/src/bit_vector/sparse.rs
+++ b/scrunch/src/bit_vector/sparse.rs
@@ -256,60 +256,59 @@ impl<'a> BitVector<'a> {
                 }
             }
         }
-        let mut bytes = vec![];
-        stack_pack(len as u64).append_to_vec(&mut bytes);
+        let bytes = builder.vec_mut();
+        let base_offset = bytes.len();
+        stack_pack(len as u64).append_to_vec(bytes);
         bytes.push(branch as u8);
         if indices.is_empty() {
-            push_slice_u64(&mut bytes, branch, &[]);
-            // TODO(rescrv): Make this not copy.
-            builder.append_raw(&bytes);
+            push_slice_u64(bytes, branch, &[]);
             return Some(());
         }
         let mut leaves = Vec::with_capacity(branch);
-        let mut dividers = vec![];
-        let mut pointers = vec![];
+        let leaf_count = indices.len().div_ceil(branch);
+        let mut dividers = Vec::with_capacity(leaf_count);
+        let mut pointers = Vec::with_capacity(leaf_count);
         for index in indices.iter() {
             leaves.push(*index as u64);
             if leaves.len() >= branch {
                 dividers.push(leaves[leaves.len() - 1]);
-                pointers.push(bytes.len() as u64);
-                push_slice_u64(&mut bytes, branch, &leaves);
+                pointers.push((bytes.len() - base_offset) as u64);
+                push_slice_u64(bytes, branch, &leaves);
                 leaves.clear();
             }
         }
         if !leaves.is_empty() {
             dividers.push(leaves[leaves.len() - 1]);
-            pointers.push(bytes.len() as u64);
-            push_slice_u64(&mut bytes, branch, &leaves);
+            pointers.push((bytes.len() - base_offset) as u64);
+            push_slice_u64(bytes, branch, &leaves);
         }
         assert_eq!(dividers.len(), pointers.len());
         let mut levels = 1u8;
         while pointers.len() > 1 {
-            let mut new_dividers = vec![];
-            let mut new_pointers = vec![];
+            let next_len = pointers.len().div_ceil(branch);
+            let mut new_dividers = Vec::with_capacity(next_len);
+            let mut new_pointers = Vec::with_capacity(next_len);
             let mut idx = 0;
             while idx + branch < pointers.len() {
                 new_dividers.push(dividers[idx + branch - 1]);
-                new_pointers.push(bytes.len() as u64);
-                push_slice_u64(&mut bytes, branch - 1, &dividers[idx..idx + branch - 1]);
-                push_slice_u64(&mut bytes, branch, &pointers[idx..idx + branch]);
+                new_pointers.push((bytes.len() - base_offset) as u64);
+                push_slice_u64(bytes, branch - 1, &dividers[idx..idx + branch - 1]);
+                push_slice_u64(bytes, branch, &pointers[idx..idx + branch]);
                 idx += branch;
             }
             let amt = pointers.len() - idx;
             if amt > 0 {
-                new_pointers.push(bytes.len() as u64);
-                push_slice_u64(&mut bytes, branch - 1, &dividers[idx..idx + amt - 1]);
-                push_slice_u64(&mut bytes, branch, &pointers[idx..idx + amt]);
+                new_pointers.push((bytes.len() - base_offset) as u64);
+                push_slice_u64(bytes, branch - 1, &dividers[idx..idx + amt - 1]);
+                push_slice_u64(bytes, branch, &pointers[idx..idx + amt]);
             }
             dividers = new_dividers;
             pointers = new_pointers;
             levels += 1;
         }
         assert_eq!(1, pointers.len());
-        stack_pack(pointers[0]).append_to_vec(&mut bytes);
+        stack_pack(pointers[0]).append_to_vec(bytes);
         bytes.push(levels);
-        // TODO(rescrv): Make this not copy.
-        builder.append_raw(&bytes);
         Some(())
     }
 


### PR DESCRIPTION
Replace linear scan in u63::select with popcount-based binary
search (select_word), yielding significant speedup for select1 and
select0 operations. Add fast paths in encode/decode for c==0 and
c==63 edge cases. Extract access_rank_at helper and fix unsafe
`as usize` casts to use try_into().ok()? in rank method.

Eliminate intermediate buffer allocation in sparse bit vector
construction by writing directly to the builder vec with relative
offsets, removing two TODO(rescrv) copy comments. Pre-compute Vec
capacities for dividers, pointers, and inner-loop Vecs.

Add access_rank benchmark for RRR bit vectors and fix black_box
usage in benchmarks to wrap return values. Apply rustfmt to
benchmarks and encoder.

Co-authored-by: AI
