### PR TITLE
feat(arrrg): add subcommand dispatch and zsh completions

### DIFF
--- a/arrrg/README.md
+++ b/arrrg/README.md
@@ -35,6 +35,64 @@ This library takes an opinionated stance on the command line.  There should be e
 canonical argument order on the command-line and all applications must be built with this in
 mind.  Users of the library can call [CommandLine::from_command_line_relaxed] to disable this checking.
 
+Subcommands
+-----------
+
+Subcommands are parsed recursively from the free arguments left by the current [CommandLine].  For
+example, this command line:
+
+```text
+/path/to/binary --arg1 root --arg2 subcommand1 --sc1-arg1 one --sc1-arg2 subcommand2 --sc2-arg1 two
+```
+
+can be dispatched with typed command-name, [CommandLine] pairs:
+
+```rust,no_run
+use arrrg::CommandLine;
+use arrrg_derive::CommandLine;
+
+#[derive(CommandLine, Debug, Default, Eq, PartialEq)]
+struct Top {
+    #[arrrg(optional, "top-level option")]
+    arg1: String,
+    #[arrrg(flag, "top-level flag")]
+    arg2: bool,
+}
+
+#[derive(CommandLine, Debug, Default, Eq, PartialEq)]
+struct Subcommand1 {
+    #[arrrg(optional, "subcommand option")]
+    sc1_arg1: String,
+    #[arrrg(flag, "subcommand flag")]
+    sc1_arg2: bool,
+}
+
+#[derive(CommandLine, Debug, Default, Eq, PartialEq)]
+struct Subcommand2 {
+    #[arrrg(required, "leaf option")]
+    sc2_arg1: String,
+}
+
+fn main() {
+    let (top, free) = Top::from_command_line("Usage: binary [OPTIONS] <command>");
+    let result = arrrg::dispatch_subcommands!(free, {
+        "subcommand1" => Subcommand1 as sc1, sc1_free => {
+            arrrg::dispatch_subcommands!(sc1_free, {
+                "subcommand2" => Subcommand2 as sc2, sc2_free => {
+                    println!("{top:?} {sc1:?} {sc2:?} {sc2_free:?}");
+                    Ok(())
+                },
+            })
+        },
+    });
+
+    if let Err(err) = result {
+        eprintln!("{err}");
+        std::process::exit(64);
+    }
+}
+```
+
 Status
 ------
 

--- a/arrrg/src/lib.rs
+++ b/arrrg/src/lib.rs
@@ -1,8 +1,177 @@
 #![doc = include_str!("../README.md")]
 
+use std::collections::HashSet;
+use std::fmt;
 use std::str::FromStr;
 
 use getopts::Fail;
+
+//////////////////////////////////////////// subcommands ///////////////////////////////////////////
+
+/// Error returned when subcommand dispatch cannot select a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubcommandError {
+    command: Option<String>,
+    expected: Vec<String>,
+}
+
+impl SubcommandError {
+    /// Create a missing-subcommand error.
+    pub fn missing(expected: Vec<String>) -> Self {
+        Self {
+            command: None,
+            expected,
+        }
+    }
+
+    /// Create an unknown-subcommand error.
+    pub fn unknown(command: String, expected: Vec<String>) -> Self {
+        Self {
+            command: Some(command),
+            expected,
+        }
+    }
+
+    /// Return the unknown subcommand, or `None` when no subcommand was provided.
+    pub fn command(&self) -> Option<&str> {
+        self.command.as_deref()
+    }
+
+    /// Return the expected command names.
+    pub fn expected(&self) -> &[String] {
+        &self.expected
+    }
+}
+
+impl fmt::Display for SubcommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(command) = &self.command {
+            write!(f, "unknown subcommand {command:?}")?;
+        } else {
+            write!(f, "missing subcommand")?;
+        }
+        write_expected_subcommands(f, &self.expected)
+    }
+}
+
+impl std::error::Error for SubcommandError {}
+
+fn write_expected_subcommands(f: &mut fmt::Formatter<'_>, expected: &[String]) -> fmt::Result {
+    if expected.is_empty() {
+        return Ok(());
+    }
+    write!(f, "; expected one of: {}", expected.join(", "))
+}
+
+/// Split a command line's free arguments into `(subcommand, remaining_args)`.
+///
+/// arrrg parsers use `getopts::ParsingStyle::StopAtFirstFree`, so recursive subcommand parsing is
+/// naturally represented as:
+///
+/// 1. parse the current command's options,
+/// 2. split the first free argument as the subcommand name,
+/// 3. parse the remaining free arguments with the selected subcommand's [CommandLine].
+pub fn split_subcommand(
+    free: Vec<String>,
+    command_names: &[&str],
+) -> Result<(String, Vec<String>), SubcommandError> {
+    let mut free = free.into_iter();
+    let expected = command_names
+        .iter()
+        .map(|command| command.to_string())
+        .collect::<Vec<_>>();
+    let Some(command) = free.next() else {
+        return Err(SubcommandError::missing(expected));
+    };
+    if !command_names.iter().any(|name| *name == command) {
+        return Err(SubcommandError::unknown(command, expected));
+    }
+    Ok((command, free.collect()))
+}
+
+/// Return the default usage string used by the subcommand dispatch macros.
+pub fn usage_for_subcommand(command: &str) -> String {
+    format!("Usage: {command} [OPTIONS]")
+}
+
+/// Dispatch a `Vec<String>` of free arguments to a named subcommand.
+///
+/// Each branch is a command-name, [CommandLine] pair plus a typed handler.  The selected branch gets
+/// a concrete command-line value and the remaining free arguments.  Branch handlers return
+/// `Result<T, SubcommandError>`, which lets the macro compose recursively without enums or
+/// downcasts.
+///
+/// ```rust
+/// # use arrrg::CommandLine;
+/// # #[derive(Default, Eq, PartialEq)]
+/// # struct Top;
+/// # impl CommandLine for Top {
+/// #     fn add_opts(&self, _: Option<&str>, _: &mut getopts::Options) {}
+/// #     fn matches(&mut self, _: Option<&str>, _: &getopts::Matches) {}
+/// #     fn canonical_command_line(&self, _: Option<&str>) -> Vec<String> { vec![] }
+/// # }
+/// # #[derive(Default, Eq, PartialEq)]
+/// # struct Get;
+/// # impl CommandLine for Get {
+/// #     fn add_opts(&self, _: Option<&str>, _: &mut getopts::Options) {}
+/// #     fn matches(&mut self, _: Option<&str>, _: &getopts::Matches) {}
+/// #     fn canonical_command_line(&self, _: Option<&str>) -> Vec<String> { vec![] }
+/// # }
+/// # let (_top, free) = Top::from_arguments("Usage: tool [OPTIONS] <command>", &["get"]);
+/// let selected = arrrg::dispatch_subcommands!(free, {
+///     "get" => Get as get, get_free => {
+///         Ok((get, get_free))
+///     },
+/// });
+/// # assert!(selected.is_ok());
+/// ```
+#[macro_export]
+macro_rules! dispatch_subcommands {
+    ($free:expr, { $($name:literal => $ty:ty as $cmd:ident, $rest:ident => $body:block),+ $(,)? }) => {{
+        $crate::__dispatch_subcommands!(from_arguments, $free, {
+            $($name => $ty as $cmd, $rest => $body),+
+        })
+    }};
+}
+
+/// Dispatch subcommands while allowing non-canonical command-line argument order.
+///
+/// This is the subcommand equivalent of [CommandLine::from_arguments_relaxed].
+#[macro_export]
+macro_rules! dispatch_subcommands_relaxed {
+    ($free:expr, { $($name:literal => $ty:ty as $cmd:ident, $rest:ident => $body:block),+ $(,)? }) => {{
+        $crate::__dispatch_subcommands!(from_arguments_relaxed, $free, {
+            $($name => $ty as $cmd, $rest => $body),+
+        })
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __dispatch_subcommands {
+    ($parser:ident, $free:expr, { $($name:literal => $ty:ty as $cmd:ident, $rest:ident => $body:block),+ $(,)? }) => {{
+        match $crate::split_subcommand($free, &[$($name),+]) {
+            Ok((__arrrg_command, __arrrg_rest)) => {
+                match __arrrg_command.as_str() {
+                    $(
+                        $name => {
+                            let __arrrg_args = __arrrg_rest
+                                .iter()
+                                .map(::std::string::String::as_str)
+                                .collect::<::std::vec::Vec<_>>();
+                            let __arrrg_usage = $crate::usage_for_subcommand($name);
+                            let ($cmd, $rest) =
+                                <$ty as $crate::CommandLine>::$parser(&__arrrg_usage, &__arrrg_args);
+                            $body
+                        }
+                    )+
+                    _ => unreachable!("split_subcommand returned an unexpected command"),
+                }
+            }
+            Err(__arrrg_err) => Err(__arrrg_err),
+        }
+    }};
+}
 
 //////////////////////////////////////////// CommandLine ///////////////////////////////////////////
 
@@ -65,7 +234,27 @@ check argument order amongst other differences",
         opts.parsing_style(getopts::ParsingStyle::StopAtFirstFree);
         opts.long_only(true);
         opts.optflag("h", "help", "Print this help menu.");
+        opts.optflag(
+            "",
+            "completions",
+            "Print zsh completion script for this command.",
+        );
         command_line.add_opts(None, &mut opts);
+
+        if args
+            .iter()
+            .any(|arg| arg == &"--completions" || arg == &"-completions")
+        {
+            Self::completions(
+                &mut command_line,
+                &opts,
+                usage,
+                &std::env::args()
+                    .next()
+                    .unwrap_or_else(|| "command".to_string()),
+            );
+            return (command_line, vec![]);
+        }
 
         let matches = match opts.parse(args) {
             Ok(matches) => matches,
@@ -87,6 +276,17 @@ check argument order amongst other differences",
             Self::usage(&mut command_line, opts, usage);
             return (command_line, vec![]);
         }
+        if matches.opt_present("completions") {
+            Self::completions(
+                &mut command_line,
+                &opts,
+                usage,
+                &std::env::args()
+                    .next()
+                    .unwrap_or_else(|| "command".to_string()),
+            );
+            return (command_line, vec![]);
+        }
         command_line.matches(None, &matches);
         let free: Vec<String> = matches.free.to_vec();
         (command_line, free)
@@ -98,6 +298,38 @@ check argument order amongst other differences",
         self.exit(1);
     }
 
+    /// Emit a zsh completion script for the current command line and terminate successfully.
+    ///
+    /// The function derives the completion entries from the full option set already defined on `opts`
+    /// and prints a minimal zsh completion function scoped to the executable in `command_path`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use arrrg::CommandLine;
+    ///
+    /// #[derive(Default, Eq, PartialEq)]
+    /// struct MyCmd;
+    ///
+    /// impl CommandLine for MyCmd {
+    ///     fn add_opts(&self, _prefix: Option<&str>, opts: &mut getopts::Options) {
+    ///         opts.optflag("h", "help", "print help");
+    ///     }
+    ///
+    ///     fn matches(&mut self, _prefix: Option<&str>, _matches: &getopts::Matches) {}
+    ///
+    ///     fn canonical_command_line(&self, _prefix: Option<&str>) -> Vec<String> {
+    ///         vec!["my-cmd".to_string()]
+    ///     }
+    /// }
+    /// ```
+    /// In normal usage, invoking `--completions` with a live implementation will print text and
+    /// exit the process with code `0`.
+    fn completions(&mut self, opts: &getopts::Options, usage: &str, command_path: &str) {
+        print!("{}", zsh_completions(opts, usage, command_path));
+        self.exit(0);
+    }
+
     /// Report an error.
     fn error(&mut self, msg: impl AsRef<str>) {
         eprintln!("{}", msg.as_ref());
@@ -106,6 +338,204 @@ check argument order amongst other differences",
     /// Exit with the provided status.
     fn exit(&mut self, status: i32) {
         std::process::exit(status);
+    }
+}
+
+fn zsh_completion_entries(opts: &getopts::Options, usage: &str) -> Vec<String> {
+    let usage = opts.usage(usage);
+    let mut options = Vec::new();
+    let mut collecting = false;
+    for line in usage.lines() {
+        if line.starts_with("Options:") {
+            collecting = true;
+            continue;
+        }
+        if !collecting {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !trimmed.starts_with('-') {
+            continue;
+        }
+        let mut split_idx = None;
+        for (i, b) in trimmed.bytes().enumerate() {
+            if b == b'\t' {
+                split_idx = Some(i);
+                break;
+            }
+            if b.is_ascii_whitespace()
+                && i + 1 < trimmed.len()
+                && trimmed.as_bytes()[i + 1].is_ascii_whitespace()
+            {
+                split_idx = Some(i);
+                break;
+            }
+        }
+        let flag_part = if let Some(i) = split_idx {
+            trimmed[..i].trim().to_string()
+        } else {
+            trimmed.to_string()
+        };
+        if flag_part.is_empty() {
+            continue;
+        }
+        let desc_part = if let Some(i) = split_idx {
+            trimmed[i..].trim()
+        } else {
+            ""
+        };
+        for name in parse_option_names(&flag_part) {
+            options.push(format_completion_option(&name, desc_part));
+        }
+    }
+    options
+}
+
+fn parse_option_names(flag_part: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for raw_name in flag_part.split(',') {
+        let mut pieces = raw_name.split_whitespace().filter(|x| !x.is_empty());
+        if let Some(name) = pieces.next()
+            && name.starts_with('-')
+        {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+fn format_completion_option(name: &str, desc: &str) -> String {
+    let desc = desc.replace('\'', "'\"'\"'");
+    format!("{}[{}]", name, desc)
+}
+
+fn zsh_completions(opts: &getopts::Options, usage: &str, command_path: &str) -> String {
+    let opts = zsh_completion_entries(opts, usage);
+    let command = command_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(command_path)
+        .to_string();
+    let mut function: String = command
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    if function.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        function.insert(0, '_');
+    }
+
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for opt in opts {
+        if seen.insert(opt.clone()) {
+            entries.push(format!("        '{opt}'"));
+        }
+    }
+
+    let mut lines = vec![format!("#compdef {command}"), format!("_{function}() {{")];
+    if entries.is_empty() {
+        lines.push("    _arguments".to_string());
+    } else {
+        lines.push("    _arguments -s \\".to_string());
+        for (i, entry) in entries.iter().enumerate() {
+            let continuation = if i + 1 == entries.len() { "" } else { " \\" };
+            lines.push(format!("{entry}{continuation}"));
+        }
+    }
+    lines.extend_from_slice(&["}".to_string(), format!("compdef _{function} {command}")]);
+    lines.join("\n") + "\n"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zsh_completions_have_help_and_completions() {
+        let mut opts = getopts::Options::new();
+        opts.optflag("h", "help", "Print this help menu.");
+        opts.optflag(
+            "",
+            "completions",
+            "Print zsh completion script for this command.",
+        );
+        let script = zsh_completions(&opts, "Usage: test", "test-binary");
+        assert!(script.contains("#compdef test-binary"));
+        assert!(script.contains("_test_binary()"));
+        assert!(script.contains("'--help[Print this help menu.]'"));
+        assert!(script.contains("'--completions[Print zsh completion script for this command.]'"));
+    }
+
+    #[test]
+    fn zsh_completion_entries_include_short_and_long_names() {
+        let mut opts = getopts::Options::new();
+        opts.optflag("h", "help", "Print this help menu.");
+        opts.optflag("v", "verbose", "Print verbose output.");
+        let entries = zsh_completion_entries(&opts, "Usage: test");
+
+        assert!(entries.contains(&"-h[Print this help menu.]".to_string()));
+        assert!(entries.contains(&"--help[Print this help menu.]".to_string()));
+        assert!(entries.contains(&"-v[Print verbose output.]".to_string()));
+        assert!(entries.contains(&"--verbose[Print verbose output.]".to_string()));
+    }
+
+    #[test]
+    fn zsh_completion_entries_escapes_single_quotes() {
+        let mut opts = getopts::Options::new();
+        opts.optflag("", "with-space", "It'll parse correctly.");
+        let entries = zsh_completion_entries(&opts, "Usage: test");
+
+        assert!(entries.contains(&"--with-space[It'\"'\"'ll parse correctly.]".to_string()));
+    }
+
+    #[test]
+    fn zsh_completions_normalize_function_name() {
+        let mut opts = getopts::Options::new();
+        opts.optflag("h", "help", "Print this help menu.");
+        let script = zsh_completions(&opts, "Usage: test", "./bin/my-cmd");
+
+        assert!(script.contains("#compdef my-cmd"));
+        assert!(script.contains("_my_cmd()"));
+        assert!(script.contains("compdef _my_cmd my-cmd"));
+    }
+
+    #[derive(Default, Eq, PartialEq)]
+    struct TestCommandLine {
+        required: String,
+    }
+
+    impl CommandLine for TestCommandLine {
+        fn add_opts(&self, _prefix: Option<&str>, opts: &mut getopts::Options) {
+            opts.reqopt("", "chooser-mode", "required mode", "METHOD");
+        }
+
+        fn matches(&mut self, _prefix: Option<&str>, matches: &getopts::Matches) {
+            if let Some(mode) = matches.opt_str("chooser-mode") {
+                self.required = mode;
+            }
+        }
+
+        fn canonical_command_line(&self, _prefix: Option<&str>) -> Vec<String> {
+            let mut result = vec!["test".to_string()];
+            if !self.required.is_empty() {
+                result.push("--chooser-mode".to_string());
+                result.push(self.required.to_string());
+            }
+            result
+        }
+    }
+
+    #[test]
+    fn completions_bypass_missing_required_args() {
+        let (command_line, _) = NoExitCommandLine::<TestCommandLine>::from_arguments_relaxed(
+            "Usage: test",
+            &["--completions"],
+        );
+        let (_, _, status) = command_line.into_parts();
+        assert_eq!(status, 0);
     }
 }
 

--- a/arrrg/tests/subcommands.rs
+++ b/arrrg/tests/subcommands.rs
@@ -1,0 +1,111 @@
+extern crate arrrg;
+#[macro_use]
+extern crate arrrg_derive;
+
+use arrrg::CommandLine;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, CommandLine)]
+struct RootOptions {
+    #[arrrg(optional, "root argument one")]
+    arg1: String,
+    #[arrrg(flag, "root argument two")]
+    arg2: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, CommandLine)]
+struct Subcommand1Options {
+    #[arrrg(optional, "subcommand one argument one")]
+    sc1_arg1: String,
+    #[arrrg(flag, "subcommand one argument two")]
+    sc1_arg2: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, CommandLine)]
+struct Subcommand2Options {
+    #[arrrg(required, "subcommand two argument one")]
+    sc2_arg1: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, CommandLine)]
+struct OtherOptions {
+    #[arrrg(flag, "unused option")]
+    other: bool,
+}
+
+#[test]
+fn recursive_subcommands_parse_each_layer() {
+    let args = [
+        "--arg1",
+        "root",
+        "--arg2",
+        "subcommand1",
+        "--sc1-arg1",
+        "one",
+        "--sc1-arg2",
+        "subcommand2",
+        "--sc2-arg1",
+        "two",
+        "positional",
+    ];
+    let (root, free) = RootOptions::from_arguments("Usage: binary [OPTIONS] <command>", &args);
+
+    let result = arrrg::dispatch_subcommands!(free, {
+        "subcommand1" => Subcommand1Options as sc1, sc1_free => {
+            arrrg::dispatch_subcommands!(sc1_free, {
+                "subcommand2" => Subcommand2Options as sc2, sc2_free => {
+                    Ok((root, sc1, sc2, sc2_free))
+                },
+                "other" => OtherOptions as other, other_free => {
+                    Ok((root, Subcommand1Options::default(), Subcommand2Options {
+                        sc2_arg1: format!("{:?}:{:?}", other, other_free),
+                    }, Vec::new()))
+                },
+            })
+        },
+        "other" => OtherOptions as other, other_free => {
+            Ok((root, Subcommand1Options::default(), Subcommand2Options {
+                sc2_arg1: format!("{:?}:{:?}", other, other_free),
+            }, Vec::new()))
+        },
+    });
+
+    assert_eq!(
+        Ok((
+            RootOptions {
+                arg1: "root".to_string(),
+                arg2: true,
+            },
+            Subcommand1Options {
+                sc1_arg1: "one".to_string(),
+                sc1_arg2: true,
+            },
+            Subcommand2Options {
+                sc2_arg1: "two".to_string(),
+            },
+            vec!["positional".to_string()],
+        )),
+        result,
+    );
+}
+
+#[test]
+fn split_subcommand_reports_missing() {
+    assert_eq!(
+        Err(arrrg::SubcommandError::missing(vec![
+            "one".to_string(),
+            "two".to_string()
+        ])),
+        arrrg::split_subcommand(vec![], &["one", "two"]),
+    );
+}
+
+#[test]
+fn split_subcommand_reports_unknown() {
+    assert_eq!(
+        Err(arrrg::SubcommandError::unknown(
+            "wat".to_string(),
+            vec!["one".to_string(), "two".to_string()],
+        )),
+        arrrg::split_subcommand(vec!["wat".to_string()], &["one", "two"]),
+    );
+}


### PR DESCRIPTION
Add recursive subcommand dispatch via split_subcommand,
SubcommandError, and the dispatch_subcommands! and
dispatch_subcommands_relaxed! macros.  Each branch binds a
typed CommandLine value and remaining free arguments, composing
naturally for nested command hierarchies.

Add --completions flag to CommandLine that emits a minimal zsh
completion script derived from the getopts option set.  The
completions handler runs before argument validation so it works
even when required arguments are missing.

Include integration tests for multi-level subcommand parsing,
missing/unknown subcommand error reporting, unit tests for zsh
completion generation, and README documentation with a worked
subcommand example.

Co-authored-by: AI
