### PR TITLE
feat(asllm): add LLM-style streaming text writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "armnod",
     "arrrg",
     "arrrg_derive",
+    "asllm",
     "biometrics",
     "biometrics_pb",
     "biometrics_prometheus",

--- a/asllm/Cargo.toml
+++ b/asllm/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "asllm"
 version = "0.1.0"
-edition.workspace = true
+authors = ["Robert Escriva <robert@rescrv.net>"]
+edition = { workspace = true }
+description = "asllm paces text output to resemble streamed LLM tokens."
+license = "Apache-2.0"
+repository = "https://github.com/rescrv/blue"
 
 [dependencies]
 arrrg = { workspace = true }

--- a/asllm/Cargo.toml
+++ b/asllm/Cargo.toml
@@ -7,7 +7,18 @@ description = "asllm paces text output to resemble streamed LLM tokens."
 license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
+[features]
+default = ["binaries"]
+
+binaries = ["command_line"]
+command_line = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts"]
+
 [dependencies]
-arrrg = { workspace = true }
-arrrg_derive = { workspace = true }
-getopts = { workspace = true }
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+getopts = { workspace = true, optional = true }
+
+[[bin]]
+name = "asllm"
+path = "src/bin/asllm.rs"
+required-features=["binaries"]

--- a/asllm/Cargo.toml
+++ b/asllm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "asllm"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+getopts = { workspace = true }

--- a/asllm/src/bin/asllm.rs
+++ b/asllm/src/bin/asllm.rs
@@ -1,0 +1,59 @@
+use std::io::{self, BufRead, Write};
+use std::time::Duration;
+
+use arrrg::CommandLine;
+
+use asllm::{AsLlm, DEFAULT_TOKEN_DELAY};
+
+#[derive(Clone, Debug, arrrg_derive::CommandLine, Default, Eq, PartialEq)]
+struct Options {
+    #[arrrg(
+        optional,
+        "Delay in milliseconds between token writes.",
+        "MILLISECONDS"
+    )]
+    delay_ms: Option<u64>,
+    #[arrrg(flag, "Write output to stderr instead of stdout.")]
+    stderr: bool,
+}
+
+fn main() -> io::Result<()> {
+    let (options, free) =
+        Options::from_command_line("USAGE: asllm [--delay-ms MILLISECONDS] [--stderr]");
+    if !free.is_empty() {
+        eprintln!("unexpected positional arguments: {:?}", free);
+        std::process::exit(1);
+    }
+
+    let delay = options
+        .delay_ms
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_TOKEN_DELAY);
+
+    let stdin = io::stdin();
+    let mut reader = io::BufReader::new(stdin.lock());
+    if options.stderr {
+        write_lines_through_asllm(&mut AsLlm::with_delay(io::stderr(), delay), &mut reader)?;
+    } else {
+        write_lines_through_asllm(&mut AsLlm::with_delay(io::stdout(), delay), &mut reader)?;
+    }
+
+    Ok(())
+}
+
+fn write_lines_through_asllm<W: Write>(
+    writer: &mut AsLlm<W>,
+    reader: &mut dyn BufRead,
+) -> io::Result<()> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            break;
+        }
+        writer.write_all(line.as_bytes())?;
+    }
+    writer.flush()?;
+    Ok(())
+}

--- a/asllm/src/lib.rs
+++ b/asllm/src/lib.rs
@@ -1,0 +1,184 @@
+use std::io::{self, Write};
+use std::time::Duration;
+
+/// Default delay applied before each token is written and flushed.
+pub const DEFAULT_TOKEN_DELAY: Duration = Duration::from_nanos(1_000_000_000 / 42);
+
+/// Maximum size (in characters) for a single long word or number token.
+const DEFAULT_LONG_TOKEN_LIMIT: usize = 12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharClass {
+    Whitespace,
+    Word,
+    Number,
+    Punctuation,
+    Other,
+}
+
+#[derive(Debug)]
+pub struct AsLlm<W: Write> {
+    inner: W,
+    delay: Duration,
+}
+
+impl<W: Write> AsLlm<W> {
+    /// Wrap any `Write` implementor, using the default token delay of 42 tokens/s.
+    pub fn new(writer: W) -> Self {
+        Self::with_delay(writer, DEFAULT_TOKEN_DELAY)
+    }
+
+    /// Wrap any `Write` implementor with a custom token delay.
+    ///
+    /// A zero delay is useful for tests.
+    pub fn with_delay(writer: W, delay: Duration) -> Self {
+        Self {
+            inner: writer,
+            delay,
+        }
+    }
+
+    /// Consume the wrapper and return the nested writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for AsLlm<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = std::str::from_utf8(buf).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "AsLlm writer expects UTF-8 text input",
+            )
+        })?;
+
+        let bytes_len = buf.len();
+        for token in tokenize(text) {
+            std::thread::sleep(self.delay);
+            self.inner.write_all(token.as_bytes())?;
+            self.inner.flush()?;
+        }
+
+        Ok(bytes_len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn char_class(c: char) -> CharClass {
+    if c.is_whitespace() {
+        CharClass::Whitespace
+    } else if c.is_alphabetic() {
+        CharClass::Word
+    } else if c.is_numeric() {
+        CharClass::Number
+    } else if c.is_ascii_punctuation() {
+        CharClass::Punctuation
+    } else {
+        CharClass::Other
+    }
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut current_class = None;
+    let mut current_chars = 0usize;
+
+    for ch in text.chars() {
+        let class = char_class(ch);
+        let should_split = current_class
+            .map(|prev| {
+                prev != class
+                    || ((prev == CharClass::Word || prev == CharClass::Number)
+                        && current_chars >= DEFAULT_LONG_TOKEN_LIMIT)
+            })
+            .unwrap_or(false);
+
+        if should_split {
+            tokens.push(std::mem::take(&mut current));
+            current_chars = 0;
+            current_class = Some(class);
+        } else if current_class.is_none() {
+            current_class = Some(class);
+        }
+
+        current.push(ch);
+        current_chars += 1;
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FlushingWriter {
+        buf: Vec<u8>,
+        pub flushes: usize,
+    }
+
+    impl Write for FlushingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flushes += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn default_token_delay_is_42_tokens_per_second() {
+        assert_eq!(
+            Duration::from_nanos(1_000_000_000 / 42),
+            DEFAULT_TOKEN_DELAY
+        );
+    }
+
+    #[test]
+    fn tokenizes_and_flushes_per_token() -> io::Result<()> {
+        let mut writer = AsLlm::with_delay(FlushingWriter::default(), Duration::ZERO);
+
+        write!(writer, "Hi there!!! ThisIsALongWord")?;
+
+        let inner = writer.into_inner();
+        assert_eq!(inner.buf, b"Hi there!!! ThisIsALongWord");
+        assert!(inner.flushes > 1);
+        Ok(())
+    }
+
+    #[test]
+    fn tokenization_breaks_by_class_and_long_words() {
+        let tokens = tokenize("hello,world!!! 12AB34 12345678901");
+        assert_eq!(
+            tokens,
+            vec![
+                "hello",
+                ",",
+                "world",
+                "!!!",
+                " ",
+                "12",
+                "AB",
+                "34",
+                " ",
+                "12345678901",
+            ]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
New crate that wraps any Write implementor and emits text
token-by-token with a configurable delay between writes,
simulating the streaming output of a large language model.
Tokenization splits on character-class boundaries (word,
number, whitespace, punctuation) and breaks long words at
12 characters.  Default rate is 42 tokens per second.

Includes a CLI binary that reads stdin line-by-line and
streams through AsLlm to stdout or stderr.  Accepts
--delay-ms for custom timing and --stderr for diagnostic
output.

Co-authored-by: AI
