### PR TITLE
feat(indicio): expand Value API, harden Collector and ProtobufEmitter

### DIFF
--- a/indicio/README.md
+++ b/indicio/README.md
@@ -11,12 +11,25 @@ Active development.  Indicio is likely to change in the near future in backwards
 Scope
 -----
 
-Indicio will provide the interface for publishing clues and to the thread-local emitter.
+Indicio provides:
+
+- A `Value` tree for structured clue payloads.
+- The `value!` and `clue!` macros for lazy clue construction.
+- `Collector` for registering an emitter and filtering by verbosity.
+- `StdioEmitter` for human-readable stderr output.
+- `ProtobufEmitter` for append-only clue files when the `prototk` feature is enabled.
+
+The protobuf file format is a sequence of field-1 clue messages.  It remains readable as a
+`ClueVector` so existing consumers can continue to decode files written by `ProtobufEmitter`.
 
 Warts
 -----
 
-- Currently it's under-tested, so may be ugly.
+- `Map` preserves insertion order and duplicate keys.  Lookup returns the first matching key.
+- `Value` equality gives `f64` values a total ordering semantics, so values such as `-0.0` and
+  `0.0` compare differently.
+- `puzzle_piece!` is intentionally small.  Use `try_extract` when callers need a missing-path or
+  type-mismatch diagnostic; `extract` remains available for the older `Option`-returning API.
 
 Documentation
 -------------

--- a/indicio/src/lib.rs
+++ b/indicio/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -9,9 +9,12 @@ use biometrics::Counter;
 use tatl::{HeyListen, Stationary};
 
 pub mod stdio;
+pub use stdio::StdioEmitter;
 
 #[cfg(feature = "prototk")]
 pub mod protobuf;
+#[cfg(feature = "prototk")]
+pub use protobuf::{ClueFrame, ClueVector, ProtobufEmitter};
 
 ///////////////////////////////////////////// constants ////////////////////////////////////////////
 
@@ -47,6 +50,32 @@ pub struct Values {
     values: Vec<Value>,
 }
 
+impl Values {
+    pub fn new() -> Self {
+        Self { values: Vec::new() }
+    }
+
+    pub fn push(&mut self, value: Value) {
+        self.values.push(value);
+    }
+
+    pub fn as_slice(&self) -> &[Value] {
+        self.values.as_slice()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Value> + '_ {
+        self.values.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
 impl Deref for Values {
     type Target = Vec<Value>;
 
@@ -72,12 +101,27 @@ pub struct MapEntry {
     value: Value,
 }
 
+impl MapEntry {
+    pub fn new(key: String, value: Value) -> Self {
+        Self { key, value }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &Value {
+        &self.value
+    }
+
+    pub fn into_pair(self) -> (String, Value) {
+        (self.key, self.value)
+    }
+}
+
 impl From<(String, Value)> for MapEntry {
     fn from(entry: (String, Value)) -> Self {
-        Self {
-            key: entry.0,
-            value: entry.1,
-        }
+        Self::new(entry.0, entry.1)
     }
 }
 
@@ -95,8 +139,27 @@ impl Map {
         self.entries.push(MapEntry::from((key, value)));
     }
 
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.entries
+            .iter()
+            .find(|entry| entry.key == key)
+            .map(|entry| &entry.value)
+    }
+
+    pub fn entries(&self) -> &[MapEntry] {
+        self.entries.as_slice()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&str, &Value)> + '_ {
         self.entries.iter().map(|e| (e.key.as_str(), &e.value))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 
@@ -107,6 +170,97 @@ impl FromIterator<(String, Value)> for Map {
         }
     }
 }
+
+///////////////////////////////////////////// ValueKind ////////////////////////////////////////////
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ValueKind {
+    Bool,
+    U64,
+    I64,
+    F64,
+    String,
+    Array,
+    Object,
+}
+
+impl Display for ValueKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ValueKind::Bool => write!(f, "bool"),
+            ValueKind::U64 => write!(f, "u64"),
+            ValueKind::I64 => write!(f, "i64"),
+            ValueKind::F64 => write!(f, "f64"),
+            ValueKind::String => write!(f, "string"),
+            ValueKind::Array => write!(f, "array"),
+            ValueKind::Object => write!(f, "object"),
+        }
+    }
+}
+
+////////////////////////////////////////// ExtractionError /////////////////////////////////////////
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ExtractionErrorKind {
+    Missing,
+    TypeMismatch {
+        expected: &'static str,
+        actual: ValueKind,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExtractionError {
+    path: Vec<String>,
+    kind: ExtractionErrorKind,
+}
+
+impl ExtractionError {
+    pub fn missing(path: &[&str]) -> Self {
+        Self {
+            path: path.iter().map(|segment| segment.to_string()).collect(),
+            kind: ExtractionErrorKind::Missing,
+        }
+    }
+
+    pub fn type_mismatch(path: &[&str], expected: &'static str, actual: ValueKind) -> Self {
+        Self {
+            path: path.iter().map(|segment| segment.to_string()).collect(),
+            kind: ExtractionErrorKind::TypeMismatch { expected, actual },
+        }
+    }
+
+    pub fn path(&self) -> &[String] {
+        self.path.as_slice()
+    }
+
+    pub fn kind(&self) -> &ExtractionErrorKind {
+        &self.kind
+    }
+}
+
+impl Display for ExtractionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let path = if self.path.is_empty() {
+            "<root>".to_string()
+        } else {
+            self.path.join(".")
+        };
+        match self.kind {
+            ExtractionErrorKind::Missing => {
+                write!(f, "missing value at {path}")
+            }
+            ExtractionErrorKind::TypeMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "type mismatch at {path}: expected {expected}, found {actual}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExtractionError {}
 
 /////////////////////////////////////////////// Value //////////////////////////////////////////////
 
@@ -132,16 +286,92 @@ pub enum Value {
 impl Value {
     pub fn lookup(&self, key: &str) -> Option<&Value> {
         if let Value::Object(map) = self {
-            map.entries
-                .iter()
-                .filter(|e| e.key == key)
-                .take(1)
-                .map(|e| &e.value)
-                .next()
+            map.get(key)
         } else {
             None
         }
     }
+
+    pub fn lookup_path(&self, path: &[&str]) -> Option<&Value> {
+        let mut value = self;
+        for segment in path {
+            value = value.lookup(segment)?;
+        }
+        Some(value)
+    }
+
+    pub fn kind(&self) -> ValueKind {
+        match self {
+            Value::Bool(_) => ValueKind::Bool,
+            Value::U64(_) => ValueKind::U64,
+            Value::I64(_) => ValueKind::I64,
+            Value::F64(_) => ValueKind::F64,
+            Value::String(_) => ValueKind::String,
+            Value::Array(_) => ValueKind::Array,
+            Value::Object(_) => ValueKind::Object,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        if let Value::Bool(value) = self {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_u64(&self) -> Option<u64> {
+        if let Value::U64(value) = self {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        if let Value::I64(value) = self {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        if let Value::F64(value) = self {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        if let Value::String(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_array(&self) -> Option<&Values> {
+        if let Value::Array(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&Map> {
+        if let Value::Object(value) = self {
+            Some(value)
+        } else {
+            None
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn lookup_path<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    value.lookup_path(path)
 }
 
 impl Default for Value {
@@ -152,43 +382,48 @@ impl Default for Value {
 
 impl Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        fn write_escaped_string(f: &mut fmt::Formatter<'_>, input: &str) -> Result<(), fmt::Error> {
+            write!(f, "\"")?;
+            for c in input.chars() {
+                match c {
+                    '\\' => write!(f, "\\\\")?,
+                    '\n' => write!(f, "\\n")?,
+                    '\r' => write!(f, "\\r")?,
+                    '\t' => write!(f, "\\t")?,
+                    '"' => write!(f, "\\\"")?,
+                    c if c.is_control() => write!(f, "\\u{:04x}", c as u32)?,
+                    c => write!(f, "{c}")?,
+                }
+            }
+            write!(f, "\"")
+        }
+
         match self {
             Value::Bool(b) => write!(f, "{}", if *b { "true" } else { "false" }),
             Value::U64(x) => write!(f, "{x}"),
             Value::I64(x) => write!(f, "{x}"),
             Value::F64(x) => write!(f, "{x}"),
-            Value::String(s) => {
-                pub fn escape(input: &str) -> String {
-                    let mut out: Vec<char> = Vec::new();
-                    for c in input.chars() {
-                        if c == '\\' {
-                            out.push('\\');
-                            out.push('\\');
-                        } else if c == '\n' {
-                            out.push('\\');
-                            out.push('n');
-                        } else if c == '"' {
-                            out.push('\\');
-                            out.push('"');
-                        } else {
-                            out.push(c);
-                        }
-                    }
-                    out.into_iter().collect()
-                }
-                write!(f, "\"{}\"", escape(s))
-            }
+            Value::String(s) => write_escaped_string(f, s),
             Value::Array(values) => {
-                let values = values.iter().map(|x| x.to_string()).collect::<Vec<_>>();
-                write!(f, "[{}]", values.join(", "))
+                write!(f, "[")?;
+                for (index, value) in values.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{value}")?;
+                }
+                write!(f, "]")
             }
             Value::Object(values) => {
-                let values = values
-                    .entries
-                    .iter()
-                    .map(|entry| format!("\"{}\": {}", entry.key, entry.value))
-                    .collect::<Vec<_>>();
-                write!(f, "{{{}}}", values.join(", "))
+                write!(f, "{{")?;
+                for (index, entry) in values.entries.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write_escaped_string(f, &entry.key)?;
+                    write!(f, ": {}", entry.value)?;
+                }
+                write!(f, "}}")
             }
         }
     }
@@ -356,6 +591,7 @@ macro_rules! value {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! value_internal {
     (@array [$($elems:expr,)*]) => {
@@ -469,20 +705,20 @@ macro_rules! value_internal {
 ////////////////////////////////////////////// Emitter /////////////////////////////////////////////
 
 /// An emitter for indicio that emits values.
-pub trait Emitter: Send {
+pub trait Emitter: Send + Sync {
     /// Emit the provided value at the specified file/line.
     fn emit(&self, file: &str, line: u32, level: u64, value: Value);
     /// Flush the emitter with whatever semantics the emitter chooses.
     fn flush(&self) {}
 }
 
-impl<E: Emitter + Sync> Emitter for Arc<E> {
+impl<E: Emitter + ?Sized> Emitter for Arc<E> {
     fn emit(&self, file: &str, line: u32, level: u64, value: Value) {
-        <E as Emitter>::emit(self, file, line, level, value)
+        <E as Emitter>::emit(self.as_ref(), file, line, level, value)
     }
 
     fn flush(&self) {
-        <E as Emitter>::flush(self)
+        <E as Emitter>::flush(self.as_ref())
     }
 }
 
@@ -554,7 +790,7 @@ impl_tuple_emitter! { A B C D E F G H I J K L M N O P Q R S T U V W X Y Z }
 pub struct Collector {
     should_log: AtomicBool,
     verbosity: AtomicU64,
-    emitter: Mutex<Option<Box<dyn Emitter>>>,
+    emitter: Mutex<Option<Arc<dyn Emitter>>>,
 }
 
 impl Collector {
@@ -569,25 +805,30 @@ impl Collector {
 
     /// True iff the collector is actively logging.
     pub fn is_logging(&self) -> bool {
-        self.should_log.load(Ordering::Relaxed)
+        self.should_log.load(Ordering::Acquire)
     }
 
     /// The verbosity of the log.  0 is least verbose, N is N levels of verbosity.
     pub fn verbosity(&self) -> u64 {
-        self.verbosity.load(Ordering::Relaxed)
+        self.verbosity.load(Ordering::Acquire)
     }
 
     /// Set the verbosity of the log.
     pub fn set_verbosity(&self, verbosity: u64) {
-        self.verbosity.store(verbosity, Ordering::Relaxed);
+        self.verbosity.store(verbosity, Ordering::Release);
+    }
+
+    /// True iff the collector will emit for the specified level.
+    pub fn enabled(&self, level: u64) -> bool {
+        self.is_logging() && self.verbosity() >= level
     }
 
     /// Emit the value via the collector if and only if it is logging and has an emitter
     /// configured.
     pub fn emit(&self, file: &str, line: u32, level: u64, value: Value) {
-        if self.is_logging() && self.verbosity() >= level {
-            let mut emitter = self.emitter.lock().unwrap();
-            if let Some(emitter) = emitter.as_deref_mut() {
+        if self.enabled(level) {
+            let emitter = self.emitter.lock().unwrap().clone();
+            if let Some(emitter) = emitter {
                 emitter.emit(file, line, level, value);
             }
         }
@@ -595,25 +836,29 @@ impl Collector {
 
     /// Call flush on the underlying emitter, if one is registered.
     pub fn flush(&self) {
-        let mut emitter = self.emitter.lock().unwrap();
-        if let Some(emitter) = emitter.as_deref_mut() {
+        let emitter = self.emitter.lock().unwrap().clone();
+        if let Some(emitter) = emitter {
             emitter.flush();
         }
     }
 
     /// Register the emitter with the collector.
     pub fn register<E: Emitter + 'static>(&self, emitter: E) {
-        let boxed: Box<dyn Emitter> = Box::new(emitter);
-        let mut emitter = self.emitter.lock().unwrap();
-        *emitter = Some(boxed);
-        self.should_log.store(true, Ordering::Relaxed);
+        self.register_arc(Arc::new(emitter));
+    }
+
+    /// Register a shared emitter with the collector.
+    pub fn register_arc(&self, emitter: Arc<dyn Emitter>) {
+        let mut current = self.emitter.lock().unwrap();
+        *current = Some(emitter);
+        self.should_log.store(true, Ordering::Release);
     }
 
     /// Unregister any emitter from the collector.
     pub fn deregister(&self) {
         let mut emitter = self.emitter.lock().unwrap();
         *emitter = None;
-        self.should_log.store(false, Ordering::Relaxed);
+        self.should_log.store(false, Ordering::Release);
     }
 }
 
@@ -625,7 +870,7 @@ impl Default for Collector {
 
 /////////////////////////////////////////////// Clue ///////////////////////////////////////////////
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "prototk", derive(prototk_derive::Message))]
 pub struct Clue {
     #[cfg_attr(feature = "prototk", prototk(1, string))]
@@ -657,12 +902,14 @@ impl Display for Clue {
 /// This will be lazy, and only evaluate the key-value pair if the collector is logging.
 #[macro_export]
 macro_rules! clue {
-    ($collector:path, $level:expr, { $($value:tt)* }) => {
-        if $collector.is_logging() && $collector.verbosity() >= $level {
+    ($collector:expr, $level:expr, { $($value:tt)* }) => {{
+        let collector = &$collector;
+        let level = $level;
+        if collector.enabled(level) {
             let loc = concat!(module_path!(), " ", file!());
-            $collector.emit(loc, line!(), $level, $crate::value!({ $($value)* }));
+            collector.emit(loc, line!(), level, $crate::value!({ $($value)* }));
         }
-    };
+    }};
 }
 
 ////////////////////////////////////// the puzzle_piece macro //////////////////////////////////////
@@ -671,68 +918,92 @@ macro_rules! clue {
 #[macro_export]
 macro_rules! puzzle_piece {
     ($type_name:ident { $($tt:tt)* }) => {
-        puzzle_piece!(@struct [$type_name] {} ($($tt)*));
+        $crate::puzzle_piece!(@struct [$type_name] {} ($($tt)*));
         impl $type_name {
-            pub fn extract(value: &indicio::Value) -> Option<Self> {
+            pub fn try_extract(value: &$crate::Value) -> Result<Self, $crate::ExtractionError> {
                 let mut this = Self::default();
-                puzzle_piece!(@extract this value [] ($($tt)*));
-                Some(this)
+                $crate::puzzle_piece!(@extract this value [] ($($tt)*));
+                Ok(this)
+            }
+
+            pub fn extract(value: &$crate::Value) -> Option<Self> {
+                Self::try_extract(value).ok()
             }
         }
     };
 
-    (@struct [$type_name:ident] { $($field:ident: $ty:path,)* } ()) => {
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ()) => {
         #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
         pub struct $type_name {
             $($field: $ty,)*
         }
     };
 
-    (@struct [$type_name:ident] { $($field:ident: $ty:path,)* } ($new_field:ident: $new_ty:path, $($tt:tt)*)) => {
-        puzzle_piece!(@struct [$type_name] { $($field: $ty,)* $new_field: $new_ty, } ($($tt)*));
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ($new_field:ident: $new_ty:ty, $($tt:tt)*)) => {
+        $crate::puzzle_piece!(@struct [$type_name] { $($field: $ty,)* $new_field: $new_ty, } ($($tt)*));
     };
 
-    (@struct [$type_name:ident] { $($field:ident: $ty:path,)* } ($new_field:ident: { $($tt1:tt)* })) => {
-        puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)*));
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ($new_field:ident: $new_ty:ty)) => {
+        $crate::puzzle_piece!(@struct [$type_name] { $($field: $ty,)* $new_field: $new_ty, } ());
     };
 
-    (@struct [$type_name:ident] { $($field:ident: $ty:path,)* } ($new_field:ident: { $($tt1:tt)* },)) => {
-        puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)*));
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ($new_field:ident: { $($tt1:tt)* })) => {
+        $crate::puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)*));
     };
 
-    (@struct [$type_name:ident] { $($field:ident: $ty:path,)* } ($new_field:ident: { $($tt1:tt)* }, $($tt2:tt)*)) => {
-        puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)* $($tt2)*));
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ($new_field:ident: { $($tt1:tt)* },)) => {
+        $crate::puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)*));
+    };
+
+    (@struct [$type_name:ident] { $($field:ident: $ty:ty,)* } ($new_field:ident: { $($tt1:tt)* }, $($tt2:tt)*)) => {
+        $crate::puzzle_piece!(@struct [$type_name] { $($field: $ty,)* } ($($tt1)* $($tt2)*));
     };
 
     (@extract $this:ident $value:ident [] ()) => {
     };
 
-    (@extract $this:ident $value:ident [$($key:ident)*] $new_field:ident) => {
-        let v = $value;
-        $(let v = v.lookup(stringify!($key))?;)*
-        $this.$new_field = v.try_into().ok()?;
+    (@extract $this:ident $value:ident [$($key:ident)*] $new_field:ident: $new_ty:ty) => {
+        {
+            const __PATH: &[&str] = &[$(stringify!($key),)* stringify!($new_field)];
+            let v = $crate::lookup_path($value, __PATH)
+                .ok_or_else(|| $crate::ExtractionError::missing(__PATH))?;
+            $this.$new_field = match <$new_ty as std::convert::TryFrom<&$crate::Value>>::try_from(v) {
+                Ok(value) => value,
+                Err(_) => {
+                    return Err($crate::ExtractionError::type_mismatch(
+                        __PATH,
+                        stringify!($new_ty),
+                        v.kind(),
+                    ));
+                }
+            };
+        }
     };
 
-    (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: $new_ty:path,)) => {
-        puzzle_piece!(@extract $this $value [$($key)* $new_field] $new_field);
+    (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: $new_ty:ty,)) => {
+        $crate::puzzle_piece!(@extract $this $value [$($key)*] $new_field: $new_ty);
     };
 
-    (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: $new_ty:path, $($tt:tt)*)) => {
-        puzzle_piece!(@extract $this $value [$($key)* $new_field] $new_field);
-        puzzle_piece!(@extract $this $value [$($key)*] ($($tt)*));
+    (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: $new_ty:ty)) => {
+        $crate::puzzle_piece!(@extract $this $value [$($key)*] $new_field: $new_ty);
+    };
+
+    (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: $new_ty:ty, $($tt:tt)*)) => {
+        $crate::puzzle_piece!(@extract $this $value [$($key)*] $new_field: $new_ty);
+        $crate::puzzle_piece!(@extract $this $value [$($key)*] ($($tt)*));
     };
 
     (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: { $($tt1:tt)* }, $($tt2:tt)*)) => {
-        puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt1)*));
-        puzzle_piece!(@extract $this $value [$($key)*] ($($tt2)*));
+        $crate::puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt1)*));
+        $crate::puzzle_piece!(@extract $this $value [$($key)*] ($($tt2)*));
     };
 
     (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: { $($tt1:tt)* })) => {
-        puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt)*));
+        $crate::puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt1)*));
     };
 
     (@extract $this:ident $value:ident [$($key:ident)*] ($new_field:ident: { $($tt1:tt)* },)) => {
-        puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt)*));
+        $crate::puzzle_piece!(@extract $this $value [$($key)* $new_field] ($($tt1)*));
     };
 }
 

--- a/indicio/src/protobuf.rs
+++ b/indicio/src/protobuf.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Error, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -10,7 +10,7 @@ use super::*;
 
 ///////////////////////////////////////////// ClueFrame ////////////////////////////////////////////
 
-#[derive(Default, prototk_derive::Message)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, prototk_derive::Message)]
 pub struct ClueFrame {
     #[prototk(1, message)]
     pub clue: Clue,
@@ -18,7 +18,7 @@ pub struct ClueFrame {
 
 //////////////////////////////////////////// ClueVector ////////////////////////////////////////////
 
-#[derive(Default, prototk_derive::Message)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, prototk_derive::Message)]
 pub struct ClueVector {
     #[prototk(1, message)]
     pub clues: Vec<Clue>,
@@ -31,6 +31,7 @@ struct OutputState {
     file: Option<File>,
     size: u64,
     timestamp: u64,
+    file_timestamp: u128,
 }
 
 /// An Emitter that writes key-value pairs to a series of log files.  When the file reaches its
@@ -43,12 +44,19 @@ pub struct ProtobufEmitter {
 
 impl ProtobufEmitter {
     pub fn new<P: AsRef<Path>>(prefix: P, target: u64) -> Result<Self, std::io::Error> {
+        if target == 0 {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "indicio protobuf emitter target must be greater than zero",
+            ));
+        }
         let prefix = prefix.as_ref().to_path_buf();
         let state = Mutex::new(OutputState {
             buffer: vec![],
             file: None,
             size: 0,
             timestamp: 0,
+            file_timestamp: 0,
         });
         Ok(Self {
             prefix,
@@ -57,25 +65,43 @@ impl ProtobufEmitter {
         })
     }
 
-    fn open(&self, state: &mut OutputState) {
-        let ts = SystemTime::now()
+    fn path_for_timestamp(&self, timestamp: u128) -> PathBuf {
+        let mut path = OsString::from(self.prefix.as_os_str());
+        let ext = OsString::from(format!(".{timestamp}"));
+        path.push(ext);
+        PathBuf::from(path)
+    }
+
+    fn now_micros() -> u128 {
+        SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .map(|x| x.as_micros())
-            .unwrap_or(0);
-        let mut path = OsString::from(self.prefix.as_os_str());
-        let ext = OsString::from(format!(".{ts}"));
-        path.push(ext);
-        let path = PathBuf::from(path);
-        let Ok(file) = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(path)
-        else {
-            return;
-        };
-        state.file = Some(file);
-        state.size = 0;
+            .unwrap_or(0)
+    }
+
+    fn open(&self, state: &mut OutputState) -> Result<(), std::io::Error> {
+        let mut timestamp = std::cmp::max(Self::now_micros(), state.file_timestamp + 1);
+        for _ in 0..1024 {
+            let path = self.path_for_timestamp(timestamp);
+            match OpenOptions::new().create_new(true).write(true).open(path) {
+                Ok(file) => {
+                    state.file = Some(file);
+                    state.size = 0;
+                    state.file_timestamp = timestamp;
+                    return Ok(());
+                }
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                    timestamp += 1;
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+        }
+        Err(Error::new(
+            ErrorKind::AlreadyExists,
+            "could not create a unique indicio protobuf log file",
+        ))
     }
 
     fn close(&self, state: &mut OutputState) {
@@ -87,26 +113,33 @@ impl ProtobufEmitter {
     }
 
     fn drain(&self, state: &mut OutputState) {
-        let buffer = std::mem::take(&mut state.buffer);
-        if buffer.is_empty() {
+        if state.buffer.is_empty() {
             return;
         }
-        'retry: for _ in 0..3 {
-            if state.file.is_none() {
-                self.open(state);
+        for _ in 0..3 {
+            if state.file.is_none() && self.open(state).is_err() {
+                EMITTER_FAILURE.click();
+                return;
             }
-            let size = state.size;
+            let buffer_len = state.buffer.len() as u64;
+            if state.size > 0 && state.size.saturating_add(buffer_len) > self.target {
+                self.close(state);
+                continue;
+            }
+            let rollback_size = state.size;
             if let Some(file) = state.file.as_mut() {
-                if size >= self.target {
+                if rollback_size >= self.target {
                     self.close(state);
                     continue;
-                } else {
-                    if file.write_all(&buffer).is_err() {
-                        break 'retry;
-                    }
-                    state.size += buffer.len() as u64;
-                    return;
                 }
+                if file.write_all(&state.buffer).is_err() {
+                    let _ = file.set_len(rollback_size);
+                    self.close(state);
+                    continue;
+                }
+                state.size = state.size.saturating_add(buffer_len);
+                state.buffer.clear();
+                return;
             }
         }
         EMITTER_FAILURE.click();
@@ -132,7 +165,8 @@ impl Emitter for ProtobufEmitter {
             },
         };
         let mut state = self.state.lock().unwrap();
-        frame.clue.timestamp = std::cmp::max(state.timestamp + 1, frame.clue.timestamp);
+        frame.clue.timestamp =
+            std::cmp::max(state.timestamp.saturating_add(1), frame.clue.timestamp);
         state.timestamp = frame.clue.timestamp;
         stack_pack(&frame).append_to_vec(&mut state.buffer);
         if state.buffer.len() > 1 << 16 {
@@ -145,6 +179,15 @@ impl Emitter for ProtobufEmitter {
         self.drain(&mut state);
         if let Some(file) = state.file.as_mut() {
             let _ = file.flush();
+        }
+    }
+}
+
+impl Drop for ProtobufEmitter {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.state.lock() {
+            self.drain(&mut state);
+            self.close(&mut state);
         }
     }
 }

--- a/indicio/src/stdio.rs
+++ b/indicio/src/stdio.rs
@@ -2,8 +2,8 @@ use std::time::SystemTime;
 
 use super::*;
 
-/// An Emitter that writes clues to stderr.  When the file reaches its size
-/// threshold, it rolls over to the next file.
+/// An Emitter that writes clues to stderr.
+#[derive(Clone, Copy, Debug, Default)]
 pub struct StdioEmitter;
 
 impl Emitter for StdioEmitter {

--- a/indicio/tests/collector.rs
+++ b/indicio/tests/collector.rs
@@ -1,0 +1,85 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use indicio::{ALWAYS, Collector, Emitter, Value, clue};
+
+#[derive(Default)]
+struct RecordingEmitter {
+    emitted: Mutex<Vec<(String, u32, u64, Value)>>,
+}
+
+impl Emitter for RecordingEmitter {
+    fn emit(&self, file: &str, line: u32, level: u64, value: Value) {
+        self.emitted
+            .lock()
+            .unwrap()
+            .push((file.to_string(), line, level, value));
+    }
+}
+
+fn expensive(flag: &AtomicBool) -> &'static str {
+    flag.store(true, Ordering::SeqCst);
+    "value"
+}
+
+#[test]
+fn clue_accepts_collector_expressions_and_remains_lazy() {
+    let collector = Collector::new();
+    let evaluated = AtomicBool::new(false);
+
+    clue!(&collector, ALWAYS, {
+        value: expensive(&evaluated),
+    });
+    assert!(!evaluated.load(Ordering::SeqCst));
+
+    let emitter = Arc::new(RecordingEmitter::default());
+    collector.register_arc(emitter.clone());
+    collector.set_verbosity(ALWAYS);
+    clue!(&collector, ALWAYS, {
+        value: expensive(&evaluated),
+    });
+
+    assert!(evaluated.load(Ordering::SeqCst));
+    let mut emitted = emitter.emitted.lock().unwrap().clone();
+    for clue in emitted.iter_mut() {
+        clue.0 = "loc".to_string();
+        clue.1 = 0;
+    }
+    assert_eq!(
+        vec![(
+            "loc".to_string(),
+            0,
+            ALWAYS,
+            indicio::value!({ value: "value" })
+        )],
+        emitted
+    );
+}
+
+struct DeregisteringEmitter {
+    collector: Arc<Collector>,
+    emitted: Arc<AtomicBool>,
+}
+
+impl Emitter for DeregisteringEmitter {
+    fn emit(&self, _file: &str, _line: u32, _level: u64, _value: Value) {
+        self.emitted.store(true, Ordering::SeqCst);
+        self.collector.deregister();
+    }
+}
+
+#[test]
+fn emitter_can_reenter_collector_without_deadlock() {
+    let collector = Arc::new(Collector::new());
+    let emitted = Arc::new(AtomicBool::new(false));
+    collector.register(DeregisteringEmitter {
+        collector: Arc::clone(&collector),
+        emitted: Arc::clone(&emitted),
+    });
+    collector.set_verbosity(ALWAYS);
+
+    collector.emit("file", 1, ALWAYS, Value::Bool(true));
+
+    assert!(emitted.load(Ordering::SeqCst));
+    assert!(!collector.is_logging());
+}

--- a/indicio/tests/macro.rs
+++ b/indicio/tests/macro.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::excessive_precision)]
 #![allow(clippy::approx_constant)]
 
-use indicio::{Value, value};
+use indicio::{Map, Value, value};
 
 #[test]
 fn value_bool() {
@@ -106,5 +106,61 @@ fn value_object() {
                 ],
             }
         })
+    );
+}
+
+#[test]
+fn map_lookup_returns_first_duplicate_key() {
+    let mut map = Map::default();
+    map.insert("key".to_string(), Value::I64(1));
+    map.insert("key".to_string(), Value::I64(2));
+
+    assert_eq!(2, map.len());
+    assert!(!map.is_empty());
+    assert_eq!(Some(&Value::I64(1)), map.get("key"));
+    assert_eq!(
+        vec![
+            ("key".to_string(), Value::I64(1)),
+            ("key".to_string(), Value::I64(2)),
+        ],
+        map.entries()
+            .iter()
+            .cloned()
+            .map(indicio::MapEntry::into_pair)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn display_escapes_string_values_and_object_keys() {
+    let mut map = Map::default();
+    map.insert("a\n\"b".to_string(), Value::String("x\t\\\r".to_string()));
+
+    assert_eq!(
+        "{\"a\\n\\\"b\": \"x\\t\\\\\\r\"}",
+        Value::Object(map).to_string()
+    );
+}
+
+#[test]
+fn value_accessors_report_kinds() {
+    let value = value!({
+        enabled: true,
+        signed: -1i64,
+        unsigned: 1u64,
+        nested: ["value"],
+    });
+
+    assert_eq!(indicio::ValueKind::Object, value.kind());
+    assert_eq!(Some(true), value.lookup("enabled").and_then(Value::as_bool));
+    assert_eq!(Some(-1), value.lookup("signed").and_then(Value::as_i64));
+    assert_eq!(Some(1), value.lookup("unsigned").and_then(Value::as_u64));
+    assert_eq!(
+        Some("value"),
+        value
+            .lookup_path(&["nested"])
+            .and_then(Value::as_array)
+            .and_then(|values| values.first())
+            .and_then(Value::as_str)
     );
 }

--- a/indicio/tests/protobuf.rs
+++ b/indicio/tests/protobuf.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "prototk")]
+
+use std::fs::{create_dir, read, read_dir, remove_dir_all};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use buffertk::{Unpackable, stack_pack};
+use indicio::{Clue, ClueFrame, ClueVector, Emitter, INFO, ProtobufEmitter, value};
+
+fn temp_prefix(name: &str) -> (PathBuf, PathBuf) {
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("indicio-{name}-{}-{timestamp}", std::process::id()));
+    create_dir(&root).unwrap();
+    let prefix = root.join("clues");
+    (root, prefix)
+}
+
+fn read_clues(root: &Path) -> Vec<Clue> {
+    let mut paths = read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+    paths.sort();
+    let mut clues = Vec::new();
+    for path in paths {
+        let buf = read(path).unwrap();
+        let mut vector = ClueVector::unpack(&buf).unwrap().0;
+        clues.append(&mut vector.clues);
+    }
+    clues
+}
+
+#[test]
+fn concatenated_frames_decode_as_clue_vector() {
+    let clues = vec![
+        Clue {
+            file: "file-a".to_string(),
+            line: 10,
+            level: INFO,
+            timestamp: 100,
+            value: value!({ event: "a" }),
+        },
+        Clue {
+            file: "file-b".to_string(),
+            line: 20,
+            level: INFO,
+            timestamp: 200,
+            value: value!({ event: "b" }),
+        },
+    ];
+    let mut buf = Vec::new();
+    for clue in clues.iter().cloned() {
+        stack_pack(&ClueFrame { clue }).append_to_vec(&mut buf);
+    }
+
+    assert_eq!(
+        ClueVector {
+            clues: clues.clone(),
+        },
+        ClueVector::unpack(&buf).unwrap().0
+    );
+}
+
+#[test]
+fn emitter_rolls_files_without_changing_clue_vector_format() {
+    let (root, prefix) = temp_prefix("rolls");
+    {
+        let emitter = ProtobufEmitter::new(&prefix, 1).unwrap();
+        emitter.emit("file-a", 10, INFO, value!({ event: "a" }));
+        emitter.flush();
+        emitter.emit("file-b", 20, INFO, value!({ event: "b" }));
+        emitter.flush();
+    }
+
+    let file_count = read_dir(&root).unwrap().count();
+    let mut clues = read_clues(&root);
+    assert_eq!(2, file_count);
+    assert_eq!(2, clues.len());
+    assert!(clues[0].timestamp < clues[1].timestamp);
+    for clue in clues.iter_mut() {
+        clue.timestamp = 0;
+    }
+    assert_eq!(
+        vec![
+            Clue {
+                file: "file-a".to_string(),
+                line: 10,
+                level: INFO,
+                timestamp: 0,
+                value: value!({ event: "a" }),
+            },
+            Clue {
+                file: "file-b".to_string(),
+                line: 20,
+                level: INFO,
+                timestamp: 0,
+                value: value!({ event: "b" }),
+            },
+        ],
+        clues
+    );
+
+    remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn emitter_rejects_zero_rollover_target() {
+    let (root, prefix) = temp_prefix("zero-target");
+    let error = match ProtobufEmitter::new(&prefix, 0) {
+        Ok(_) => panic!("zero rollover target should be rejected"),
+        Err(error) => error,
+    };
+
+    assert_eq!(std::io::ErrorKind::InvalidInput, error.kind());
+    assert_eq!(Vec::<Clue>::new(), read_clues(&root));
+
+    remove_dir_all(root).unwrap();
+}

--- a/indicio/tests/puzzle_piece.rs
+++ b/indicio/tests/puzzle_piece.rs
@@ -85,3 +85,72 @@ fn type4() {
         }))
     );
 }
+
+puzzle_piece!(
+    Type5 {
+        nested: {
+            foo: String
+        }
+    }
+);
+
+#[test]
+fn nested_terminal_without_trailing_comma() {
+    let type5 = Type5 {
+        foo: "foo".to_string(),
+    };
+    assert_eq!(
+        Some(type5),
+        Type5::extract(&indicio::value!({
+            nested: {
+                foo: "foo",
+            },
+        }))
+    );
+}
+
+#[test]
+fn try_extract_reports_missing_path() {
+    assert_eq!(
+        indicio::ExtractionError::missing(&["field1", "bar"]),
+        Type3::try_extract(&indicio::value!({
+            field1: {
+                foo: "foo",
+            },
+            baz: "baz",
+        }))
+        .unwrap_err()
+    );
+}
+
+#[test]
+fn try_extract_reports_type_mismatch() {
+    assert_eq!(
+        indicio::ExtractionError::type_mismatch(&["foo"], "String", indicio::ValueKind::I64),
+        Type2::try_extract(&indicio::value!({
+            foo: 42,
+            bar: "bar",
+        }))
+        .unwrap_err()
+    );
+}
+
+mod qualified {
+    indicio::puzzle_piece!(QualifiedType {
+        outer: {
+            answer: i64,
+        },
+    });
+
+    #[test]
+    fn qualified_macro_invocation() {
+        assert_eq!(
+            Some(QualifiedType { answer: 42 }),
+            QualifiedType::extract(&indicio::value!({
+                outer: {
+                    answer: 42i64,
+                },
+            }))
+        );
+    }
+}


### PR DESCRIPTION
Enrich the core Value tree with typed accessors (as_bool, as_u64,
as_i64, as_f64, as_str, as_array, as_object), a ValueKind enum,
lookup_path for multi-segment traversal, and an ExtractionError type
that puzzle_piece! now returns from a new try_extract method, giving
callers missing-path and type-mismatch diagnostics.  The older
Option-returning extract stays for backward compatibility.

Add public helpers to Map (get, entries, len, is_empty) and Values
(push, as_slice, iter, len, is_empty), along with MapEntry accessors
(key, value, into_pair).  Re-export StdioEmitter, ProtobufEmitter,
ClueFrame, and ClueVector from the crate root.

Harden Collector by switching its internal emitter storage from
Box<dyn Emitter> to Arc<dyn Emitter>, cloning before calling emit so
emitters may safely re-enter or deregister the collector without
deadlocking.  Add Sync to the Emitter trait bound, register_arc, and
an enabled helper.  Upgrade atomic orderings from Relaxed to
Acquire/Release.  The clue! macro now accepts arbitrary expressions
for the collector argument instead of requiring a path.

Harden ProtobufEmitter: reject a zero rollover target, use
create_new to avoid clobbering existing files, rollback partial
writes on failure, implement Drop to flush on teardown, and escape
\r and \t in the Value Display impl.

Qualify all macro-internal paths with $crate:: so puzzle_piece!
and value_internal! work from external crates.  Switch puzzle_piece!
field type bounds from $ty:path to $ty:ty so types like i64 parse
correctly.  Update README to document the new scope and known warts.

Co-authored-by: AI
