### PR TITLE
feat(macarunes): expand API with covering sets, ergonomic builders, and comprehensive tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ quote = { version = "1.0" }
 serde_yaml = { version = "0.9" }
 serde_json = { version = "1.0" }
 siphasher = { version = "1.0.0" }
-libsodium-sys-stable = { version = "1.19" }
+libsodium-sys-stable = { version = "1.24.0" }
 
 [profile.dev]
 panic = "abort"

--- a/macarunes/Cargo.toml
+++ b/macarunes/Cargo.toml
@@ -14,3 +14,6 @@ biometrics = { workspace = true }
 buffertk = { workspace = true }
 prototk = { workspace = true }
 prototk_derive = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/macarunes/README.md
+++ b/macarunes/README.md
@@ -5,6 +5,522 @@ This library provides an implementation of Macaroons.  For an introduction to
 macaroons, [check out the paper](https://research.google/pubs/pub41892/), or
 the [Python README](https://github.com/rescrv/libmacaroons/blob/master/README).
 
+Quick Start
+-----------
+
+Mint a macaroon with a root secret, attenuate it with caveats, and verify it
+with the same root secret plus the request context that satisfies those caveats.
+
+```rust
+use macarunes::{Macaroon, Secret, Verifier};
+
+let secret = Secret::from_bytes([7; macarunes::SIGNATURE_BYTES]);
+let mut macaroon = Macaroon::new(
+    "https://issuer.example",
+    "alice@example",
+    secret.clone(),
+);
+macaroon.add_exact_string("role = admin");
+macaroon.add_expires(4_102_444_800);
+
+let verifier = Verifier::new()
+    .with_context("role = admin")
+    .with_current_time(1_700_000_000);
+
+verifier.verify(&macaroon, &secret, &[])?;
+# Ok::<_, macarunes::Error>(())
+```
+
+Why Macaroons?
+--------------
+
+Macaroons occupy the same practical space as cookies and bearer tokens: the
+holder presents the token, and the receiver decides whether the token authorizes
+the requested action.  The difference is that a macaroon can carry restrictions
+that are added after it is minted.  That makes delegation safer.  A user can
+hand a macaroon to another program after adding caveats that narrow it to one
+account, one action, a short time window, or a proof from an authentication
+service.
+
+That gives macaroons several useful properties:
+
+- Delegation can be confined to the context in which it should be valid.
+- Attenuation is monotonic: holders can add caveats, but cannot remove caveats
+  that have already been signed into the macaroon.
+- Authorization proofs travel with the request, so the verifier does not need
+  to keep a server-side copy of every attenuated macaroon.
+- Third-party caveats let one service depend on another service's decision
+  without putting that decision logic into the first service.
+- The verifier stays small and reusable.  The policy lives in the macaroons
+  that services mint and attenuate, while the verifier checks whether the proof
+  and current request context satisfy that policy.
+
+Core Ideas
+----------
+
+Macaroons are bearer credentials that can be attenuated.  A service mints a
+root macaroon from a root secret and an identifier.  Whoever holds that
+macaroon can add caveats that restrict where, when, or under which application
+context it verifies.  Adding a caveat changes the macaroon signature, so a
+receiver can detect tampering without keeping a copy of every macaroon it has
+issued.
+
+`macarunes` keeps the core language intentionally small:
+
+- `Macaroon` carries a location hint, an identifier, a signature, and caveats.
+- `Secret` holds 32 bytes of key material and scrubs its storage on drop.
+- `Verifier` checks a root macaroon, its first-party caveats, and any discharge
+  macaroons supplied for third-party caveats.
+- `ThirdPartySecret` lets one service require proof from another service
+  without revealing the discharge service's root secret.
+- `RequestBuilder` and `Loader` assemble the root macaroon plus the transitive
+  set of discharge macaroons a client should send with a request.
+
+The caveat language has three cases:
+
+- Exact-string caveats require a verifier context string with exactly the same
+  bytes.
+- Expiration caveats require `expiration > current_time`; equality is expired.
+- Third-party caveats require a matching discharge macaroon, bound to the root
+  macaroon for this request.
+
+Installing
+----------
+
+Use the crate from this workspace or add it as a normal Rust dependency:
+
+```toml
+[dependencies]
+macarunes = "0.11"
+```
+
+Secrets
+-------
+
+Use `Secret::random` when minting real credentials.  Use `Secret::from_bytes`
+when loading configured key material, writing deterministic tests, or decoding a
+secret from a protected storage system.
+
+```rust
+use macarunes::{Secret, SIGNATURE_BYTES};
+
+let generated = Secret::random();
+assert_eq!(SIGNATURE_BYTES * 2, generated.hexdigest().len());
+
+let configured = Secret::from_bytes([0xab; SIGNATURE_BYTES]);
+assert_eq!(
+    "abababababababababababababababababababababababababababababababab",
+    configured.hexdigest(),
+);
+```
+
+`Secret` makes a best-effort attempt to scrub its internal memory when dropped.
+That does not make logged, cloned, serialized, swapped, or otherwise copied
+secrets safe.  Treat root secrets and discharge secrets as server-side keys.
+The fixed width of `Secret` is intentional: use all `SIGNATURE_BYTES` bytes, and
+draw them from a cryptographically strong random source.  Short, human-readable,
+or predictable secrets make it easier to forge macaroons.
+
+Minting a Root Macaroon
+-----------------------
+
+A root macaroon starts with a public location, a public identifier, and a secret
+known to the service that will later verify it.
+
+```rust
+use macarunes::{Macaroon, Secret};
+
+let root_secret = Secret::from_bytes([1; macarunes::SIGNATURE_BYTES]);
+let macaroon = Macaroon::new(
+    "https://files.example/macaroons",
+    "file:alpha",
+    root_secret,
+);
+
+assert_eq!("https://files.example/macaroons", macaroon.location());
+assert_eq!("file:alpha", macaroon.identifier());
+assert!(!macaroon.has_caveats());
+```
+
+The location is a routing hint.  It is intentionally not protected by the
+macaroon signature, so do not use it as an authority decision.  The identifier
+is the stable public value the issuing service uses to find or derive the root
+secret needed for verification.  Common identifier strategies include a database
+key, an encrypted record that only the issuer can open, or a structured name
+that is enough to deterministically derive the secret.  The identifier can be
+visible to anyone who holds the macaroon; it must not reveal the root secret.
+
+The signature is also present in the macaroon.  It changes when caveats are
+added and becomes the key material used for later attenuation.  In application
+code, treat possession of a macaroon or its signature as possession of the
+credential.
+
+First-Party Caveats
+-------------------
+
+First-party caveats are checked directly by the final verifier.  They are useful
+for request facts that the verifier can compute locally, such as method, path,
+tenant, role, or deadline.
+
+```rust
+use macarunes::{Error, Macaroon, Secret, Verifier};
+
+let secret = Secret::from_bytes([2; macarunes::SIGNATURE_BYTES]);
+let mut macaroon = Macaroon::new("https://issuer.example", "alice", secret.clone());
+macaroon.add_exact_string("method = GET");
+macaroon.add_exact_string("path = /v1/accounts/alice");
+macaroon.add_expires(1_900_000_000);
+
+let accepted = Verifier::new()
+    .with_context("method = GET")
+    .with_context("path = /v1/accounts/alice")
+    .with_current_time(1_800_000_000);
+assert_eq!(Ok(()), accepted.verify(&macaroon, &secret, &[]));
+
+let rejected = Verifier::new()
+    .with_context("method = POST")
+    .with_context("path = /v1/accounts/alice")
+    .with_current_time(1_800_000_000);
+assert_eq!(
+    Err(Error::ProofInvalid),
+    rejected.verify(&macaroon, &secret, &[]),
+);
+```
+
+Exact-string caveats are not parsed by the library.  Define your own canonical
+format, normalize request facts before adding them to the verifier, and keep
+those strings stable across services.
+
+Verifier Design
+---------------
+
+Build the verifier from facts about the request, not by inspecting the macaroon
+and trying to make its caveats pass.  For example, an HTTP service can add facts
+like `method = GET`, `path = /v1/accounts/alice`, `user = alice`,
+`account = 3735928559`, and `action = deposit` for every request.  A macaroon
+that mentions any subset of those true facts will verify; a macaroon that adds
+an unknown or false fact will not.
+
+This keeps authorization policy decoupled from enforcement.  You can mint a new
+macaroon with a narrower policy without changing the verifier, provided the
+verifier already knows how to state the relevant request facts.  This crate does
+not expose libmacaroons-style general callback caveats.  Use exact strings for
+canonical request facts and `add_expires` for the built-in time predicate.  If
+you need a richer predicate, evaluate it in your application and add the
+resulting canonical fact to the verifier context; or, use third-party caveats.
+
+Expiration Caveats
+------------------
+
+`add_expires` takes an unsigned integer timestamp.  The verifier accepts the
+macaroon only when the expiration is strictly greater than the verifier's
+current time.
+
+```rust
+use macarunes::{Error, Macaroon, Secret, Verifier};
+
+let secret = Secret::from_bytes([3; macarunes::SIGNATURE_BYTES]);
+let mut macaroon = Macaroon::new("https://issuer.example", "alice", secret.clone());
+macaroon.add_expires(1_700_000_000);
+
+assert_eq!(
+    Ok(()),
+    Verifier::new()
+        .with_current_time(1_699_999_999)
+        .verify(&macaroon, &secret, &[]),
+);
+assert_eq!(
+    Err(Error::ProofInvalid),
+    Verifier::new()
+        .with_current_time(1_700_000_000)
+        .verify(&macaroon, &secret, &[]),
+);
+```
+
+What Verification Rejects
+-------------------------
+
+`Verifier::verify` succeeds only when all of these conditions hold:
+
+- The root secret matches the root macaroon identifier.
+- Every first-party caveat is satisfied by the verifier context or current time.
+- Every third-party caveat has a matching discharge macaroon.
+- Every discharge macaroon verifies under the secret hidden in the third-party
+  caveat.
+- Every discharge has been bound to the root macaroon for this request.
+- The final signatures match after replaying the caveat chain.
+
+The verifier deliberately collapses most proof failures into
+`Error::ProofInvalid`.  For authorization decisions, treat `ProofInvalid` as
+"not authorized" rather than trying to distinguish wrong secrets, missing
+contexts, expired caveats, tampering, or missing discharges.
+
+Third-Party Caveats
+-------------------
+
+A third-party caveat lets the root service require a second service to issue a
+discharge macaroon.  The root service does not learn the discharge service's
+secret.  The discharge service receives the current root macaroon signature,
+wraps its discharge secret in a `ThirdPartySecret`, and gives that value back to
+the root service.  The root service then embeds the third-party caveat.
+
+The usual flow is:
+
+1. The root service decides that a request should require a third-party proof.
+2. The third party chooses or records the predicate it will enforce, such as
+   `user = alice`.
+3. The third party creates a discharge secret and a public identifier that lets
+   it recover the predicate and discharge secret later.
+4. The root service embeds the public location, public identifier, and
+   `ThirdPartySecret` in the root macaroon.
+5. The client presents the location and identifier to the third party.
+6. The third party checks its predicate and returns a discharge macaroon.
+7. The client binds the discharge to the root macaroon and sends both to the
+   verifier.
+
+The root macaroon does not need to reveal the predicate that the third party
+checked.  The identifier may be an opaque handle into the third party's storage.
+That lets the final verifier accept the third-party proof without knowing the
+third party's internal policy, user database, or authentication protocol.
+
+```rust
+use macarunes::{Macaroon, Secret, ThirdPartySecret, Verifier};
+
+const ROOT_LOCATION: &str = "https://files.example/macaroons";
+const AUTH_LOCATION: &str = "https://auth.example/discharges";
+
+let root_secret = Secret::from_bytes([4; macarunes::SIGNATURE_BYTES]);
+let auth_secret = Secret::from_bytes([5; macarunes::SIGNATURE_BYTES]);
+
+let mut root = Macaroon::new(ROOT_LOCATION, "file:alpha", root_secret.clone());
+let third_party_secret = ThirdPartySecret::random(root.signature(), &auth_secret);
+root.add_third_party_caveat(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    third_party_secret,
+);
+
+let mut discharge = Macaroon::new(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    auth_secret,
+);
+discharge.add_exact_string("user = alice");
+
+root.bind_discharge(&mut discharge);
+
+let verifier = Verifier::new().with_context("user = alice");
+verifier.verify(&root, &root_secret, &[discharge])?;
+# Ok::<_, macarunes::Error>(())
+```
+
+Binding matters.  A discharge macaroon must be bound to the root macaroon before
+verification so that a discharge created for one request cannot be replayed with
+another root macaroon.  If you assemble discharges manually, call
+`root.bind_discharge(&mut discharge)` for every discharge.  If you use
+`RequestBuilder`, it performs this binding for you.
+
+The upstream libmacaroons guide also describes a public-key variant in which the
+third-party identifier can carry encrypted caveat material instead of requiring a
+round trip to create an identifier.  `macarunes` does not provide that public-key
+scheme directly.  You can still build a protocol with the same shape by making
+the identifier an opaque ciphertext or lookup key understood by your
+third-party service, then issuing a normal `Macaroon` as the discharge.
+
+Preparing Requests with Loaders
+-------------------------------
+
+`RequestBuilder` is the client-side helper for request assembly.  Register one
+`Loader` per location.  The builder loads the root macaroon, recursively follows
+third-party caveats, loads each required discharge macaroon, and binds all
+discharges to the root before returning them.
+
+```rust
+use macarunes::{
+    Error, Loader, Macaroon, RequestBuilder, Secret, ThirdPartySecret, Verifier,
+};
+
+const ROOT_LOCATION: &str = "https://files.example/macaroons";
+const AUTH_LOCATION: &str = "https://auth.example/discharges";
+
+#[derive(Debug)]
+struct StaticLoader {
+    location: &'static str,
+    macaroons: Vec<Macaroon>,
+}
+
+impl StaticLoader {
+    fn new(location: &'static str, macaroons: Vec<Macaroon>) -> Self {
+        Self { location, macaroons }
+    }
+}
+
+impl Loader for StaticLoader {
+    fn location(&self) -> &'static str {
+        self.location
+    }
+
+    fn lookup(&self, identifier: &str) -> Result<Macaroon, Error> {
+        self.macaroons
+            .iter()
+            .find(|macaroon| macaroon.identifier() == identifier)
+            .cloned()
+            .ok_or_else(|| Error::MissingLoader {
+                what: format!("{}/{}", self.location, identifier),
+            })
+    }
+}
+
+let root_secret = Secret::from_bytes([6; macarunes::SIGNATURE_BYTES]);
+let auth_secret = Secret::from_bytes([7; macarunes::SIGNATURE_BYTES]);
+
+let mut root = Macaroon::new(ROOT_LOCATION, "file:alpha", root_secret.clone());
+let third_party_secret = ThirdPartySecret::random(root.signature(), &auth_secret);
+root.add_third_party_caveat(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    third_party_secret,
+);
+
+let mut discharge = Macaroon::new(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    auth_secret,
+);
+discharge.add_exact_string("user = alice");
+
+let builder = RequestBuilder::new()
+    .with_loader(StaticLoader::new(ROOT_LOCATION, vec![root]))
+    .with_loader(StaticLoader::new(AUTH_LOCATION, vec![discharge]));
+
+let (request_root, request_discharges) =
+    builder.prepare_request(ROOT_LOCATION, "file:alpha")?;
+
+Verifier::new()
+    .with_context("user = alice")
+    .verify(&request_root, &root_secret, &request_discharges)?;
+# Ok::<_, macarunes::Error>(())
+```
+
+Production loaders usually wrap an RPC client, local cache, database lookup, or
+service-discovery layer.  A loader should return macaroons for exactly one
+location.  `RequestBuilder` rejects a macaroon if the loader returns a different
+location than the one requested.
+
+Selecting Discharges from a Cache
+---------------------------------
+
+Use `Macaroon::covering_set` when a client already has many candidate discharge
+macaroons and only needs to select the transitive set referenced by a root
+macaroon.  Selection uses public location and identifier data only.  It does not
+verify signatures, decrypt third-party secrets, satisfy caveats, or bind
+unbound discharges.
+
+```rust
+use macarunes::{Macaroon, Secret, ThirdPartySecret, Verifier};
+
+const ROOT_LOCATION: &str = "https://files.example/macaroons";
+const AUTH_LOCATION: &str = "https://auth.example/discharges";
+
+let root_secret = Secret::from_bytes([8; macarunes::SIGNATURE_BYTES]);
+let auth_secret = Secret::from_bytes([9; macarunes::SIGNATURE_BYTES]);
+
+let mut root = Macaroon::new(ROOT_LOCATION, "file:alpha", root_secret.clone());
+let third_party_secret = ThirdPartySecret::random(root.signature(), &auth_secret);
+root.add_third_party_caveat(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    third_party_secret,
+);
+
+let mut discharge = Macaroon::new(
+    AUTH_LOCATION,
+    "authz:alice:file:alpha",
+    auth_secret,
+);
+root.bind_discharge(&mut discharge);
+
+let noise = Macaroon::new(
+    "https://other.example/discharges",
+    "unrelated",
+    Secret::from_bytes([10; macarunes::SIGNATURE_BYTES]),
+);
+let candidates = vec![noise, discharge];
+let selected = root.covering_set(&candidates)?;
+
+assert_eq!(1, selected.len());
+Verifier::new().verify(&root, &root_secret, &selected)?;
+# Ok::<_, macarunes::Error>(())
+```
+
+Use `covering_set_refs` when you want references into the candidate slice
+instead of cloned macaroons.
+
+Serialization
+-------------
+
+`Macaroon`, `Secret`, and `ThirdPartySecret` implement the repository's
+`prototk` message traits.  Use `buffertk` to encode and decode them for storage
+or transport.
+
+```rust
+use buffertk::{stack_pack, Unpacker};
+use macarunes::{Macaroon, Secret};
+
+let secret = Secret::from_bytes([11; macarunes::SIGNATURE_BYTES]);
+let mut macaroon = Macaroon::new("https://issuer.example", "alice", secret);
+macaroon.add_exact_string("role = admin");
+
+let bytes = stack_pack(&macaroon).to_vec();
+let mut unpacker = Unpacker::new(&bytes);
+let decoded: Macaroon = unpacker.unpack().expect("macaroon decodes");
+
+assert!(unpacker.is_empty());
+assert_eq!(macaroon, decoded);
+```
+
+The encoded bytes are suitable for structured storage or transport protocols
+that already carry bytes.  If you need to place a macaroon in a cookie, header,
+URL, or email body, wrap the encoded bytes in an ASCII-safe envelope such as
+base64 and decode that envelope before calling `Unpacker`.
+
+Verification Checklist
+----------------------
+
+On the service that verifies a request:
+
+1. Recover or derive the root secret for the root macaroon identifier.
+2. Build a `Verifier`.
+3. Add every exact-string context that should be true for this request.
+4. Set the verifier time before checking expiration caveats.
+5. Pass the root macaroon, root secret, and all bound discharges to
+   `Verifier::verify`.
+6. Treat every `Error::ProofInvalid` as authentication failure.
+
+On the client that prepares a request:
+
+1. Start with the root macaroon the target service gave you.
+2. Fetch every required discharge macaroon, including nested discharges.
+3. Bind every discharge to the root macaroon, or use `RequestBuilder`.
+4. Send the root macaroon and the bound discharge list together.
+
+Errors
+------
+
+The public error type is `macarunes::Error`:
+
+- `ProofInvalid` means the proof failed: wrong secret, missing context, expired
+  caveat, missing discharge, unbound discharge, tampering, or any other
+  verification failure.
+- `Cycle` means verification detected recursive discharge structure deeper than
+  the supplied discharge set.
+- `MissingLoader` means `RequestBuilder` has no loader for a location, or a
+  loader could not find the requested macaroon.
+- `LocationMismatch` means a loader returned a macaroon whose location differs
+  from the requested loader location.
+- `MissingMacaroon` means `covering_set` could not find a candidate with the
+  public location and identifier required by a third-party caveat.
+
 Assumptions
 -----------
 
@@ -23,32 +539,21 @@ Assumptions
   a third-party caveat that enforces some arbitrary predicate before the
   discharge macaroon is granted.
 
-Third-Party Macaroons
----------------------
-
-This is the algorithm for satisfying third-party secrets:
-
-1) Obtain `signature` from the macaroon to which we want to add a third-party
-   caveat.
-2) Make an RPC to the third-party that exchanges `signature` for a
-   `ThirdPartySecret`.
-3) Call `Macaroon.add_third_party(location, identifier, third_party_secret)`.
-
 About Locations
 ---------------
 
-A location is a hint that is not part of the macaroons's signature.  The
-library does this intentionally as the paper suggests that only keys speak.
+A location is a hint that is not part of the macaroon's signature.  The library
+does this intentionally as the paper suggests that only keys speak.
 
 For that reason, locations should be treated as hints that give a plain-text
-description of how to use the endpoint.  The location in the macaroon is not
-the endpoint for discharge; it's a opaque identifier that the `RequestBuilder`
+description of how to use the endpoint.  The location in the macaroon is not the
+endpoint for discharge; it is an opaque identifier that the `RequestBuilder`
 will iterate over.
 
-For each third party, a Loader should be developed that negotiates the
-protocol to get discharge macaroons.  A location that's not known to a client
-cannot be trusted.  Given that we have to trust servers that give us
-macaroons, this is not a compromise or limitation.
+For each third party, a `Loader` should be developed that negotiates the
+protocol to get discharge macaroons.  A location that is not known to a client
+cannot be trusted.  Given that we have to trust servers that give us macaroons,
+this is not a compromise or limitation.
 
 Status
 ------
@@ -68,4 +573,4 @@ Warts
 Documentation
 -------------
 
-The latest documentation is always available at [docs.rs](https://docs.rs/buffertk/latest/buffertk/).
+The latest documentation is always available at [docs.rs](https://docs.rs/macarunes/latest/macarunes/).

--- a/macarunes/src/lib.rs
+++ b/macarunes/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::c_void;
 use std::fmt::{Debug, Write};
 
@@ -25,7 +25,7 @@ static VERIFIER_THIRD_PARTY_SUCCESS: Counter = Counter::new("macaroons.verifier.
 /////////////////////////////////////////////// Error //////////////////////////////////////////////
 
 /// The error cases macarunes can encounter.
-#[derive(Clone, Debug, Default, Message)]
+#[derive(Clone, Debug, Default, Eq, Message, PartialEq)]
 pub enum Error {
     /// Success is the default error.
     #[prototk(294912, message)]
@@ -44,7 +44,53 @@ pub enum Error {
         #[prototk(1, string)]
         what: String,
     },
+    /// The loader returned a macarune for a different location than the one requested.
+    #[prototk(294916, message)]
+    LocationMismatch {
+        /// The location that was requested from the loader.
+        #[prototk(1, string)]
+        expected: String,
+        /// The location returned by the loader.
+        #[prototk(2, string)]
+        actual: String,
+    },
+    /// A covering set could not find a macaroon with the required public location and identifier.
+    #[prototk(294917, message)]
+    MissingMacaroon {
+        /// The public location required by a third-party caveat.
+        #[prototk(1, string)]
+        location: String,
+        /// The public identifier required by a third-party caveat.
+        #[prototk(2, string)]
+        identifier: String,
+    },
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Error::Success => write!(fmt, "success"),
+            Error::Cycle => write!(fmt, "cycle detected while verifying macaroon discharges"),
+            Error::ProofInvalid => write!(fmt, "macaroon proof is invalid"),
+            Error::MissingLoader { what } => {
+                write!(fmt, "missing macaroon loader for {what:?}")
+            }
+            Error::LocationMismatch { expected, actual } => write!(
+                fmt,
+                "loader returned macaroon for {actual:?}, expected {expected:?}"
+            ),
+            Error::MissingMacaroon {
+                location,
+                identifier,
+            } => write!(
+                fmt,
+                "missing macaroon for location {location:?} and identifier {identifier:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 ////////////////////////////////////////////// Caveat //////////////////////////////////////////////
 
@@ -176,15 +222,8 @@ mod crypto {
     }
 
     pub fn chained_hmac_n(key: &mut Secret, messages: &[&[u8]]) {
-        let mut intermediaries = Vec::new();
         for message in messages {
-            let mut sig = key.clone();
-            hmac(key, message, &mut sig);
-            intermediaries.push(sig);
-        }
-        let orig = key.clone();
-        for digest in intermediaries.into_iter() {
-            hmac(&orig, &digest.bytes, key);
+            chained_hmac_1(key, message);
         }
     }
 
@@ -246,6 +285,11 @@ pub struct Secret {
 }
 
 impl Secret {
+    /// Construct a [Secret] from raw bytes.
+    pub fn from_bytes(bytes: [u8; SIGNATURE_BYTES]) -> Self {
+        Self { bytes }
+    }
+
     /// A textual representation of the secret.
     pub fn hexdigest(&self) -> String {
         let mut hexdigest = String::with_capacity(2 * SIGNATURE_BYTES);
@@ -330,6 +374,12 @@ impl ThirdPartySecret {
         tps
     }
 
+    /// Create a new [ThirdPartySecret] with a fresh nonce.
+    pub fn random(signature: &Secret, discharge_secret: &Secret) -> Self {
+        let nonce = Secret::random();
+        Self::new(signature, &nonce, discharge_secret)
+    }
+
     /// Scrub the memory locations of the nonce and data.
     pub fn scrub(&mut self) {
         crypto::explicit_bzero(&mut self.nonce);
@@ -370,10 +420,15 @@ pub struct Macaroon {
 
 impl Macaroon {
     /// Mint a new macaroon for the location, identifier, and root secret.
-    pub fn new(location: String, identifier: String, mut secret: Secret) -> Self {
+    pub fn new(
+        location: impl Into<String>,
+        identifier: impl Into<String>,
+        mut secret: Secret,
+    ) -> Self {
+        let identifier = identifier.into();
         crypto::chained_hmac_1(&mut secret, identifier.as_bytes());
         Macaroon {
-            location,
+            location: location.into(),
             identifier,
             signature: secret,
             caveats: Vec::new(),
@@ -397,9 +452,19 @@ impl Macaroon {
         &self.signature
     }
 
+    /// The number of caveats attached to the macaroon.
+    pub fn caveat_count(&self) -> usize {
+        self.caveats.len()
+    }
+
+    /// Returns true if this macaroon has any caveats.
+    pub fn has_caveats(&self) -> bool {
+        !self.caveats.is_empty()
+    }
+
     /// Add a caveat that must match exactly.
-    pub fn add_exact_string(&mut self, what: String) {
-        self.add_caveat(Caveat::ExactString { what });
+    pub fn add_exact_string(&mut self, what: impl Into<String>) {
+        self.add_caveat(Caveat::ExactString { what: what.into() });
     }
 
     /// Add a caveat that expires the macaroon after when.
@@ -411,13 +476,13 @@ impl Macaroon {
     /// identifier and secret.
     pub fn add_third_party_caveat(
         &mut self,
-        location: String,
-        identifier: String,
+        location: impl Into<String>,
+        identifier: impl Into<String>,
         secret: ThirdPartySecret,
     ) {
         self.add_caveat(Caveat::ThirdParty {
-            location,
-            identifier,
+            location: location.into(),
+            identifier: identifier.into(),
             secret,
         });
     }
@@ -426,6 +491,75 @@ impl Macaroon {
     /// contexts.
     pub fn bind_discharge(&self, discharge: &mut Macaroon) {
         crypto::bind_for_request(self, &mut discharge.signature);
+    }
+
+    /// Assemble the transitive discharge cover from `candidates`.
+    ///
+    /// The returned set contains discharge macaroons only, not `self`.  Selection is based only on
+    /// public macaroon data: locations, identifiers, and third-party caveat references.  This does
+    /// not verify signatures, decrypt third-party secrets, or prove that the selected macaroons
+    /// satisfy their caveats; pass the returned set to [Verifier::verify] for that.
+    ///
+    /// If more than one candidate has the same public location and identifier, the first candidate
+    /// is selected because public data cannot distinguish which proof is valid.
+    pub fn covering_set(&self, candidates: &[Macaroon]) -> Result<Vec<Macaroon>, Error> {
+        Ok(self
+            .covering_set_refs(candidates)?
+            .into_iter()
+            .cloned()
+            .collect())
+    }
+
+    /// Assemble the transitive discharge cover from `candidates`, returning references into the
+    /// candidate slice.
+    ///
+    /// See [Macaroon::covering_set] for selection semantics.
+    pub fn covering_set_refs<'a>(
+        &self,
+        candidates: &'a [Macaroon],
+    ) -> Result<Vec<&'a Macaroon>, Error> {
+        let mut cover = Vec::new();
+        let mut queue = VecDeque::new();
+        let mut enqueued = HashSet::new();
+
+        self.enqueue_third_party_requirements(&mut queue, &mut enqueued);
+
+        while let Some((location, identifier)) = queue.pop_front() {
+            let discharge = candidates
+                .iter()
+                .find(|candidate| {
+                    crypto::str_eq(candidate.location(), &location)
+                        && crypto::str_eq(candidate.identifier(), &identifier)
+                })
+                .ok_or_else(|| Error::MissingMacaroon {
+                    location: location.clone(),
+                    identifier: identifier.clone(),
+                })?;
+            discharge.enqueue_third_party_requirements(&mut queue, &mut enqueued);
+            cover.push(discharge);
+        }
+
+        Ok(cover)
+    }
+
+    fn enqueue_third_party_requirements(
+        &self,
+        queue: &mut VecDeque<(String, String)>,
+        enqueued: &mut HashSet<(String, String)>,
+    ) {
+        for caveat in &self.caveats {
+            if let Caveat::ThirdParty {
+                location,
+                identifier,
+                ..
+            } = caveat
+            {
+                let key = (location.clone(), identifier.clone());
+                if enqueued.insert(key.clone()) {
+                    queue.push_back(key);
+                }
+            }
+        }
     }
 
     fn add_caveat(&mut self, caveat: Caveat) {
@@ -504,18 +638,29 @@ impl RequestBuilder {
         self.loaders.insert(loader.location(), Box::new(loader));
     }
 
+    /// Add a loader and return the builder for call chaining.
+    pub fn with_loader<L: Loader + 'static>(mut self, loader: L) -> Self {
+        self.add_loader(loader);
+        self
+    }
+
     /// Prepare a request with the location and identifier provided.
     pub fn prepare_request(
         &self,
         location: &str,
         identifier: &str,
     ) -> Result<(Macaroon, Vec<Macaroon>), Error> {
-        let root = self.get_loader_for(location)?.lookup(identifier)?;
+        let root = self.lookup_macaroon(location, identifier)?;
         let mut discharges = Vec::new();
         let mut queue = VecDeque::new();
-        self.enqueue_discharges(&root, &mut discharges, &mut queue)?;
-        while let Some(macaroon) = discharges.pop() {
-            self.enqueue_discharges(&macaroon, &mut discharges, &mut queue)?;
+        let mut enqueued = HashSet::new();
+        self.enqueue_discharges(&root, &mut discharges, &mut queue, &mut enqueued)?;
+        while let Some(index) = queue.pop_front() {
+            let macaroon = discharges[index].clone();
+            self.enqueue_discharges(&macaroon, &mut discharges, &mut queue, &mut enqueued)?;
+        }
+        for discharge in &mut discharges {
+            root.bind_discharge(discharge);
         }
         Ok((root, discharges))
     }
@@ -530,11 +675,24 @@ impl RequestBuilder {
         }
     }
 
+    fn lookup_macaroon(&self, location: &str, identifier: &str) -> Result<Macaroon, Error> {
+        let macaroon = self.get_loader_for(location)?.lookup(identifier)?;
+        if crypto::str_eq(macaroon.location(), location) {
+            Ok(macaroon)
+        } else {
+            Err(Error::LocationMismatch {
+                expected: location.to_owned(),
+                actual: macaroon.location().to_owned(),
+            })
+        }
+    }
+
     fn enqueue_discharges(
         &self,
         macaroon: &Macaroon,
         discharges: &mut Vec<Macaroon>,
         queue: &mut VecDeque<usize>,
+        enqueued: &mut HashSet<(String, String)>,
     ) -> Result<(), Error> {
         for caveat in macaroon.caveats.iter() {
             if let Caveat::ThirdParty {
@@ -543,9 +701,12 @@ impl RequestBuilder {
                 secret: _,
             } = caveat
             {
-                let discharge = self.get_loader_for(location)?.lookup(identifier)?;
-                queue.push_back(discharges.len());
-                discharges.push(discharge);
+                let key = (location.clone(), identifier.clone());
+                if enqueued.insert(key) {
+                    let discharge = self.lookup_macaroon(location, identifier)?;
+                    queue.push_back(discharges.len());
+                    discharges.push(discharge);
+                }
             }
         }
         Ok(())
@@ -563,15 +724,32 @@ pub struct Verifier {
 }
 
 impl Verifier {
+    /// Create a new verifier.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Add `context` to the context of the request.  Concretely adding a string here means the
     /// client can add a contextual caveat that we will verify.
-    pub fn add_context(&mut self, context: String) {
-        self.contexts.push(context);
+    pub fn add_context(&mut self, context: impl Into<String>) {
+        self.contexts.push(context.into());
+    }
+
+    /// Add `context` and return the verifier for call chaining.
+    pub fn with_context(mut self, context: impl Into<String>) -> Self {
+        self.add_context(context);
+        self
     }
 
     /// Set the time to use for the verifier.
     pub fn set_current_time(&mut self, now: u64) {
         self.now = now;
+    }
+
+    /// Set the time to use and return the verifier for call chaining.
+    pub fn with_current_time(mut self, now: u64) -> Self {
+        self.set_current_time(now);
+        self
     }
 
     /// Verify a macaroon.  Resistant to timing attacks, but quadratic as a result.
@@ -712,7 +890,7 @@ impl Verifier {
 
             let messages = &[
                 identifier.as_bytes(),
-                &secret.nonce[..NONCE_BYTES],
+                &secret.nonce,
                 &secret.box_bytes,
                 &secret.data,
             ];
@@ -728,6 +906,7 @@ impl Verifier {
 mod tests {
     use super::crypto::*;
     use super::*;
+    use buffertk::Unpacker;
 
     #[allow(clippy::assertions_on_constants)]
     #[test]
@@ -756,7 +935,7 @@ mod tests {
     }
 
     #[test]
-    fn test_secretbox_xsalsa20poly1305() {
+    fn secretbox_xsalsa20poly1305_known_vector_round_trips() {
         use super::crypto::*;
 
         let key = [0u8; ZERO_BYTES];
@@ -786,6 +965,103 @@ mod tests {
         assert_eq!(known_plaintext, plaintext);
     }
 
+    #[test]
+    fn chained_hmac_n_uses_every_message() {
+        let mut baseline = SECRET;
+        chained_hmac_n(&mut baseline, &[b"identifier", b"nonce", b"box", b"data"]);
+
+        let mut first_changed = SECRET;
+        chained_hmac_n(
+            &mut first_changed,
+            &[b"other-identifier", b"nonce", b"box", b"data"],
+        );
+        let mut middle_changed = SECRET;
+        chained_hmac_n(
+            &mut middle_changed,
+            &[b"identifier", b"other-nonce", b"box", b"data"],
+        );
+        let mut last_changed = SECRET;
+        chained_hmac_n(
+            &mut last_changed,
+            &[b"identifier", b"nonce", b"box", b"other-data"],
+        );
+
+        assert_ne!(baseline.hexdigest(), first_changed.hexdigest());
+        assert_ne!(baseline.hexdigest(), middle_changed.hexdigest());
+        assert_ne!(baseline.hexdigest(), last_changed.hexdigest());
+    }
+
+    #[test]
+    fn chained_hmac_n_preserves_message_order() {
+        let mut ordered = SECRET;
+        chained_hmac_n(&mut ordered, &[b"identifier", b"nonce", b"box", b"data"]);
+        let mut reordered = SECRET;
+        chained_hmac_n(&mut reordered, &[b"data", b"box", b"nonce", b"identifier"]);
+
+        assert_ne!(ordered.hexdigest(), reordered.hexdigest());
+    }
+
+    #[test]
+    fn error_display_messages_are_actionable() {
+        assert_eq!("success", Error::Success.to_string());
+        assert_eq!(
+            "cycle detected while verifying macaroon discharges",
+            Error::Cycle.to_string()
+        );
+        assert_eq!("macaroon proof is invalid", Error::ProofInvalid.to_string());
+        assert_eq!(
+            "missing macaroon loader for \"http://example.net/auth\"",
+            Error::MissingLoader {
+                what: AUTH_LOCATION.to_owned()
+            }
+            .to_string()
+        );
+        assert_eq!(
+            "loader returned macaroon for \"actual\", expected \"expected\"",
+            Error::LocationMismatch {
+                expected: "expected".to_owned(),
+                actual: "actual".to_owned(),
+            }
+            .to_string()
+        );
+        assert_eq!(
+            "missing macaroon for location \"http://example.net/auth\" and identifier \"bob@example.net\"",
+            Error::MissingMacaroon {
+                location: AUTH_LOCATION.to_owned(),
+                identifier: AUTH_IDENTIFIER.to_owned(),
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn error_round_trips_through_prototk() {
+        let cases = [
+            Error::Success,
+            Error::Cycle,
+            Error::ProofInvalid,
+            Error::MissingLoader {
+                what: AUTH_LOCATION.to_owned(),
+            },
+            Error::LocationMismatch {
+                expected: ROOT_LOCATION.to_owned(),
+                actual: AUTH_LOCATION.to_owned(),
+            },
+            Error::MissingMacaroon {
+                location: AUTH_LOCATION.to_owned(),
+                identifier: AUTH_IDENTIFIER.to_owned(),
+            },
+        ];
+
+        for expected in cases {
+            let buf = stack_pack(&expected).to_vec();
+            let mut unpacker = Unpacker::new(&buf);
+            let got: Error = unpacker.unpack().unwrap();
+            assert_eq!(expected, got);
+            assert!(unpacker.is_empty());
+        }
+    }
+
     const SECRET: Secret = Secret {
         bytes: [
             0x90, 0xcb, 0x0a, 0xc8, 0x5f, 0xd5, 0xad, 0x88, 0x0f, 0xed, 0xf4, 0x4c, 0x2e, 0xac,
@@ -802,6 +1078,14 @@ mod tests {
         ],
     };
 
+    const SECRET3: Secret = Secret {
+        bytes: [
+            0x1c, 0x22, 0x27, 0xe1, 0x3a, 0x3f, 0x40, 0x88, 0x16, 0x9d, 0xe4, 0x1b, 0xad, 0xd7,
+            0x35, 0x02, 0x5f, 0x41, 0x2d, 0x08, 0x4d, 0x0f, 0x4f, 0xde, 0x1b, 0xa9, 0x74, 0xa7,
+            0x3b, 0xcf, 0x3f, 0x82,
+        ],
+    };
+
     const NONCE: Secret = Secret {
         bytes: [
             77, 7, 89, 54, 102, 186, 68, 35, 238, 87, 239, 15, 145, 99, 66, 233, 155, 109, 210,
@@ -809,9 +1093,43 @@ mod tests {
         ],
     };
 
+    const NONCE2: Secret = Secret {
+        bytes: [
+            0x4d, 0xd8, 0x47, 0x17, 0xfe, 0x0c, 0x95, 0x31, 0xc1, 0x49, 0x3f, 0x9e, 0xd0, 0x39,
+            0x49, 0x8e, 0xb7, 0x92, 0x9d, 0xf5, 0xc8, 0x97, 0xc4, 0x37, 0x72, 0x1d, 0xf3, 0x84,
+            0x5c, 0xd9, 0x24, 0xb6,
+        ],
+    };
+
+    const ROOT_LOCATION: &str = "http://example.org/macaroons";
+    const ROOT_IDENTIFIER: &str = "alice@example.org";
+    const AUTH_LOCATION: &str = "http://example.net/auth";
+    const AUTH_IDENTIFIER: &str = "bob@example.net";
+    const NESTED_AUTH_LOCATION: &str = "http://example.com/group-auth";
+    const NESTED_AUTH_IDENTIFIER: &str = "carol@example.com";
+
     fn expect(macaroon: Macaroon, exp: &str) {
         let got = format!("{macaroon:#?}");
         assert_eq!(got.trim(), exp.trim());
+    }
+
+    fn root_macaroon() -> Macaroon {
+        Macaroon::new(ROOT_LOCATION.to_owned(), ROOT_IDENTIFIER.to_owned(), SECRET)
+    }
+
+    fn root_with_third_party_caveat() -> Macaroon {
+        let mut macaroon = root_macaroon();
+        let tps = ThirdPartySecret::new(macaroon.signature(), &NONCE, &SECRET2);
+        macaroon.add_third_party_caveat(AUTH_LOCATION.to_owned(), AUTH_IDENTIFIER.to_owned(), tps);
+        macaroon
+    }
+
+    fn discharge_macaroon() -> Macaroon {
+        Macaroon::new(
+            AUTH_LOCATION.to_owned(),
+            AUTH_IDENTIFIER.to_owned(),
+            SECRET2,
+        )
     }
 
     #[test]
@@ -835,6 +1153,21 @@ signature: 0000000000000000000000000000000000000000000000000000000000000000
             "alice@example.org".to_owned(),
             SECRET,
         );
+        assert_eq!(
+            Macaroon {
+                location: ROOT_LOCATION.to_owned(),
+                identifier: ROOT_IDENTIFIER.to_owned(),
+                signature: Secret {
+                    bytes: [
+                        0xdf, 0x8d, 0x9f, 0x90, 0xd5, 0xf1, 0xa6, 0xa3, 0xc6, 0xaa, 0x89, 0x70,
+                        0x01, 0xec, 0x26, 0xa6, 0x5d, 0x09, 0x69, 0x21, 0x53, 0xeb, 0x40, 0x85,
+                        0x47, 0xbe, 0x5f, 0xb3, 0x8a, 0xc9, 0x08, 0x5b,
+                    ],
+                },
+                caveats: Vec::new(),
+            },
+            macaroon
+        );
         expect(
             macaroon,
             "
@@ -846,8 +1179,128 @@ signature: df8d9f90d5f1a6a3c6aa897001ec26a65d09692153eb408547be5fb38ac9085b
         )
     }
 
+    #[test]
+    fn ergonomic_constructors_accept_borrowed_strings() {
+        let mut macaroon = Macaroon::new(ROOT_LOCATION, ROOT_IDENTIFIER, SECRET);
+
+        assert_eq!(ROOT_LOCATION, macaroon.location());
+        assert_eq!(ROOT_IDENTIFIER, macaroon.identifier());
+        assert_eq!(0, macaroon.caveat_count());
+        assert!(!macaroon.has_caveats());
+
+        macaroon.add_exact_string("ip = 127.0.0.1");
+
+        assert_eq!(1, macaroon.caveat_count());
+        assert!(macaroon.has_caveats());
+    }
+
+    #[test]
+    fn root_location_hint_is_not_signed() {
+        let mut macaroon = root_macaroon();
+        macaroon.location = "http://mirror.example.org/macaroons".to_owned();
+
+        assert_eq!(Ok(()), Verifier::default().verify(&macaroon, &SECRET, &[]));
+    }
+
+    #[test]
+    fn root_identifier_is_signed() {
+        let mut macaroon = root_macaroon();
+        macaroon.identifier = "mallory@example.org".to_owned();
+
+        assert_eq!(
+            Err(Error::ProofInvalid),
+            Verifier::default().verify(&macaroon, &SECRET, &[])
+        );
+    }
+
+    #[test]
+    fn secret_from_bytes_supports_configured_secrets() {
+        let secret = Secret::from_bytes([0xab; SIGNATURE_BYTES]);
+        assert_eq!(
+            "abababababababababababababababababababababababababababababababab",
+            secret.hexdigest()
+        );
+    }
+
+    #[test]
+    fn macaroon_round_trips_through_prototk() {
+        let mut expected = root_macaroon();
+        expected.add_exact_string("role = admin");
+        expected.add_expires(1_900_000_000);
+        let tps = ThirdPartySecret::new(expected.signature(), &NONCE, &SECRET2);
+        expected.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, tps);
+
+        let buf = stack_pack(&expected).to_vec();
+        let mut unpacker = Unpacker::new(&buf);
+        let got: Macaroon = unpacker.unpack().unwrap();
+
+        assert_eq!(expected, got);
+        assert!(unpacker.is_empty());
+    }
+
     mod caveats {
         use super::*;
+
+        #[test]
+        fn default_is_expired_first_party_caveat() {
+            assert_eq!(Caveat::Expires { when: 0 }, Caveat::default());
+        }
+
+        #[test]
+        fn first_and_third_party_classification() {
+            let exact = Caveat::ExactString {
+                what: "ip = 127.0.0.1".to_owned(),
+            };
+            let expires = Caveat::Expires { when: 1693945396 };
+            let third_party = Caveat::ThirdParty {
+                location: AUTH_LOCATION.to_owned(),
+                identifier: AUTH_IDENTIFIER.to_owned(),
+                secret: ThirdPartySecret::new(&root_macaroon().signature, &NONCE, &SECRET2),
+            };
+
+            assert!(exact.is_first_party());
+            assert!(!exact.is_third_party());
+            assert!(expires.is_first_party());
+            assert!(!expires.is_third_party());
+            assert!(!third_party.is_first_party());
+            assert!(third_party.is_third_party());
+        }
+
+        #[test]
+        fn exact_string_round_trips_through_prototk() {
+            let expected = Caveat::ExactString {
+                what: "role = admin".to_owned(),
+            };
+            let buf = stack_pack(&expected).to_vec();
+            let mut unpacker = Unpacker::new(&buf);
+            let got: Caveat = unpacker.unpack().unwrap();
+            assert_eq!(expected, got);
+            assert!(unpacker.is_empty());
+        }
+
+        #[test]
+        fn expires_round_trips_through_prototk() {
+            let expected = Caveat::Expires { when: u64::MAX };
+            let buf = stack_pack(&expected).to_vec();
+            let mut unpacker = Unpacker::new(&buf);
+            let got: Caveat = unpacker.unpack().unwrap();
+            assert_eq!(expected, got);
+            assert!(unpacker.is_empty());
+        }
+
+        #[test]
+        fn third_party_round_trips_through_prototk() {
+            let expected = Caveat::ThirdParty {
+                location: AUTH_LOCATION.to_owned(),
+                identifier: AUTH_IDENTIFIER.to_owned(),
+                secret: ThirdPartySecret::new(&root_macaroon().signature, &NONCE, &SECRET2),
+            };
+            let buf = stack_pack(&expected).to_vec();
+            let mut unpacker = Unpacker::new(&buf);
+            let got: Caveat = unpacker.unpack().unwrap();
+            assert_eq!(expected, got);
+            assert!(unpacker.is_empty());
+        }
 
         #[test]
         fn exact_string() {
@@ -857,6 +1310,23 @@ signature: df8d9f90d5f1a6a3c6aa897001ec26a65d09692153eb408547be5fb38ac9085b
                 SECRET,
             );
             macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
+            assert_eq!(
+                Macaroon {
+                    location: ROOT_LOCATION.to_owned(),
+                    identifier: ROOT_IDENTIFIER.to_owned(),
+                    signature: Secret {
+                        bytes: [
+                            0x6c, 0x85, 0xbc, 0x5f, 0xc9, 0x15, 0x84, 0x31, 0xcf, 0x2e, 0x6f, 0xce,
+                            0x5f, 0xc9, 0xa0, 0x7f, 0x85, 0x9e, 0x86, 0x6e, 0x6a, 0xc8, 0xbd, 0xce,
+                            0xed, 0x3b, 0x34, 0x2b, 0x34, 0xf2, 0xfd, 0x86,
+                        ],
+                    },
+                    caveats: vec![Caveat::ExactString {
+                        what: "ip = 127.0.0.1".to_owned(),
+                    }],
+                },
+                macaroon
+            );
             expect(
                 macaroon,
                 "
@@ -877,6 +1347,21 @@ exact-string: what=\"ip = 127.0.0.1\"
                 SECRET,
             );
             macaroon.add_expires(1693945396);
+            assert_eq!(
+                Macaroon {
+                    location: ROOT_LOCATION.to_owned(),
+                    identifier: ROOT_IDENTIFIER.to_owned(),
+                    signature: Secret {
+                        bytes: [
+                            0x46, 0xba, 0x0d, 0x66, 0x77, 0xfd, 0xf7, 0xbe, 0x67, 0x16, 0x7f, 0x27,
+                            0x9e, 0xb4, 0x1a, 0x34, 0x71, 0xf7, 0xb8, 0x99, 0xe7, 0xcf, 0x55, 0x42,
+                            0xff, 0x9b, 0xbd, 0xd0, 0xbb, 0xed, 0x2f, 0x02,
+                        ],
+                    },
+                    caveats: vec![Caveat::Expires { when: 1693945396 }],
+                },
+                macaroon
+            );
             expect(
                 macaroon,
                 "
@@ -902,16 +1387,186 @@ expires: when=1693945396
                 "bob@example.net".to_owned(),
                 tps,
             );
+            assert_eq!(
+                Macaroon {
+                    location: ROOT_LOCATION.to_owned(),
+                    identifier: ROOT_IDENTIFIER.to_owned(),
+                    signature: Secret {
+                        bytes: [
+                            0x5b, 0x35, 0x2e, 0x0a, 0x04, 0x49, 0x7d, 0x12, 0x87, 0xc2, 0xdd, 0xd6,
+                            0x4d, 0xb6, 0x67, 0x61, 0xa4, 0xe8, 0x67, 0x74, 0xcc, 0x14, 0x5b, 0xcf,
+                            0x63, 0x63, 0x9c, 0xb8, 0x13, 0x43, 0x26, 0x6c,
+                        ],
+                    },
+                    caveats: vec![Caveat::ThirdParty {
+                        location: AUTH_LOCATION.to_owned(),
+                        identifier: AUTH_IDENTIFIER.to_owned(),
+                        secret: ThirdPartySecret::new(&root_macaroon().signature, &NONCE, &SECRET2),
+                    }],
+                },
+                macaroon
+            );
             expect(
                 macaroon,
                 "
 location: http://example.org/macaroons
 identifier: alice@example.org
-signature: f9933abf18be79303ff46a0cf1ab5eb15c886932303f7c2b2217b734c97d79d1
+signature: 5b352e0a04497d1287c2ddd64db66761a4e86774cc145bcf63639cb81343266c
 1 caveat
 third-party: location=http://example.net/auth identifier=bob@example.net
 ",
             )
+        }
+
+        #[test]
+        fn third_party_random_generates_a_usable_secret() {
+            let mut macaroon = root_macaroon();
+            let tps = ThirdPartySecret::random(macaroon.signature(), &SECRET2);
+            macaroon.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, tps);
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            let verifier = Verifier::default();
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[discharge]));
+        }
+    }
+
+    mod covering_set {
+        use super::*;
+
+        #[test]
+        fn no_third_party_caveats_returns_empty_cover() {
+            let root = root_macaroon();
+            let candidates = vec![discharge_macaroon()];
+
+            assert_eq!(Ok(Vec::<Macaroon>::new()), root.covering_set(&candidates));
+            assert_eq!(
+                Ok(Vec::<&Macaroon>::new()),
+                root.covering_set_refs(&candidates)
+            );
+        }
+
+        #[test]
+        fn missing_discharge_is_reported_by_public_identity() {
+            let root = root_with_third_party_caveat();
+
+            assert_eq!(
+                Err(Error::MissingMacaroon {
+                    location: AUTH_LOCATION.to_owned(),
+                    identifier: AUTH_IDENTIFIER.to_owned(),
+                }),
+                root.covering_set(&[])
+            );
+        }
+
+        #[test]
+        fn refs_are_returned_from_candidate_slice() {
+            let root = root_with_third_party_caveat();
+            let noise = Macaroon::new(
+                "http://noise.example.invalid",
+                "noise@example.invalid",
+                SECRET,
+            );
+            let mut discharge = discharge_macaroon();
+            root.bind_discharge(&mut discharge);
+            let candidates = vec![noise, discharge];
+
+            let cover = root.covering_set_refs(&candidates).unwrap();
+
+            assert_eq!(vec![&candidates[1]], cover);
+            assert!(std::ptr::eq(&candidates[1], cover[0]));
+        }
+
+        #[test]
+        fn duplicate_public_identities_select_first_candidate() {
+            let root = root_with_third_party_caveat();
+            let mut first_candidate = Macaroon::new(AUTH_LOCATION, AUTH_IDENTIFIER, SECRET3);
+            first_candidate.add_exact_string("candidate = first");
+            let mut second_candidate = discharge_macaroon();
+            root.bind_discharge(&mut second_candidate);
+            let candidates = vec![first_candidate.clone(), second_candidate];
+
+            assert_eq!(Ok(vec![first_candidate]), root.covering_set(&candidates));
+        }
+
+        #[test]
+        fn duplicate_third_party_caveats_share_one_discharge() {
+            let mut root = root_macaroon();
+            let first_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, first_secret);
+            let second_secret = ThirdPartySecret::new(root.signature(), &NONCE2, &SECRET2);
+            root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, second_secret);
+            let mut discharge = discharge_macaroon();
+            root.bind_discharge(&mut discharge);
+            let candidates = vec![discharge.clone()];
+
+            assert_eq!(Ok(vec![discharge]), root.covering_set(&candidates));
+        }
+
+        #[test]
+        fn nested_discharges_are_selected_from_many_candidates() {
+            let mut root = root_macaroon();
+            let root_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, root_secret);
+            let mut first_discharge = discharge_macaroon();
+            let nested_secret =
+                ThirdPartySecret::new(first_discharge.signature(), &NONCE2, &SECRET3);
+            first_discharge.add_third_party_caveat(
+                NESTED_AUTH_LOCATION,
+                NESTED_AUTH_IDENTIFIER,
+                nested_secret,
+            );
+            let second_discharge =
+                Macaroon::new(NESTED_AUTH_LOCATION, NESTED_AUTH_IDENTIFIER, SECRET3);
+
+            let mut expected_first = first_discharge;
+            let mut expected_second = second_discharge;
+            root.bind_discharge(&mut expected_first);
+            root.bind_discharge(&mut expected_second);
+            let noise = Macaroon::new(
+                "http://noise.example.invalid",
+                "noise@example.invalid",
+                SECRET,
+            );
+            let candidates = vec![
+                noise.clone(),
+                expected_second.clone(),
+                expected_first.clone(),
+                noise,
+            ];
+
+            let cover = root.covering_set(&candidates);
+
+            assert_eq!(
+                Ok(vec![expected_first.clone(), expected_second.clone()]),
+                cover
+            );
+            assert_eq!(
+                Ok(()),
+                Verifier::default().verify(&root, &SECRET, &[expected_first, expected_second])
+            );
+        }
+
+        #[test]
+        fn nested_missing_discharge_reports_nested_identity() {
+            let mut root = root_macaroon();
+            let root_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, root_secret);
+            let mut first_discharge = discharge_macaroon();
+            let nested_secret =
+                ThirdPartySecret::new(first_discharge.signature(), &NONCE2, &SECRET3);
+            first_discharge.add_third_party_caveat(
+                NESTED_AUTH_LOCATION,
+                NESTED_AUTH_IDENTIFIER,
+                nested_secret,
+            );
+
+            assert_eq!(
+                Err(Error::MissingMacaroon {
+                    location: NESTED_AUTH_LOCATION.to_owned(),
+                    identifier: NESTED_AUTH_IDENTIFIER.to_owned(),
+                }),
+                root.covering_set(&[first_discharge])
+            );
         }
     }
 
@@ -928,7 +1583,86 @@ third-party: location=http://example.net/auth identifier=bob@example.net
             macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
             let mut verifier = Verifier::default();
             verifier.add_context("ip = 127.0.0.1".to_owned());
-            assert!(verifier.verify(&macaroon, &SECRET, &[]).is_ok());
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+        }
+
+        #[test]
+        fn fluent_context_and_time_setup() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("ip = 127.0.0.1");
+            macaroon.add_expires(1693945396);
+            let verifier = Verifier::new()
+                .with_context("ip = 127.0.0.1")
+                .with_current_time(1693945395);
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+        }
+
+        #[test]
+        fn exact_string_rejects_missing_context() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+        }
+
+        #[test]
+        fn exact_string_rejects_non_exact_context() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
+            let mut verifier = Verifier::default();
+            verifier.add_context("ip = 127.0.0.1 ".to_owned());
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+        }
+
+        #[test]
+        fn exact_string_accepts_matching_context_among_others() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
+            let mut verifier = Verifier::default();
+            verifier.add_context("role = admin".to_owned());
+            verifier.add_context("ip = 127.0.0.1".to_owned());
+            verifier.add_context("method = GET".to_owned());
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+        }
+
+        #[test]
+        fn caveat_order_is_signed() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("method = GET");
+            macaroon.add_exact_string("path = /v1/files");
+            let verifier = Verifier::new()
+                .with_context("method = GET")
+                .with_context("path = /v1/files");
+
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+
+            macaroon.caveats.swap(0, 1);
+
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+        }
+
+        #[test]
+        fn exact_string_rejects_tampered_caveat() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_exact_string("ip = 127.0.0.1".to_owned());
+            macaroon.caveats[0] = Caveat::ExactString {
+                what: "ip = 127.0.0.2".to_owned(),
+            };
+            let mut verifier = Verifier::default();
+            verifier.add_context("ip = 127.0.0.2".to_owned());
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
         }
 
         #[test]
@@ -942,18 +1676,46 @@ third-party: location=http://example.net/auth identifier=bob@example.net
             macaroon.add_expires(NOW);
             let mut verifier = Verifier::default();
             verifier.set_current_time(NOW);
-            assert!(verifier.verify(&macaroon, &SECRET, &[]).is_err());
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
             verifier.set_current_time(NOW - 1);
-            assert!(verifier.verify(&macaroon, &SECRET, &[]).is_ok());
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+            verifier.set_current_time(NOW + 1);
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+        }
+
+        #[test]
+        fn expires_accepts_u64_max_until_time_reaches_it() {
+            let mut macaroon = root_macaroon();
+            macaroon.add_expires(u64::MAX);
+            let mut verifier = Verifier::default();
+            verifier.set_current_time(u64::MAX - 1);
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[]));
+            verifier.set_current_time(u64::MAX);
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+        }
+
+        #[test]
+        fn proof_invalid_for_wrong_root_secret() {
+            let macaroon = root_macaroon();
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET2, &[])
+            );
         }
 
         #[test]
         fn third_party() {
-            let mut macaroon = Macaroon::new(
-                "http://example.org/macaroons".to_owned(),
-                "alice@example.org".to_owned(),
-                SECRET,
-            );
+            let mut macaroon = root_macaroon();
             assert_eq!(
                 &[
                     0xdf, 0x8d, 0x9f, 0x90, 0xd5, 0xf1, 0xa6, 0xa3, 0xc6, 0xaa, 0x89, 0x70, 0x1,
@@ -968,15 +1730,1023 @@ third-party: location=http://example.net/auth identifier=bob@example.net
                 "bob@example.net".to_owned(),
                 tps,
             );
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[])
+            );
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[discharge]));
+        }
+
+        #[test]
+        fn third_party_rejects_unbound_discharge() {
+            let macaroon = root_with_third_party_caveat();
+            let discharge = discharge_macaroon();
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_wrong_discharge_identifier() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = Macaroon::new(AUTH_LOCATION, NESTED_AUTH_IDENTIFIER, SECRET2);
+            macaroon.bind_discharge(&mut discharge);
+            let verifier = Verifier::default();
+
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_wrong_discharge_secret() {
+            let macaroon = root_with_third_party_caveat();
             let mut discharge = Macaroon::new(
-                "http://example.net/auth".to_owned(),
-                "bob@example.net".to_owned(),
-                SECRET2,
+                AUTH_LOCATION.to_owned(),
+                AUTH_IDENTIFIER.to_owned(),
+                SECRET3,
             );
             macaroon.bind_discharge(&mut discharge);
             let verifier = Verifier::default();
-            assert!(verifier.verify(&macaroon, &SECRET, &[]).is_err());
-            assert!(verifier.verify(&macaroon, &SECRET, &[discharge]).is_ok());
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_tampered_secret_nonce_tail() {
+            let mut macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            if let Caveat::ThirdParty { secret, .. } = &mut macaroon.caveats[0] {
+                secret.nonce[NONCE_BYTES] ^= 0xff;
+            }
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_tampered_secret_box_bytes() {
+            let mut macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            if let Caveat::ThirdParty { secret, .. } = &mut macaroon.caveats[0] {
+                secret.box_bytes[0] ^= 0xff;
+            }
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_tampered_secret_data() {
+            let mut macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            if let Caveat::ThirdParty { secret, .. } = &mut macaroon.caveats[0] {
+                secret.data[0] ^= 0xff;
+            }
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_bound_to_one_root_rejects_other_root() {
+            let mut first_root = root_macaroon();
+            let first_secret = ThirdPartySecret::new(first_root.signature(), &NONCE, &SECRET2);
+            first_root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, first_secret);
+
+            let mut second_root = root_macaroon();
+            second_root.add_exact_string("method = GET");
+            let second_secret = ThirdPartySecret::new(second_root.signature(), &NONCE2, &SECRET2);
+            second_root.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, second_secret);
+
+            let mut discharge = discharge_macaroon();
+            first_root.bind_discharge(&mut discharge);
+            let verifier = Verifier::new().with_context("method = GET");
+
+            assert_eq!(
+                Ok(()),
+                verifier.verify(&first_root, &SECRET, &[discharge.clone()])
+            );
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&second_root, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_caveat_location_hint_is_not_signed() {
+            let mut macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            if let Caveat::ThirdParty { location, .. } = &mut macaroon.caveats[0] {
+                *location = "http://mirror.example.net/auth".to_owned();
+            }
+
+            assert_eq!(
+                Ok(()),
+                Verifier::default().verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_discharge_location_hint_is_not_signed() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            discharge.location = "http://mirror.example.net/auth".to_owned();
+
+            assert_eq!(
+                Ok(()),
+                Verifier::default().verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_ignores_unrelated_discharges() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            macaroon.bind_discharge(&mut discharge);
+            let mut unrelated =
+                Macaroon::new(NESTED_AUTH_LOCATION, NESTED_AUTH_IDENTIFIER, SECRET3);
+            unrelated.add_exact_string("group = admin");
+
+            assert_eq!(
+                Ok(()),
+                Verifier::default().verify(&macaroon, &SECRET, &[unrelated, discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_accepts_multiple_discharges_in_any_order() {
+            let mut macaroon = root_macaroon();
+            let first_secret = ThirdPartySecret::new(macaroon.signature(), &NONCE, &SECRET2);
+            macaroon.add_third_party_caveat(AUTH_LOCATION, AUTH_IDENTIFIER, first_secret);
+            let second_secret = ThirdPartySecret::new(macaroon.signature(), &NONCE2, &SECRET3);
+            macaroon.add_third_party_caveat(
+                NESTED_AUTH_LOCATION,
+                NESTED_AUTH_IDENTIFIER,
+                second_secret,
+            );
+            let mut first_discharge = discharge_macaroon();
+            let mut second_discharge =
+                Macaroon::new(NESTED_AUTH_LOCATION, NESTED_AUTH_IDENTIFIER, SECRET3);
+            macaroon.bind_discharge(&mut first_discharge);
+            macaroon.bind_discharge(&mut second_discharge);
+            let verifier = Verifier::default();
+
+            assert_eq!(
+                Ok(()),
+                verifier.verify(
+                    &macaroon,
+                    &SECRET,
+                    &[first_discharge.clone(), second_discharge.clone()]
+                )
+            );
+            assert_eq!(
+                Ok(()),
+                verifier.verify(&macaroon, &SECRET, &[second_discharge, first_discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_accepts_discharge_with_satisfied_first_party_caveat() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            discharge.add_exact_string("group = admin".to_owned());
+            macaroon.bind_discharge(&mut discharge);
+            let mut verifier = Verifier::default();
+            verifier.add_context("group = admin".to_owned());
+            assert_eq!(Ok(()), verifier.verify(&macaroon, &SECRET, &[discharge]));
+        }
+
+        #[test]
+        fn third_party_rejects_tampered_discharge_caveat() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            discharge.add_exact_string("group = admin");
+            macaroon.bind_discharge(&mut discharge);
+            discharge.caveats[0] = Caveat::ExactString {
+                what: "group = owner".to_owned(),
+            };
+            let verifier = Verifier::new().with_context("group = owner");
+
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+
+        #[test]
+        fn third_party_rejects_discharge_with_unsatisfied_first_party_caveat() {
+            let macaroon = root_with_third_party_caveat();
+            let mut discharge = discharge_macaroon();
+            discharge.add_exact_string("group = admin".to_owned());
+            macaroon.bind_discharge(&mut discharge);
+            let verifier = Verifier::default();
+            assert_eq!(
+                Err(Error::ProofInvalid),
+                verifier.verify(&macaroon, &SECRET, &[discharge])
+            );
+        }
+    }
+
+    mod request_builder {
+        use super::*;
+
+        #[derive(Clone, Debug)]
+        struct StaticLoader {
+            location: &'static str,
+            macaroons: Vec<Macaroon>,
+        }
+
+        impl StaticLoader {
+            fn new(location: &'static str, macaroons: Vec<Macaroon>) -> Self {
+                Self {
+                    location,
+                    macaroons,
+                }
+            }
+        }
+
+        impl Loader for StaticLoader {
+            fn location(&self) -> &'static str {
+                self.location
+            }
+
+            fn lookup(&self, identifier: &str) -> Result<Macaroon, Error> {
+                for macaroon in &self.macaroons {
+                    if crypto::str_eq(macaroon.identifier(), identifier) {
+                        return Ok(macaroon.clone());
+                    }
+                }
+                Err(Error::MissingLoader {
+                    what: format!("{}/{}", self.location, identifier),
+                })
+            }
+        }
+
+        fn request_builder_with_root(root: Macaroon) -> RequestBuilder {
+            let mut builder = RequestBuilder::new();
+            builder.add_loader(StaticLoader::new(ROOT_LOCATION, vec![root]));
+            builder
+        }
+
+        #[test]
+        fn missing_root_loader() {
+            let builder = RequestBuilder::new();
+            assert_eq!(
+                Err(Error::MissingLoader {
+                    what: ROOT_LOCATION.to_owned(),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn rejects_loader_location_mismatch() {
+            let wrong_location = Macaroon::new(
+                "http://wrong.example.org/macaroons".to_owned(),
+                ROOT_IDENTIFIER.to_owned(),
+                SECRET,
+            );
+            let builder = request_builder_with_root(wrong_location);
+            assert_eq!(
+                Err(Error::LocationMismatch {
+                    expected: ROOT_LOCATION.to_owned(),
+                    actual: "http://wrong.example.org/macaroons".to_owned(),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn request_without_third_party_caveats_returns_root_only() {
+            let root = root_macaroon();
+            let builder = request_builder_with_root(root.clone());
+            assert_eq!(
+                Ok((root, Vec::new())),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn fluent_loader_setup() {
+            let root = root_macaroon();
+            let builder = RequestBuilder::new()
+                .with_loader(StaticLoader::new(ROOT_LOCATION, vec![root.clone()]));
+            assert_eq!(
+                Ok((root, Vec::new())),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn single_third_party_missing_loader_is_reported() {
+            let root = root_with_third_party_caveat();
+            let builder = request_builder_with_root(root);
+
+            assert_eq!(
+                Err(Error::MissingLoader {
+                    what: AUTH_LOCATION.to_owned(),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn discharge_lookup_error_is_returned() {
+            let root = root_with_third_party_caveat();
+            let mut builder = request_builder_with_root(root);
+            builder.add_loader(StaticLoader::new(AUTH_LOCATION, Vec::new()));
+
+            assert_eq!(
+                Err(Error::MissingLoader {
+                    what: format!("{AUTH_LOCATION}/{AUTH_IDENTIFIER}"),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn rejects_discharge_loader_location_mismatch() {
+            let root = root_with_third_party_caveat();
+            let wrong_location = "http://wrong.example.net/auth";
+            let wrong_discharge = Macaroon::new(wrong_location, AUTH_IDENTIFIER, SECRET2);
+            let mut builder = request_builder_with_root(root);
+            builder.add_loader(StaticLoader::new(AUTH_LOCATION, vec![wrong_discharge]));
+
+            assert_eq!(
+                Err(Error::LocationMismatch {
+                    expected: AUTH_LOCATION.to_owned(),
+                    actual: wrong_location.to_owned(),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn single_third_party_caveat_returns_bound_discharge() {
+            let root = root_with_third_party_caveat();
+            let discharge = discharge_macaroon();
+            let mut builder = request_builder_with_root(root.clone());
+            builder.add_loader(StaticLoader::new(AUTH_LOCATION, vec![discharge.clone()]));
+            let mut expected_discharge = discharge;
+            root.bind_discharge(&mut expected_discharge);
+            assert_eq!(
+                Ok((root.clone(), vec![expected_discharge.clone()])),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+            let verifier = Verifier::default();
+            assert_eq!(
+                Ok(()),
+                verifier.verify(&root, &SECRET, &[expected_discharge])
+            );
+        }
+
+        #[test]
+        fn nested_third_party_caveats_are_loaded_and_bound() {
+            let mut root = root_macaroon();
+            let root_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(
+                AUTH_LOCATION.to_owned(),
+                AUTH_IDENTIFIER.to_owned(),
+                root_secret,
+            );
+            let mut first_discharge = discharge_macaroon();
+            let nested_secret =
+                ThirdPartySecret::new(first_discharge.signature(), &NONCE2, &SECRET3);
+            first_discharge.add_third_party_caveat(
+                NESTED_AUTH_LOCATION.to_owned(),
+                NESTED_AUTH_IDENTIFIER.to_owned(),
+                nested_secret,
+            );
+            let second_discharge = Macaroon::new(
+                NESTED_AUTH_LOCATION.to_owned(),
+                NESTED_AUTH_IDENTIFIER.to_owned(),
+                SECRET3,
+            );
+
+            let mut builder = request_builder_with_root(root.clone());
+            builder.add_loader(StaticLoader::new(
+                AUTH_LOCATION,
+                vec![first_discharge.clone()],
+            ));
+            builder.add_loader(StaticLoader::new(
+                NESTED_AUTH_LOCATION,
+                vec![second_discharge.clone()],
+            ));
+
+            let mut expected_first = first_discharge;
+            let mut expected_second = second_discharge;
+            root.bind_discharge(&mut expected_first);
+            root.bind_discharge(&mut expected_second);
+            let expected_discharges = vec![expected_first, expected_second];
+
+            assert_eq!(
+                Ok((root.clone(), expected_discharges.clone())),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+            let verifier = Verifier::default();
+            assert_eq!(
+                Ok(()),
+                verifier.verify(&root, &SECRET, &expected_discharges)
+            );
+        }
+
+        #[test]
+        fn nested_third_party_missing_loader_is_reported() {
+            let mut root = root_macaroon();
+            let root_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(
+                AUTH_LOCATION.to_owned(),
+                AUTH_IDENTIFIER.to_owned(),
+                root_secret,
+            );
+            let mut first_discharge = discharge_macaroon();
+            let nested_secret =
+                ThirdPartySecret::new(first_discharge.signature(), &NONCE2, &SECRET3);
+            first_discharge.add_third_party_caveat(
+                NESTED_AUTH_LOCATION.to_owned(),
+                NESTED_AUTH_IDENTIFIER.to_owned(),
+                nested_secret,
+            );
+
+            let mut builder = request_builder_with_root(root);
+            builder.add_loader(StaticLoader::new(AUTH_LOCATION, vec![first_discharge]));
+
+            assert_eq!(
+                Err(Error::MissingLoader {
+                    what: NESTED_AUTH_LOCATION.to_owned(),
+                }),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+        }
+
+        #[test]
+        fn duplicate_third_party_caveats_share_one_bound_discharge() {
+            let mut root = root_macaroon();
+            let first_secret = ThirdPartySecret::new(root.signature(), &NONCE, &SECRET2);
+            root.add_third_party_caveat(
+                AUTH_LOCATION.to_owned(),
+                AUTH_IDENTIFIER.to_owned(),
+                first_secret,
+            );
+            let second_secret = ThirdPartySecret::new(root.signature(), &NONCE2, &SECRET2);
+            root.add_third_party_caveat(
+                AUTH_LOCATION.to_owned(),
+                AUTH_IDENTIFIER.to_owned(),
+                second_secret,
+            );
+            let discharge = discharge_macaroon();
+            let mut builder = request_builder_with_root(root.clone());
+            builder.add_loader(StaticLoader::new(AUTH_LOCATION, vec![discharge.clone()]));
+
+            let mut expected_discharge = discharge;
+            root.bind_discharge(&mut expected_discharge);
+            let expected_discharges = vec![expected_discharge];
+
+            assert_eq!(
+                Ok((root.clone(), expected_discharges.clone())),
+                builder.prepare_request(ROOT_LOCATION, ROOT_IDENTIFIER)
+            );
+            let verifier = Verifier::default();
+            assert_eq!(
+                Ok(()),
+                verifier.verify(&root, &SECRET, &expected_discharges)
+            );
+        }
+    }
+
+    mod generated_proofs {
+        use super::*;
+        use proptest::prelude::*;
+
+        const MAX_GENERATED_CAVEATS: usize = 4;
+        const MAX_GENERATED_DEPTH: usize = 3;
+        const MAX_GENERATED_MACAROONS: usize = 64;
+        const PROPERTY_NOW: u64 = 1_000_000;
+
+        #[derive(Clone)]
+        struct GeneratedProof {
+            root: GeneratedNode,
+            node_count: usize,
+            max_depth: usize,
+            max_caveats: usize,
+        }
+
+        #[derive(Clone)]
+        struct GeneratedNode {
+            location: String,
+            identifier: String,
+            secret: Secret,
+            caveats: Vec<GeneratedCaveat>,
+        }
+
+        #[derive(Clone)]
+        enum GeneratedCaveat {
+            ExactString {
+                what: String,
+            },
+            Expires {
+                when: u64,
+            },
+            ThirdParty {
+                nonce: Secret,
+                child: Box<GeneratedNode>,
+            },
+        }
+
+        #[derive(Clone)]
+        struct BuiltGeneratedProof {
+            root: Macaroon,
+            root_secret: Secret,
+            discharges: Vec<Macaroon>,
+        }
+
+        #[derive(Clone, Copy, Debug)]
+        enum RejectScenario {
+            WrongRootSecret,
+            MissingContext,
+            Expired,
+            MissingDischarge,
+            TamperedRootSignature,
+            TamperedDischargeSignature,
+        }
+
+        struct Entropy {
+            bytes: Vec<u8>,
+            index: usize,
+        }
+
+        impl Entropy {
+            fn new(mut bytes: Vec<u8>) -> Self {
+                if bytes.is_empty() {
+                    bytes.push(0);
+                }
+                Self { bytes, index: 0 }
+            }
+
+            fn next(&mut self) -> u8 {
+                let byte = self.bytes[self.index % self.bytes.len()];
+                self.index += 1;
+                byte
+            }
+
+            fn choice(&mut self, upper: usize) -> usize {
+                if upper == 0 {
+                    0
+                } else {
+                    usize::from(self.next()) % upper
+                }
+            }
+
+            fn secret(&mut self, label: u8, id: usize) -> Secret {
+                let mut bytes = [0u8; SIGNATURE_BYTES];
+                for (offset, byte) in bytes.iter_mut().enumerate() {
+                    *byte = self
+                        .next()
+                        .wrapping_add(label)
+                        .wrapping_add((id as u8).wrapping_mul(31))
+                        .wrapping_add(offset as u8);
+                }
+                Secret { bytes }
+            }
+        }
+
+        struct GeneratedState {
+            entropy: Entropy,
+            node_count: usize,
+            max_depth: usize,
+            max_caveats: usize,
+        }
+
+        impl GeneratedState {
+            fn new(bytes: Vec<u8>) -> Self {
+                Self {
+                    entropy: Entropy::new(bytes),
+                    node_count: 0,
+                    max_depth: 0,
+                    max_caveats: 0,
+                }
+            }
+
+            fn node(&mut self, depth: usize) -> GeneratedNode {
+                let id = self.node_count;
+                self.node_count += 1;
+                self.max_depth = self.max_depth.max(depth);
+
+                let location = format!("generated-location-{id}");
+                let identifier = format!("generated-identifier-{id}");
+                let secret = self.entropy.secret(0xa5, id);
+                let caveat_count = self.entropy.choice(MAX_GENERATED_CAVEATS + 1);
+                self.max_caveats = self.max_caveats.max(caveat_count);
+
+                let mut caveats = Vec::with_capacity(caveat_count);
+                for caveat_idx in 0..caveat_count {
+                    let can_add_child =
+                        depth < MAX_GENERATED_DEPTH && self.node_count < MAX_GENERATED_MACAROONS;
+                    match self.entropy.choice(if can_add_child { 3 } else { 2 }) {
+                        0 => caveats.push(GeneratedCaveat::ExactString {
+                            what: format!(
+                                "generated-context-{id}-{caveat_idx}-{}",
+                                self.entropy.next()
+                            ),
+                        }),
+                        1 => caveats.push(GeneratedCaveat::Expires {
+                            when: PROPERTY_NOW
+                                + 1
+                                + self.entropy.choice(256) as u64
+                                + id as u64
+                                + caveat_idx as u64,
+                        }),
+                        _ => {
+                            let nonce = self
+                                .entropy
+                                .secret(0x5a, id * MAX_GENERATED_CAVEATS + caveat_idx);
+                            let child = Box::new(self.node(depth + 1));
+                            caveats.push(GeneratedCaveat::ThirdParty { nonce, child });
+                        }
+                    }
+                }
+
+                GeneratedNode {
+                    location,
+                    identifier,
+                    secret,
+                    caveats,
+                }
+            }
+        }
+
+        impl GeneratedProof {
+            fn from_entropy(bytes: Vec<u8>) -> Self {
+                let mut state = GeneratedState::new(bytes);
+                let root = state.node(0);
+                Self {
+                    root,
+                    node_count: state.node_count,
+                    max_depth: state.max_depth,
+                    max_caveats: state.max_caveats,
+                }
+            }
+
+            fn build(&self) -> BuiltGeneratedProof {
+                let (root, mut discharges) = self.root.build();
+                for discharge in &mut discharges {
+                    root.bind_discharge(discharge);
+                }
+                BuiltGeneratedProof {
+                    root,
+                    root_secret: self.root.secret.clone(),
+                    discharges,
+                }
+            }
+
+            fn verifier(&self, now: u64, skip_context: Option<&str>) -> Verifier {
+                let mut verifier = Verifier::default();
+                verifier.set_current_time(now);
+                self.root.add_contexts(&mut verifier, skip_context);
+                verifier
+            }
+
+            fn verify(
+                &self,
+                root: &Macaroon,
+                root_secret: &Secret,
+                discharges: &[Macaroon],
+                now: u64,
+                skip_context: Option<&str>,
+            ) -> Result<(), Error> {
+                self.verifier(now, skip_context)
+                    .verify(root, root_secret, discharges)
+            }
+
+            fn verify_built(&self, built: &BuiltGeneratedProof) -> Result<(), Error> {
+                self.verify(
+                    &built.root,
+                    &built.root_secret,
+                    &built.discharges,
+                    PROPERTY_NOW,
+                    None,
+                )
+            }
+
+            fn reject_result(
+                &self,
+                built: &BuiltGeneratedProof,
+                scenario: RejectScenario,
+            ) -> Result<(), Error> {
+                match scenario {
+                    RejectScenario::WrongRootSecret => self.verify(
+                        &built.root,
+                        &different_secret(&built.root_secret),
+                        &built.discharges,
+                        PROPERTY_NOW,
+                        None,
+                    ),
+                    RejectScenario::MissingContext => {
+                        if let Some(context) = self.root.first_context() {
+                            self.verify(
+                                &built.root,
+                                &built.root_secret,
+                                &built.discharges,
+                                PROPERTY_NOW,
+                                Some(&context),
+                            )
+                        } else {
+                            self.tampered_root_signature_result(built)
+                        }
+                    }
+                    RejectScenario::Expired => {
+                        if let Some(when) = self.root.first_expiration() {
+                            self.verify(
+                                &built.root,
+                                &built.root_secret,
+                                &built.discharges,
+                                when,
+                                None,
+                            )
+                        } else {
+                            self.tampered_root_signature_result(built)
+                        }
+                    }
+                    RejectScenario::MissingDischarge => {
+                        if built.discharges.is_empty() {
+                            self.tampered_root_signature_result(built)
+                        } else {
+                            let mut discharges = built.discharges.clone();
+                            discharges.remove(0);
+                            self.verify(
+                                &built.root,
+                                &built.root_secret,
+                                &discharges,
+                                PROPERTY_NOW,
+                                None,
+                            )
+                        }
+                    }
+                    RejectScenario::TamperedRootSignature => {
+                        self.tampered_root_signature_result(built)
+                    }
+                    RejectScenario::TamperedDischargeSignature => {
+                        if built.discharges.is_empty() {
+                            self.tampered_root_signature_result(built)
+                        } else {
+                            let mut discharges = built.discharges.clone();
+                            tamper_signature(&mut discharges[0].signature);
+                            self.verify(
+                                &built.root,
+                                &built.root_secret,
+                                &discharges,
+                                PROPERTY_NOW,
+                                None,
+                            )
+                        }
+                    }
+                }
+            }
+
+            fn tampered_root_signature_result(
+                &self,
+                built: &BuiltGeneratedProof,
+            ) -> Result<(), Error> {
+                let mut root = built.root.clone();
+                tamper_signature(&mut root.signature);
+                self.verify(
+                    &root,
+                    &built.root_secret,
+                    &built.discharges,
+                    PROPERTY_NOW,
+                    None,
+                )
+            }
+        }
+
+        impl GeneratedNode {
+            fn build(&self) -> (Macaroon, Vec<Macaroon>) {
+                let mut macaroon = Macaroon::new(
+                    self.location.clone(),
+                    self.identifier.clone(),
+                    self.secret.clone(),
+                );
+                let mut discharges = Vec::new();
+                for caveat in &self.caveats {
+                    match caveat {
+                        GeneratedCaveat::ExactString { what } => {
+                            macaroon.add_exact_string(what.clone());
+                        }
+                        GeneratedCaveat::Expires { when } => {
+                            macaroon.add_expires(*when);
+                        }
+                        GeneratedCaveat::ThirdParty { nonce, child } => {
+                            let secret =
+                                ThirdPartySecret::new(macaroon.signature(), nonce, &child.secret);
+                            macaroon.add_third_party_caveat(
+                                child.location.clone(),
+                                child.identifier.clone(),
+                                secret,
+                            );
+                            let (child_macaroon, child_discharges) = child.build();
+                            discharges.push(child_macaroon);
+                            discharges.extend(child_discharges);
+                        }
+                    }
+                }
+                (macaroon, discharges)
+            }
+
+            fn add_contexts(&self, verifier: &mut Verifier, skip_context: Option<&str>) {
+                for caveat in &self.caveats {
+                    match caveat {
+                        GeneratedCaveat::ExactString { what } => {
+                            if skip_context
+                                .map(|skip_context| skip_context != what.as_str())
+                                .unwrap_or(true)
+                            {
+                                verifier.add_context(what.clone());
+                            }
+                        }
+                        GeneratedCaveat::Expires { .. } => {}
+                        GeneratedCaveat::ThirdParty { child, .. } => {
+                            child.add_contexts(verifier, skip_context);
+                        }
+                    }
+                }
+            }
+
+            fn first_context(&self) -> Option<String> {
+                for caveat in &self.caveats {
+                    match caveat {
+                        GeneratedCaveat::ExactString { what } => {
+                            return Some(what.clone());
+                        }
+                        GeneratedCaveat::Expires { .. } => {}
+                        GeneratedCaveat::ThirdParty { child, .. } => {
+                            if let Some(context) = child.first_context() {
+                                return Some(context);
+                            }
+                        }
+                    }
+                }
+                None
+            }
+
+            fn first_expiration(&self) -> Option<u64> {
+                for caveat in &self.caveats {
+                    match caveat {
+                        GeneratedCaveat::ExactString { .. } => {}
+                        GeneratedCaveat::Expires { when } => {
+                            return Some(*when);
+                        }
+                        GeneratedCaveat::ThirdParty { child, .. } => {
+                            if let Some(when) = child.first_expiration() {
+                                return Some(when);
+                            }
+                        }
+                    }
+                }
+                None
+            }
+        }
+
+        fn different_secret(secret: &Secret) -> Secret {
+            let mut different = secret.clone();
+            tamper_signature(&mut different);
+            different
+        }
+
+        fn tamper_signature(secret: &mut Secret) {
+            secret.bytes[0] ^= 0x80;
+        }
+
+        fn noise_macaroon(index: usize) -> Macaroon {
+            let mut bytes = [0u8; SIGNATURE_BYTES];
+            for (offset, byte) in bytes.iter_mut().enumerate() {
+                *byte = 0xc3u8
+                    .wrapping_add(index as u8)
+                    .wrapping_add((offset as u8).wrapping_mul(17));
+            }
+            let mut macaroon = Macaroon::new(
+                format!("noise-location-{index}"),
+                format!("noise-identifier-{index}"),
+                Secret::from_bytes(bytes),
+            );
+            macaroon.add_exact_string(format!("noise-context-{index}"));
+            macaroon
+        }
+
+        fn candidates_with_noise(discharges: &[Macaroon]) -> Vec<Macaroon> {
+            let mut candidates = Vec::with_capacity(discharges.len() * 2 + 1);
+            for (idx, discharge) in discharges.iter().enumerate() {
+                candidates.push(noise_macaroon(idx));
+                candidates.push(discharge.clone());
+            }
+            candidates.push(noise_macaroon(discharges.len()));
+            candidates
+        }
+
+        fn public_identities(macaroons: &[Macaroon]) -> Vec<(String, String)> {
+            let mut identities: Vec<_> = macaroons
+                .iter()
+                .map(|macaroon| {
+                    (
+                        macaroon.location().to_owned(),
+                        macaroon.identifier().to_owned(),
+                    )
+                })
+                .collect();
+            identities.sort();
+            identities
+        }
+
+        fn reject_scenario() -> impl Strategy<Value = RejectScenario> {
+            prop_oneof![
+                Just(RejectScenario::WrongRootSecret),
+                Just(RejectScenario::MissingContext),
+                Just(RejectScenario::Expired),
+                Just(RejectScenario::MissingDischarge),
+                Just(RejectScenario::TamperedRootSignature),
+                Just(RejectScenario::TamperedDischargeSignature),
+            ]
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig {
+                cases: 128,
+                max_shrink_iters: 4096,
+                .. ProptestConfig::default()
+            })]
+
+            #[test]
+            fn generated_proof_trees_accept_and_reject(
+                entropy in prop::collection::vec(any::<u8>(), 1..=512),
+                scenario in reject_scenario(),
+            ) {
+                let proof = GeneratedProof::from_entropy(entropy);
+                let built = proof.build();
+
+                prop_assert!(proof.node_count <= MAX_GENERATED_MACAROONS);
+                prop_assert!(proof.max_depth <= MAX_GENERATED_DEPTH);
+                prop_assert!(proof.max_caveats <= MAX_GENERATED_CAVEATS);
+                let total_macaroons = built.discharges.len() + 1;
+                prop_assert_eq!(proof.node_count, total_macaroons);
+                prop_assert!(total_macaroons <= MAX_GENERATED_MACAROONS);
+
+                prop_assert_eq!(
+                    Ok(()),
+                    proof.verify_built(&built)
+                );
+
+                prop_assert_eq!(
+                    Err(Error::ProofInvalid),
+                    proof.reject_result(&built, scenario)
+                );
+            }
+
+            #[test]
+            fn generated_covering_sets_select_required_public_discharges(
+                entropy in prop::collection::vec(any::<u8>(), 1..=512),
+            ) {
+                let proof = GeneratedProof::from_entropy(entropy);
+                let built = proof.build();
+                let candidates = candidates_with_noise(&built.discharges);
+                let cover = built
+                    .root
+                    .covering_set(&candidates)
+                    .expect("generated candidates include every required discharge");
+
+                prop_assert_eq!(
+                    public_identities(&built.discharges),
+                    public_identities(&cover)
+                );
+                prop_assert_eq!(
+                    Ok(()),
+                    proof.verify(
+                        &built.root,
+                        &built.root_secret,
+                        &cover,
+                        PROPERTY_NOW,
+                        None,
+                    )
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Add covering_set and covering_set_refs methods to Macaroon for
assembling the transitive set of discharge macaroons needed to
satisfy third-party caveats.  Add fluent builder methods to
Verifier (new, with_context, with_current_time) and accept
impl Into<String> throughout the public API for ergonomic use.

New error variants LocationMismatch and MissingMacaroon give
callers actionable diagnostics.  Error now implements Display
and std::error::Error.  Secret::from_bytes and
ThirdPartySecret::random round out the constructors.

Comprehensive test suite covers caveat classification, prototk
round-trips, signature binding, tamper detection, nested
third-party discharges, and proptest-driven generated proof
trees that exercise accept/reject paths and covering set
selection.

Expand README with quick-start example, motivation, core
ideas, caveat language reference, third-party caveat guide,
covering set documentation, and security considerations.

Bump libsodium-sys-stable to 1.24.0 and add proptest as a
dev-dependency.

Co-authored-by: AI
