### PR TITLE
feat(biometrics): add histograms, tooling, docs, and tests

### DIFF
--- a/biometrics/Cargo.toml
+++ b/biometrics/Cargo.toml
@@ -3,9 +3,23 @@ name = "biometrics"
 version = "0.14.0"
 authors = ["Robert Escriva <robert@rescrv.net>"]
 edition = { workspace = true }
-description = "Biometrics provide the vitals of a process in the form of counters, gauges, moments, and T-digests."
+description = "Biometrics provide the vitals of a process in the form of counters, gauges, moments, and histograms."
 license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
+[features]
+default = ["binaries"]
+
+binaries = ["dep:proc-macro2", "dep:serde", "dep:syn", "dep:toml"]
+
 [dependencies]
+proc-macro2 = { workspace = true, features = ["span-locations"], optional = true }
+serde = { workspace = true, optional = true }
 sig_fig_histogram = { workspace = true }
+syn = { version = "2.0", features = ["full", "visit"], optional = true }
+toml = { workspace = true, optional = true }
+
+[[bin]]
+name = "biometrics-audit-counters"
+path = "src/bin/biometrics-audit-counters.rs"
+required-features = ["binaries"]

--- a/biometrics/README.md
+++ b/biometrics/README.md
@@ -15,14 +15,18 @@ will affect how to register sensors in order to solve the dependency graph probl
 Scope
 -----
 
-Biometrics will provide core sensor types and a plaintext emitter for counter, gauge, and moments types.  Protocol
-buffer definitions for sensor readings can be found in the [biometrics_pb](https://crates.io/crates/biometrics_pb)
+Biometrics will provide core sensor types and a plaintext emitter for counter, gauge, moments, and histogram types.
+Protocol buffer definitions for sensor readings can be found in the
+[biometrics_pb](https://crates.io/crates/biometrics_pb)
 
 Warts
 -----
 
 - The blue repo currently is not uniform in its register_biometrics functions.  The convention is that a public method
   should not call other public methods.
+- A future breaking cleanup should make histogram observation errors directly visible, likely with `try_observe` and
+  `try_observe_n` methods or fallible `observe` methods.
+- A future breaking cleanup should normalize `register_biometrics` conventions across the wider blue repo.
 
 Documentation
 -------------

--- a/biometrics/src/bin/biometrics-audit-counters.rs
+++ b/biometrics/src/bin/biometrics-audit-counters.rs
@@ -330,24 +330,25 @@ impl<'ast> Visit<'ast> for CounterVisitor<'_> {
     }
 
     fn visit_item_static(&mut self, item: &'ast ItemStatic) {
-        if self.function_depth == 0 {
-            if let Some(label) = counter_new_label(&item.expr) {
-                self.audit.counters.push(CounterDefinition {
-                    ident: item.ident.to_string(),
-                    label,
-                    package_path: self.package_path.to_path_buf(),
-                    file: self.file.to_path_buf(),
-                    line: item.ident.span().start().line,
-                });
-            }
+        if self.function_depth == 0
+            && let Some(label) = counter_new_label(&item.expr)
+        {
+            self.audit.counters.push(CounterDefinition {
+                ident: item.ident.to_string(),
+                label,
+                package_path: self.package_path.to_path_buf(),
+                file: self.file.to_path_buf(),
+                line: item.ident.span().start().line,
+            });
         }
     }
 
     fn visit_expr_method_call(&mut self, method_call: &'ast ExprMethodCall) {
-        if method_call.method == "register_counter" && method_call.args.len() == 1 {
-            if let Some(ident) = registered_counter_ident(&method_call.args[0]) {
-                self.audit.registered.insert(ident);
-            }
+        if method_call.method == "register_counter"
+            && method_call.args.len() == 1
+            && let Some(ident) = registered_counter_ident(&method_call.args[0])
+        {
+            self.audit.registered.insert(ident);
         }
         visit::visit_expr_method_call(self, method_call);
     }

--- a/biometrics/src/bin/biometrics-audit-counters.rs
+++ b/biometrics/src/bin/biometrics-audit-counters.rs
@@ -1,0 +1,645 @@
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::io;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use serde::Deserialize;
+use syn::meta::ParseNestedMeta;
+use syn::visit::{self, Visit};
+use syn::{Attribute, Expr, ExprMethodCall, File, Item, ItemStatic, Lit, Path as SynPath};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Package {
+    name: String,
+    path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CounterDefinition {
+    ident: String,
+    label: String,
+    package_path: PathBuf,
+    file: PathBuf,
+    line: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MissingCounter {
+    label: String,
+    package_path: PathBuf,
+    file: PathBuf,
+    line: usize,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct FileAudit {
+    counters: Vec<CounterDefinition>,
+    registered: BTreeSet<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoManifest {
+    package: Option<CargoPackage>,
+    workspace: Option<CargoWorkspace>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoPackage {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoWorkspace {
+    #[serde(default)]
+    members: Vec<String>,
+}
+
+fn main() {
+    let root = match env::current_dir() {
+        Ok(root) => root,
+        Err(err) => {
+            eprintln!("error: failed to read current directory: {err}");
+            process::exit(2);
+        }
+    };
+    let args = env::args().skip(1);
+    match run(&root, args, &mut io::stdout()) {
+        Ok(status) => process::exit(status),
+        Err(err) => {
+            eprintln!("error: {err}");
+            process::exit(2);
+        }
+    }
+}
+
+fn run<I, W>(root: &Path, args: I, output: &mut W) -> Result<i32, String>
+where
+    I: IntoIterator<Item = String>,
+    W: Write,
+{
+    let package = parse_args(args)?;
+    let missing = audit_workspace(root, package.as_deref())?;
+    for counter in &missing {
+        writeln!(
+            output,
+            "{}\t{}\t{}",
+            counter.label,
+            path_to_string(&counter.file),
+            counter.line
+        )
+        .map_err(|err| format!("failed to write audit output: {err}"))?;
+    }
+    Ok(if missing.is_empty() { 0 } else { 1 })
+}
+
+fn parse_args<I>(args: I) -> Result<Option<String>, String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut args = args.into_iter();
+    let mut package = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-p" | "--package" => {
+                if package.is_some() {
+                    return Err(format!("package specified more than once\n{}", usage()));
+                }
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("missing package name after {arg}\n{}", usage()))?;
+                if value.is_empty() {
+                    return Err(format!("empty package name after {arg}\n{}", usage()));
+                }
+                package = Some(value);
+            }
+            "-h" | "--help" => {
+                return Err(usage().to_string());
+            }
+            _ => {
+                return Err(format!("unexpected argument: {arg}\n{}", usage()));
+            }
+        }
+    }
+    Ok(package)
+}
+
+fn usage() -> &'static str {
+    "usage: biometrics-audit-counters [-p <package>]"
+}
+
+fn audit_workspace(root: &Path, package: Option<&str>) -> Result<Vec<MissingCounter>, String> {
+    let packages = select_packages(load_workspace_packages(root)?, package)?;
+    let mut missing = Vec::new();
+    for package in packages {
+        missing.extend(audit_package(root, &package)?);
+    }
+    missing.sort_by(|lhs, rhs| {
+        lhs.package_path
+            .cmp(&rhs.package_path)
+            .then_with(|| lhs.file.cmp(&rhs.file))
+            .then_with(|| lhs.line.cmp(&rhs.line))
+            .then_with(|| lhs.label.cmp(&rhs.label))
+    });
+    Ok(missing)
+}
+
+fn select_packages(packages: Vec<Package>, package: Option<&str>) -> Result<Vec<Package>, String> {
+    if let Some(package) = package {
+        let matches: Vec<Package> = packages
+            .into_iter()
+            .filter(|candidate| candidate.name == package)
+            .collect();
+        match matches.len() {
+            0 => Err(format!("package not found in workspace: {package}")),
+            1 => Ok(matches),
+            _ => Err(format!("package name is ambiguous in workspace: {package}")),
+        }
+    } else {
+        Ok(packages)
+    }
+}
+
+fn load_workspace_packages(root: &Path) -> Result<Vec<Package>, String> {
+    let manifest = load_manifest(&root.join("Cargo.toml"))?;
+    let mut packages = Vec::new();
+    if let Some(workspace) = manifest.workspace {
+        for member in workspace.members {
+            if member.contains('*') {
+                return Err(format!(
+                    "workspace member globs are not supported: {member}"
+                ));
+            }
+            let package_path = PathBuf::from(&member);
+            let member_manifest = load_manifest(&root.join(&package_path).join("Cargo.toml"))?;
+            let package = member_manifest.package.ok_or_else(|| {
+                format!(
+                    "workspace member has no [package] section: {}",
+                    path_to_string(&package_path)
+                )
+            })?;
+            packages.push(Package {
+                name: package.name,
+                path: package_path,
+            });
+        }
+    } else if let Some(package) = manifest.package {
+        packages.push(Package {
+            name: package.name,
+            path: PathBuf::from("."),
+        });
+    } else {
+        return Err("Cargo.toml contains neither [workspace] nor [package]".to_string());
+    }
+    packages.sort_by(|lhs, rhs| {
+        lhs.path
+            .cmp(&rhs.path)
+            .then_with(|| lhs.name.cmp(&rhs.name))
+    });
+    Ok(packages)
+}
+
+fn load_manifest(path: &Path) -> Result<CargoManifest, String> {
+    let contents = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read {}: {err}", path_to_string(path)))?;
+    toml::from_str(&contents)
+        .map_err(|err| format!("failed to parse {}: {err}", path_to_string(path)))
+}
+
+fn audit_package(root: &Path, package: &Package) -> Result<Vec<MissingCounter>, String> {
+    let package_root = root.join(&package.path);
+    let src = package_root.join("src");
+    let files = rust_files_under(&src)?;
+    let mut counters = Vec::new();
+    let mut registered = BTreeSet::new();
+    for file in files {
+        let relative_file = relative_to_root(root, &file);
+        let source = fs::read_to_string(&file)
+            .map_err(|err| format!("failed to read {}: {err}", path_to_string(&relative_file)))?;
+        let audit = audit_rust_source(&package.path, &relative_file, &source)?;
+        counters.extend(audit.counters);
+        registered.extend(audit.registered);
+    }
+    Ok(missing_counters(counters, &registered))
+}
+
+fn rust_files_under(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut files = Vec::new();
+    collect_rust_files(root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(dir)
+        .map_err(|err| format!("failed to read directory {}: {err}", path_to_string(dir)))?
+    {
+        let entry = entry.map_err(|err| {
+            format!(
+                "failed to read directory entry in {}: {err}",
+                path_to_string(dir)
+            )
+        })?;
+        entries.push(entry);
+    }
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|err| format!("failed to stat {}: {err}", path_to_string(&path)))?;
+        if file_type.is_dir() {
+            if !is_ignored_dir(&path) {
+                collect_rust_files(&path, files)?;
+            }
+        } else if file_type.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn is_ignored_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "target" || name.starts_with('.'))
+}
+
+fn audit_rust_source(package_path: &Path, file: &Path, source: &str) -> Result<FileAudit, String> {
+    let parsed = syn::parse_file(source)
+        .map_err(|err| format!("failed to parse {}: {err}", path_to_string(file)))?;
+    Ok(audit_syntax_tree(package_path, file, &parsed))
+}
+
+fn audit_syntax_tree(package_path: &Path, file: &Path, parsed: &File) -> FileAudit {
+    let mut visitor = CounterVisitor {
+        package_path,
+        file,
+        function_depth: 0,
+        audit: FileAudit::default(),
+    };
+    visitor.visit_file(parsed);
+    visitor.audit
+}
+
+fn missing_counters(
+    mut counters: Vec<CounterDefinition>,
+    registered: &BTreeSet<String>,
+) -> Vec<MissingCounter> {
+    counters.sort_by(|lhs, rhs| {
+        lhs.package_path
+            .cmp(&rhs.package_path)
+            .then_with(|| lhs.file.cmp(&rhs.file))
+            .then_with(|| lhs.line.cmp(&rhs.line))
+            .then_with(|| lhs.label.cmp(&rhs.label))
+    });
+    counters
+        .into_iter()
+        .filter(|counter| !registered.contains(&counter.ident))
+        .map(|counter| MissingCounter {
+            label: counter.label,
+            package_path: counter.package_path,
+            file: counter.file,
+            line: counter.line,
+        })
+        .collect()
+}
+
+struct CounterVisitor<'a> {
+    package_path: &'a Path,
+    file: &'a Path,
+    function_depth: usize,
+    audit: FileAudit,
+}
+
+impl<'ast> Visit<'ast> for CounterVisitor<'_> {
+    fn visit_item(&mut self, item: &'ast Item) {
+        if item_attrs(item).is_some_and(is_ignored_item) {
+            return;
+        }
+        visit::visit_item(self, item);
+    }
+
+    fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+        self.function_depth += 1;
+        visit::visit_item_fn(self, item);
+        self.function_depth -= 1;
+    }
+
+    fn visit_item_static(&mut self, item: &'ast ItemStatic) {
+        if self.function_depth == 0 {
+            if let Some(label) = counter_new_label(&item.expr) {
+                self.audit.counters.push(CounterDefinition {
+                    ident: item.ident.to_string(),
+                    label,
+                    package_path: self.package_path.to_path_buf(),
+                    file: self.file.to_path_buf(),
+                    line: item.ident.span().start().line,
+                });
+            }
+        }
+    }
+
+    fn visit_expr_method_call(&mut self, method_call: &'ast ExprMethodCall) {
+        if method_call.method == "register_counter" && method_call.args.len() == 1 {
+            if let Some(ident) = registered_counter_ident(&method_call.args[0]) {
+                self.audit.registered.insert(ident);
+            }
+        }
+        visit::visit_expr_method_call(self, method_call);
+    }
+}
+
+fn item_attrs(item: &Item) -> Option<&[Attribute]> {
+    match item {
+        Item::Const(item) => Some(&item.attrs),
+        Item::Enum(item) => Some(&item.attrs),
+        Item::ExternCrate(item) => Some(&item.attrs),
+        Item::Fn(item) => Some(&item.attrs),
+        Item::ForeignMod(item) => Some(&item.attrs),
+        Item::Impl(item) => Some(&item.attrs),
+        Item::Macro(item) => Some(&item.attrs),
+        Item::Mod(item) => Some(&item.attrs),
+        Item::Static(item) => Some(&item.attrs),
+        Item::Struct(item) => Some(&item.attrs),
+        Item::Trait(item) => Some(&item.attrs),
+        Item::TraitAlias(item) => Some(&item.attrs),
+        Item::Type(item) => Some(&item.attrs),
+        Item::Union(item) => Some(&item.attrs),
+        Item::Use(item) => Some(&item.attrs),
+        Item::Verbatim(_) => None,
+        _ => None,
+    }
+}
+
+fn is_ignored_item(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(is_cfg_test_attr) || attrs.iter().any(is_test_attr)
+}
+
+fn is_test_attr(attr: &Attribute) -> bool {
+    attr.path().is_ident("test")
+}
+
+fn is_cfg_test_attr(attr: &Attribute) -> bool {
+    if !attr.path().is_ident("cfg") {
+        return false;
+    }
+    let mut requires_test = false;
+    let _ = attr.parse_nested_meta(|meta| mark_cfg_requires_test(meta, &mut requires_test));
+    requires_test
+}
+
+fn mark_cfg_requires_test(meta: ParseNestedMeta<'_>, requires_test: &mut bool) -> syn::Result<()> {
+    if meta.path.is_ident("test") {
+        *requires_test = true;
+    } else if meta.path.is_ident("all") {
+        meta.parse_nested_meta(|nested| mark_cfg_requires_test(nested, requires_test))?;
+    }
+    Ok(())
+}
+
+fn counter_new_label(expr: &Expr) -> Option<String> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    if call.args.len() != 1 || !is_counter_new_path_expr(&call.func) {
+        return None;
+    }
+    let Expr::Lit(lit) = &call.args[0] else {
+        return None;
+    };
+    let Lit::Str(label) = &lit.lit else {
+        return None;
+    };
+    Some(label.value())
+}
+
+fn is_counter_new_path_expr(expr: &Expr) -> bool {
+    let Expr::Path(path) = expr else {
+        return false;
+    };
+    if path.qself.is_some() {
+        return false;
+    }
+    is_counter_new_path(&path.path)
+}
+
+fn is_counter_new_path(path: &SynPath) -> bool {
+    let segments: Vec<String> = path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect();
+    segments == ["Counter", "new"] || segments == ["biometrics", "Counter", "new"]
+}
+
+fn registered_counter_ident(expr: &Expr) -> Option<String> {
+    let Expr::Reference(reference) = expr else {
+        return None;
+    };
+    let Expr::Path(path) = reference.expr.as_ref() else {
+        return None;
+    };
+    if path.qself.is_some() || path.path.segments.len() != 1 {
+        return None;
+    }
+    Some(path.path.segments[0].ident.to_string())
+}
+
+fn relative_to_root(root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn registered_static_counter_produces_no_missing_row() {
+        let source = "use biometrics::{Collector, Counter};\nstatic REQUESTS: Counter = Counter::new(\"requests\");\nfn register(collector: &Collector) {\n    collector.register_counter(&REQUESTS);\n}\n";
+        let missing = audit_sources(&[("pkg/src/lib.rs", source)]).unwrap();
+
+        assert_eq!(Vec::<MissingCounter>::new(), missing);
+    }
+
+    #[test]
+    fn unregistered_static_counter_reports_label_file_and_line() {
+        let source =
+            "use biometrics::Counter;\nstatic MISSED: Counter = Counter::new(\"missed\");\n";
+        let missing = audit_sources(&[("pkg/src/lib.rs", source)]).unwrap();
+
+        assert_eq!(
+            vec![MissingCounter {
+                label: "missed".to_string(),
+                package_path: PathBuf::from("pkg"),
+                file: PathBuf::from("pkg/src/lib.rs"),
+                line: 2,
+            }],
+            missing
+        );
+    }
+
+    #[test]
+    fn counter_new_forms_are_detected() {
+        let source = "use biometrics::Counter;\nstatic IMPORTED: Counter = Counter::new(\"imported\");\nstatic QUALIFIED: biometrics::Counter = biometrics::Counter::new(\"qualified\");\n";
+        let missing = audit_sources(&[("pkg/src/lib.rs", source)]).unwrap();
+
+        assert_eq!(
+            vec![
+                MissingCounter {
+                    label: "imported".to_string(),
+                    package_path: PathBuf::from("pkg"),
+                    file: PathBuf::from("pkg/src/lib.rs"),
+                    line: 2,
+                },
+                MissingCounter {
+                    label: "qualified".to_string(),
+                    package_path: PathBuf::from("pkg"),
+                    file: PathBuf::from("pkg/src/lib.rs"),
+                    line: 3,
+                },
+            ],
+            missing
+        );
+    }
+
+    #[test]
+    fn test_only_and_local_counters_are_ignored() {
+        let source = "use biometrics::Counter;\n#[cfg(test)]\nmod tests {\n    use super::*;\n    static TEST_ONLY: Counter = Counter::new(\"test.only\");\n}\n#[test]\nfn test_function() {\n    static LOCAL_TEST: Counter = Counter::new(\"local.test\");\n}\nfn runtime_function() {\n    static LOCAL_RUNTIME: Counter = Counter::new(\"local.runtime\");\n    let _counter = Counter::new(\"local.value\");\n}\n";
+        let missing = audit_sources(&[("pkg/src/lib.rs", source)]).unwrap();
+
+        assert_eq!(Vec::<MissingCounter>::new(), missing);
+    }
+
+    #[test]
+    fn test_function_registration_does_not_register_production_counter() {
+        let source = "use biometrics::{Collector, Counter};\nstatic PRODUCTION: Counter = Counter::new(\"production\");\n#[test]\nfn registers_only_in_tests() {\n    let collector = Collector::new();\n    collector.register_counter(&PRODUCTION);\n}\n";
+        let missing = audit_sources(&[("pkg/src/lib.rs", source)]).unwrap();
+
+        assert_eq!(
+            vec![MissingCounter {
+                label: "production".to_string(),
+                package_path: PathBuf::from("pkg"),
+                file: PathBuf::from("pkg/src/lib.rs"),
+                line: 2,
+            }],
+            missing
+        );
+    }
+
+    #[test]
+    fn workspace_and_package_selection() {
+        let temp = TempDir::new();
+        temp.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"one\", \"two\"]\nresolver = \"3\"\n",
+        );
+        temp.write(
+            "one/Cargo.toml",
+            "[package]\nname = \"one\"\nversion = \"0.0.0\"\n",
+        );
+        temp.write(
+            "one/src/lib.rs",
+            "static ONE: biometrics::Counter = biometrics::Counter::new(\"one.missing\");\n",
+        );
+        temp.write(
+            "two/Cargo.toml",
+            "[package]\nname = \"two\"\nversion = \"0.0.0\"\n",
+        );
+        temp.write(
+            "two/src/lib.rs",
+            "static TWO: biometrics::Counter = biometrics::Counter::new(\"two.missing\");\n",
+        );
+
+        let workspace_missing = audit_workspace(temp.path(), None).unwrap();
+        let selected_missing = audit_workspace(temp.path(), Some("two")).unwrap();
+
+        assert_eq!(
+            vec![
+                MissingCounter {
+                    label: "one.missing".to_string(),
+                    package_path: PathBuf::from("one"),
+                    file: PathBuf::from("one/src/lib.rs"),
+                    line: 1,
+                },
+                MissingCounter {
+                    label: "two.missing".to_string(),
+                    package_path: PathBuf::from("two"),
+                    file: PathBuf::from("two/src/lib.rs"),
+                    line: 1,
+                },
+            ],
+            workspace_missing
+        );
+        assert_eq!(
+            vec![MissingCounter {
+                label: "two.missing".to_string(),
+                package_path: PathBuf::from("two"),
+                file: PathBuf::from("two/src/lib.rs"),
+                line: 1,
+            }],
+            selected_missing
+        );
+    }
+
+    fn audit_sources(sources: &[(&str, &str)]) -> Result<Vec<MissingCounter>, String> {
+        let package_path = Path::new("pkg");
+        let mut counters = Vec::new();
+        let mut registered = BTreeSet::new();
+        for (file, source) in sources {
+            let audit = audit_rust_source(package_path, Path::new(file), source)?;
+            counters.extend(audit.counters);
+            registered.extend(audit.registered);
+        }
+        Ok(missing_counters(counters, &registered))
+    }
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let nonce = NEXT_TEMP_DIR.fetch_add(1, Ordering::Relaxed);
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = env::temp_dir().join(format!(
+                "biometrics-audit-counters-test-{}-{nanos}-{nonce}",
+                process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn write(&self, relative: &str, contents: &str) {
+            let path = self.path.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, contents).unwrap();
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}

--- a/biometrics/src/lib.rs
+++ b/biometrics/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
 
 use std::fs::File;
 use std::io::Write;
@@ -24,7 +25,7 @@ pub trait Sensor {
     /// Every sensor has a label.  This is a UTF-8 string.  It must be static because sensors are
     /// meant to be instantiated statically as well, and having the constraint here enforces that.
     fn label(&self) -> &'static str;
-    /// Return a linearlizable view of the sensor.
+    /// Return a linearizable view of the sensor.
     fn read(&self) -> Self::Reading;
 }
 
@@ -42,7 +43,7 @@ impl<S: Sensor + 'static> SensorRegistry<S> {
     /// Create a new [SensorRegistry] using the three counters for internal instrumentation.  We
     /// don't define these counters here, so that each registry can define its own counters and get
     /// ground truth about the registry.
-    pub fn new(register: &'static Counter, emit: &'static Counter, err: &'static Counter) -> Self {
+    fn new(register: &'static Counter, emit: &'static Counter, err: &'static Counter) -> Self {
         Self {
             sensors: Mutex::new(Vec::new()),
             register,
@@ -52,7 +53,7 @@ impl<S: Sensor + 'static> SensorRegistry<S> {
     }
 
     /// Unconditionally register the sensor with the sensor library.
-    pub fn register(&self, sensor: &'static S) {
+    fn register(&self, sensor: &'static S) {
         {
             let mut sensors = self.sensors.lock().unwrap();
             sensors.push(sensor);
@@ -68,14 +69,7 @@ impl<S: Sensor + 'static> SensorRegistry<S> {
         emit: impl Fn(&mut EM, &S, u64) -> Result<(), ERR>,
         now: u64,
     ) -> Result<(), ERR> {
-        let num_sensors = { self.sensors.lock().unwrap().len() };
-        let mut sensors: Vec<&'static S> = Vec::with_capacity(num_sensors);
-        {
-            let sensors_guard = self.sensors.lock().unwrap();
-            for s in sensors_guard.iter() {
-                sensors.push(*s);
-            }
-        }
+        let sensors = self.sensors.lock().unwrap().clone();
         let mut result = Ok(());
         for sensor in sensors {
             match emit(emitter, sensor, now) {
@@ -170,13 +164,13 @@ impl Collector {
         self.moments.register(moments);
     }
 
-    /// Register `moments` with the Collector.
+    /// Register `histogram` with the Collector.
     pub fn register_histogram(&self, histogram: &'static Histogram) {
         self.histograms.register(histogram);
     }
 
     /// Output the sensors registered to this emitter.
-    pub fn emit<EM: Emitter<Error = ERR>, ERR: std::fmt::Debug>(
+    pub fn emit<EM: Emitter<Error = ERR>, ERR>(
         &self,
         emitter: &mut EM,
         now: u64,
@@ -257,7 +251,7 @@ impl Emitter for PlainTextEmitter {
         let label = histogram.label();
         for (bucket, count) in histogram.read().iter() {
             self.output
-                .write_fmt(format_args!("{label} {now} {{approx={bucket}}} {count}",))?;
+                .write_fmt(format_args!("{label} {now} {{approx={bucket}}} {count}\n",))?;
         }
         Ok(())
     }
@@ -267,10 +261,119 @@ impl Emitter for PlainTextEmitter {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::{File, read_to_string, remove_file};
+    use std::sync::Mutex;
+
     use super::*;
 
     #[test]
     fn collector_new() {
         let _: Collector = Collector::new();
+    }
+
+    #[derive(Default)]
+    struct RecordingEmitter {
+        events: Vec<(&'static str, &'static str)>,
+    }
+
+    impl Emitter for RecordingEmitter {
+        type Error = std::io::Error;
+
+        fn emit_counter(&mut self, counter: &Counter, _: u64) -> Result<(), Self::Error> {
+            self.events.push(("counter", counter.label()));
+            Ok(())
+        }
+
+        fn emit_gauge(&mut self, gauge: &Gauge, _: u64) -> Result<(), Self::Error> {
+            self.events.push(("gauge", gauge.label()));
+            Ok(())
+        }
+
+        fn emit_moments(&mut self, moments: &Moments, _: u64) -> Result<(), Self::Error> {
+            self.events.push(("moments", moments.label()));
+            Ok(())
+        }
+
+        fn emit_histogram(&mut self, histogram: &Histogram, _: u64) -> Result<(), Self::Error> {
+            self.events.push(("histogram", histogram.label()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn collector_emits_registered_sensor_types() {
+        static COUNTER: Counter = Counter::new("collector.emits.counter");
+        static GAUGE: Gauge = Gauge::new("collector.emits.gauge");
+        static MOMENTS: Moments = Moments::new("collector.emits.moments");
+        static HISTOGRAM_IMPL: sig_fig_histogram::LockFreeHistogram<1> =
+            sig_fig_histogram::LockFreeHistogram::new(2);
+        static HISTOGRAM: Histogram = Histogram::new("collector.emits.histogram", &HISTOGRAM_IMPL);
+
+        let collector = Collector::new();
+        collector.register_counter(&COUNTER);
+        collector.register_gauge(&GAUGE);
+        collector.register_moments(&MOMENTS);
+        collector.register_histogram(&HISTOGRAM);
+        let mut emitter = RecordingEmitter::default();
+
+        collector.emit(&mut emitter, 42).unwrap();
+
+        assert!(
+            emitter
+                .events
+                .contains(&("counter", "collector.emits.counter"))
+        );
+        assert!(emitter.events.contains(&("gauge", "collector.emits.gauge")));
+        assert!(
+            emitter
+                .events
+                .contains(&("moments", "collector.emits.moments"))
+        );
+        assert!(
+            emitter
+                .events
+                .contains(&("histogram", "collector.emits.histogram"))
+        );
+    }
+
+    #[test]
+    fn plain_text_emitter_writes_one_reading_per_line() {
+        static MUTEX: Mutex<()> = Mutex::new(());
+        static COUNTER: Counter = Counter::new("plain.counter");
+        static GAUGE: Gauge = Gauge::new("plain.gauge");
+        static MOMENTS: Moments = Moments::new("plain.moments");
+        static HISTOGRAM_IMPL: sig_fig_histogram::LockFreeHistogram<2> =
+            sig_fig_histogram::LockFreeHistogram::new(2);
+        static HISTOGRAM: Histogram = Histogram::new("plain.histogram", &HISTOGRAM_IMPL);
+        let _guard = MUTEX.lock().unwrap();
+        let path = "tmp.biometrics.plain_text_emitter_writes_one_reading_per_line";
+        if std::path::Path::new(path).exists() {
+            remove_file(path).unwrap();
+        }
+
+        COUNTER.count(3);
+        GAUGE.set(12.5);
+        MOMENTS.add(1.0);
+        MOMENTS.add(3.0);
+        HISTOGRAM.observe(1.0);
+        HISTOGRAM.observe_n(1.1, 3);
+        {
+            let file = File::create(path).unwrap();
+            let mut emitter = PlainTextEmitter::new(file);
+            emitter.emit_counter(&COUNTER, 7).unwrap();
+            emitter.emit_gauge(&GAUGE, 7).unwrap();
+            emitter.emit_moments(&MOMENTS, 7).unwrap();
+            emitter.emit_histogram(&HISTOGRAM, 7).unwrap();
+        }
+
+        assert_eq!(
+            "plain.counter 7 3\n\
+plain.gauge 7 12.5\n\
+plain.moments 7 2 2 2 0 2\n\
+plain.histogram 7 {approx=1} 1\n\
+plain.histogram 7 {approx=1.1} 3\n",
+            read_to_string(path).unwrap()
+        );
+        remove_file(path).unwrap();
     }
 }

--- a/biometrics/src/moments.rs
+++ b/biometrics/src/moments.rs
@@ -6,9 +6,9 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 /// kurtosis (m4).  When a distribution goes long tailed, skewness and kurtosis blow up, so the
 /// hope is that this type will be good for monitoring general "no bad tail" insights.
 ///
-/// The type itelf is algebraic.  Take two readings separated by time and subtract them to get
+/// The type itself is algebraic.  Take two readings separated by time and subtract them to get
 /// perfectly recorded moments for the interval between the points.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct Moments {
     /// The number of observations.
     pub n: u64,
@@ -78,6 +78,12 @@ impl Moments {
     /// Add two [Moments] together to get the equivalent of one that had the same set of values
     /// pushed.
     pub fn add(lhs: &Self, rhs: &Self) -> Self {
+        if lhs.n == 0 {
+            return *rhs;
+        }
+        if rhs.n == 0 {
+            return *lhs;
+        }
         let delta: f64 = rhs.m1 - lhs.m1;
         let delta2: f64 = delta * delta;
         let delta3: f64 = delta * delta2;
@@ -106,11 +112,29 @@ impl Moments {
         }
     }
 
-    /// Compute lhs - rhs.
+    /// Compute `lhs - rhs`.
+    ///
+    /// This operation treats `rhs` as an earlier cumulative reading and `lhs` as a later
+    /// cumulative reading.  The result is the moments for the observations that occurred between
+    /// the two readings.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rhs` contains more observations than `lhs`.
     pub fn sub(lhs: &Self, rhs: &Self) -> Self {
+        assert!(
+            lhs.n >= rhs.n,
+            "cannot subtract a moments reading with more observations"
+        );
+        if rhs.n == 0 {
+            return *lhs;
+        }
+        if lhs.n == rhs.n {
+            return Self::new();
+        }
         let lhs_n: f64 = lhs.n as f64;
         let rhs_n: f64 = rhs.n as f64;
-        let n: f64 = (rhs.n - lhs.n) as f64;
+        let n: f64 = (lhs.n - rhs.n) as f64;
         let m1: f64 = (lhs_n * lhs.m1 - rhs_n * rhs.m1) / n;
         let delta: f64 = rhs.m1 - m1;
         let delta2: f64 = delta * delta;
@@ -170,15 +194,116 @@ impl SubAssign<Moments> for Moments {
 mod tests {
     use super::*;
 
+    const EPSILON: f64 = 1e-10;
+
+    fn moments_from(values: &[f64]) -> Moments {
+        let mut moments = Moments::new();
+        for value in values {
+            moments.push(*value);
+        }
+        moments
+    }
+
+    fn assert_close(expected: f64, actual: f64) {
+        if expected.is_nan() {
+            assert!(actual.is_nan(), "expected NaN, got {actual}");
+        } else {
+            assert!(
+                (expected - actual).abs() <= EPSILON,
+                "expected {expected}, got {actual}"
+            );
+        }
+    }
+
+    fn assert_moments_approx(expected: Moments, actual: Moments) {
+        assert_eq!(expected.n, actual.n);
+        assert_close(expected.m1, actual.m1);
+        assert_close(expected.m2, actual.m2);
+        assert_close(expected.m3, actual.m3);
+        assert_close(expected.m4, actual.m4);
+    }
+
     #[test]
     fn moments_may_be_static() {
         static MOMENTS: Moments = Moments::new();
-        println!(
-            "MOMENTS = {} {} {} {}",
-            MOMENTS.n(),
-            MOMENTS.mean(),
-            MOMENTS.skewness(),
-            MOMENTS.kurtosis()
+        assert_eq!(Moments::new(), MOMENTS);
+    }
+
+    #[test]
+    fn empty_moments_are_zero() {
+        assert_eq!(
+            Moments {
+                n: 0,
+                m1: 0.0,
+                m2: 0.0,
+                m3: 0.0,
+                m4: 0.0,
+            },
+            Moments::new()
         );
+    }
+
+    #[test]
+    fn one_observation_has_undefined_sample_statistics() {
+        let moments = moments_from(&[42.0]);
+        assert_eq!(
+            Moments {
+                n: 1,
+                m1: 42.0,
+                m2: 0.0,
+                m3: 0.0,
+                m4: 0.0,
+            },
+            moments
+        );
+        assert!(moments.variance().is_nan());
+        assert!(moments.skewness().is_nan());
+        assert!(moments.kurtosis().is_nan());
+    }
+
+    #[test]
+    fn add_empty_is_identity() {
+        let populated = moments_from(&[1.0, 3.0, 5.0]);
+
+        assert_eq!(populated, Moments::add(&Moments::new(), &populated));
+        assert_eq!(populated, Moments::add(&populated, &Moments::new()));
+        assert_eq!(
+            Moments::new(),
+            Moments::add(&Moments::new(), &Moments::new())
+        );
+    }
+
+    #[test]
+    fn add_matches_incremental_push() {
+        let lhs = moments_from(&[1.0, 2.0, 3.0]);
+        let rhs = moments_from(&[10.0, 20.0]);
+        let expected = moments_from(&[1.0, 2.0, 3.0, 10.0, 20.0]);
+
+        assert_moments_approx(expected, Moments::add(&lhs, &rhs));
+    }
+
+    #[test]
+    fn sub_extracts_interval_between_readings() {
+        let earlier = moments_from(&[1.0, 2.0, 3.0]);
+        let interval = moments_from(&[5.0, 8.0, 13.0]);
+        let later = Moments::add(&earlier, &interval);
+
+        assert_moments_approx(interval, Moments::sub(&later, &earlier));
+    }
+
+    #[test]
+    fn sub_with_no_new_observations_is_empty() {
+        let reading = moments_from(&[1.0, 2.0, 3.0]);
+
+        assert_eq!(Moments::new(), Moments::sub(&reading, &reading));
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot subtract a moments reading with more observations")]
+    fn sub_panics_when_rhs_has_more_observations() {
+        let earlier = moments_from(&[1.0, 2.0, 3.0]);
+        let later = moments_from(&[1.0]);
+
+        let _ = Moments::sub(&later, &earlier);
     }
 }

--- a/biometrics/src/sensors.rs
+++ b/biometrics/src/sensors.rs
@@ -132,9 +132,17 @@ impl Sensor for Moments {
 
 ///////////////////////////////////////////// Histogram ////////////////////////////////////////////
 
+/// Stores histogram observations for a [`Histogram`] sensor.
+///
+/// Implementations provide the storage strategy.  The crate ships an implementation for
+/// [`sig_fig_histogram::LockFreeHistogram`], which is suitable for static sensors shared across
+/// threads.
 pub trait HistogramImpl: Send + Sync {
+    /// Record one observation.
     fn observe(&self, x: f64) -> Result<(), sig_fig_histogram::Error>;
+    /// Record `n` copies of one observation.
     fn observe_n(&self, x: f64, n: u64) -> Result<(), sig_fig_histogram::Error>;
+    /// Convert the current state to an owned histogram reading.
     fn to_histogram(&self) -> sig_fig_histogram::Histogram;
 }
 
@@ -152,6 +160,11 @@ impl<const N: usize> HistogramImpl for sig_fig_histogram::LockFreeHistogram<N> {
     }
 }
 
+/// [Histogram] captures a distribution of non-negative floating point observations.
+///
+/// Invalid observations do not escape as errors.  Instead, observations that exceed the backing
+/// histogram's maximum bucket increment [`Histogram::exceeds_max`], while negative observations
+/// increment [`Histogram::is_negative`].
 pub struct Histogram {
     label: &'static str,
     histogram: &'static dyn HistogramImpl,
@@ -160,6 +173,7 @@ pub struct Histogram {
 }
 
 impl Histogram {
+    /// Create a new histogram sensor with the provided label and backing implementation.
     pub const fn new(label: &'static str, histogram: &'static dyn HistogramImpl) -> Self {
         let exceeds_max = Counter::new(label);
         let is_negative = Counter::new(label);
@@ -173,14 +187,17 @@ impl Histogram {
 }
 
 impl Histogram {
+    /// Return the counter for observations that exceed the backing histogram's maximum bucket.
     pub fn exceeds_max(&self) -> &Counter {
         &self.exceeds_max
     }
 
+    /// Return the counter for observations that are negative.
     pub fn is_negative(&self) -> &Counter {
         &self.is_negative
     }
 
+    /// Record one observation or count why it could not be recorded.
     pub fn observe(&self, x: f64) {
         match self.histogram.observe(x) {
             Ok(()) => {}
@@ -193,6 +210,7 @@ impl Histogram {
         }
     }
 
+    /// Record `n` copies of one observation or count why they could not be recorded.
     pub fn observe_n(&self, x: f64, n: u64) {
         match self.histogram.observe_n(x, n) {
             Ok(()) => {}
@@ -240,8 +258,29 @@ mod tests {
     }
 
     #[test]
+    fn counter_counts_clicks_and_batches() {
+        let counter = Counter::new("counter.counts.clicks.and.batches");
+
+        assert_eq!("counter.counts.clicks.and.batches", counter.label());
+        assert_eq!(0, counter.read());
+        counter.click();
+        counter.count(41);
+        assert_eq!(42, counter.read());
+    }
+
+    #[test]
     fn gauge_may_be_static() {
         static _GAUGE: Gauge = Gauge::new("gauge.may.be.static");
+    }
+
+    #[test]
+    fn gauge_sets_floating_point_value() {
+        let gauge = Gauge::new("gauge.sets.floating.point.value");
+
+        assert_eq!("gauge.sets.floating.point.value", gauge.label());
+        assert_eq!(0.0_f64.to_bits(), gauge.read().to_bits());
+        gauge.set(-13.5);
+        assert_eq!((-13.5_f64).to_bits(), gauge.read().to_bits());
     }
 
     #[test]
@@ -255,8 +294,16 @@ mod tests {
         MOMENTS.add(0.0);
         MOMENTS.add(5.0);
         MOMENTS.add(10.0);
-        assert_eq!(MOMENTS.read().n(), 3);
-        assert_eq!(MOMENTS.read().mean(), 5.0);
+        assert_eq!(
+            moments::Moments {
+                n: 3,
+                m1: 5.0,
+                m2: 50.0,
+                m3: 0.0,
+                m4: 1250.0,
+            },
+            MOMENTS.read()
+        );
     }
 
     #[test]
@@ -267,5 +314,26 @@ mod tests {
         HISTOGRAM_SENSOR.observe(0.0);
         HISTOGRAM_SENSOR.observe(5.0);
         HISTOGRAM_SENSOR.observe(10.0);
+    }
+
+    #[test]
+    fn histogram_records_observations_and_error_counters() {
+        static HISTOGRAM: sig_fig_histogram::LockFreeHistogram<1> =
+            sig_fig_histogram::LockFreeHistogram::new(2);
+        static HISTOGRAM_SENSOR: Histogram = Histogram::new(
+            "histogram.records.observations.and.error.counters",
+            &HISTOGRAM,
+        );
+
+        HISTOGRAM_SENSOR.observe_n(1.0, 4);
+        HISTOGRAM_SENSOR.observe(2.0);
+        HISTOGRAM_SENSOR.observe(-1.0);
+
+        assert_eq!(
+            vec![(1.0, 4)],
+            HISTOGRAM_SENSOR.read().iter().collect::<Vec<_>>()
+        );
+        assert_eq!(1, HISTOGRAM_SENSOR.exceeds_max().read());
+        assert_eq!(1, HISTOGRAM_SENSOR.is_negative().read());
     }
 }

--- a/biometrics_pb/Cargo.toml
+++ b/biometrics_pb/Cargo.toml
@@ -13,5 +13,6 @@ buffertk = { workspace = true }
 one_two_eight = { workspace = true }
 prototk = { workspace = true }
 prototk_derive = { workspace = true }
+sig_fig_histogram = { workspace = true }
 tuple_key = { workspace = true }
 tuple_key_derive = { workspace = true }

--- a/biometrics_pb/README.md
+++ b/biometrics_pb/README.md
@@ -9,18 +9,10 @@ Status
 Active development.  Biometrics is likely to change in the near future in backwards-incompatible ways and the readings
 may change too.  Planned changes will affect how to register sensors in order to solve the dependency graph problem.
 
-This library will be documented when it transitions to maintenance track.
-
 Scope
 -----
 
 This library should provide one type for each type of reading supported by the biometrics crate.
-
-Warts
------
-
-- Currently there's no support for T-digest.
-- Currently there's no documentation.
 
 Documentation
 -------------

--- a/biometrics_pb/src/lib.rs
+++ b/biometrics_pb/src/lib.rs
@@ -1,4 +1,4 @@
-//! biometrics_pb provides protocol buffers corresponding to biometric readings.
+#![doc = include_str!("../README.md")]
 
 use std::fmt::{Display, Formatter};
 
@@ -13,17 +13,25 @@ generate_id_prototk! {SensorID}
 
 /////////////////////////////////////////// SensorReading //////////////////////////////////////////
 
-#[derive(Clone, Debug, Default, prototk_derive::Message)]
+/// A protocol-buffer representation of one biometric sensor reading.
+#[derive(Clone, Debug, Default, PartialEq, prototk_derive::Message)]
 pub enum SensorReading {
+    /// An unset reading.
     #[default]
     #[prototk(1, message)]
     Zero,
+    /// A counter reading.
     #[prototk(2, message)]
     Counter(CounterPb),
+    /// A gauge reading.
     #[prototk(3, message)]
     Gauge(GaugePb),
+    /// A moments reading.
     #[prototk(4, message)]
     Moments(MomentsPb),
+    /// A histogram reading.
+    #[prototk(5, message)]
+    Histogram(HistogramPb),
 }
 
 impl Display for SensorReading {
@@ -39,14 +47,24 @@ impl Display for SensorReading {
             SensorReading::Moments(moments) => {
                 write!(f, "{}, ...", moments.n)
             }
+            SensorReading::Histogram(histogram) => {
+                write!(
+                    f,
+                    "{} sig figs, {} buckets",
+                    histogram.sig_figs,
+                    histogram.buckets.len()
+                )
+            }
         }
     }
 }
 
 ////////////////////////////////////////////// Counter /////////////////////////////////////////////
 
-#[derive(Clone, Debug, Default, Message)]
+/// A protocol-buffer counter reading.
+#[derive(Clone, Debug, Default, Message, PartialEq)]
 pub struct CounterPb {
+    /// The cumulative counter value.
     #[prototk(1, uint64)]
     pub count: u64,
 }
@@ -65,8 +83,10 @@ impl From<u64> for CounterPb {
 
 /////////////////////////////////////////////// Gauge //////////////////////////////////////////////
 
-#[derive(Clone, Debug, Default, Message)]
+/// A protocol-buffer gauge reading.
+#[derive(Clone, Debug, Default, Message, PartialEq)]
 pub struct GaugePb {
+    /// The latest gauge value.
     #[prototk(2, double)]
     pub value: f64,
 }
@@ -85,25 +105,33 @@ impl From<f64> for GaugePb {
 
 ////////////////////////////////////////////// Moments /////////////////////////////////////////////
 
-#[derive(Clone, Debug, Default, Message)]
+/// A protocol-buffer moments reading.
+#[derive(Clone, Debug, Default, Message, PartialEq)]
 pub struct MomentsPb {
+    /// The number of observations.
     #[prototk(3, uint64)]
     pub n: u64,
+    /// The first moment accumulator.
     #[prototk(4, double)]
     pub m1: f64,
+    /// The second moment accumulator.
     #[prototk(5, double)]
     pub m2: f64,
+    /// The third moment accumulator.
     #[prototk(6, double)]
     pub m3: f64,
+    /// The fourth moment accumulator.
     #[prototk(7, double)]
     pub m4: f64,
 }
 
 impl MomentsPb {
+    /// Create a new moments protocol-buffer reading.
     pub const fn new(n: u64, m1: f64, m2: f64, m3: f64, m4: f64) -> Self {
         Self { n, m1, m2, m3, m4 }
     }
 
+    /// Convert this reading into the biometrics moments type.
     pub fn into_moments(self) -> biometrics::moments::Moments {
         biometrics::moments::Moments {
             n: self.n,
@@ -130,5 +158,120 @@ impl From<biometrics::moments::Moments> for MomentsPb {
             m3: m.m3,
             m4: m.m4,
         }
+    }
+}
+
+///////////////////////////////////////////// Histogram ////////////////////////////////////////////
+
+/// A protocol-buffer histogram reading.
+#[derive(Clone, Debug, Default, Message, PartialEq)]
+pub struct HistogramPb {
+    /// The number of significant figures used by the histogram.
+    #[prototk(8, uint32)]
+    pub sig_figs: u32,
+    /// Bucket counts indexed by [`sig_fig_histogram::SigFigBucketizer`].
+    #[prototk(9, uint64)]
+    pub buckets: Vec<u64>,
+}
+
+impl HistogramPb {
+    /// Create a new histogram protocol-buffer reading.
+    pub fn new(sig_figs: u32, buckets: Vec<u64>) -> Self {
+        Self { sig_figs, buckets }
+    }
+
+    /// Convert this reading into the biometrics histogram type.
+    pub fn try_into_histogram(self) -> Result<sig_fig_histogram::Histogram, &'static str> {
+        let sig_figs: i32 = self
+            .sig_figs
+            .try_into()
+            .map_err(|_| "sig figs out of bounds")?;
+        if !(1..=4).contains(&sig_figs) {
+            return Err("sig figs out of bounds");
+        }
+        let bucketizer = sig_fig_histogram::SigFigBucketizer::new(sig_figs);
+        let mut histogram = sig_fig_histogram::Histogram::new(sig_figs);
+        for (idx, count) in self.buckets.into_iter().enumerate() {
+            if count == 0 {
+                continue;
+            }
+            histogram
+                .observe_n(bucketizer.boundary_for(idx as i32), count)
+                .map_err(|_| "could not observe histogram bucket")?;
+        }
+        Ok(histogram)
+    }
+}
+
+impl Display for HistogramPb {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "Histogram(sig_figs={}, buckets={})",
+            self.sig_figs,
+            self.buckets.len()
+        )
+    }
+}
+
+impl From<sig_fig_histogram::Histogram> for HistogramPb {
+    fn from(histogram: sig_fig_histogram::Histogram) -> Self {
+        let mut buckets = histogram
+            .iter()
+            .map(|(_, count)| count)
+            .collect::<Vec<u64>>();
+        while buckets.last() == Some(&0) {
+            buckets.pop();
+        }
+        Self {
+            sig_figs: histogram.sig_figs() as u32,
+            buckets,
+        }
+    }
+}
+
+/////////////////////////////////////////////// tests //////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use buffertk::{Unpacker, stack_pack};
+
+    use super::*;
+
+    #[test]
+    fn histogram_pb_round_trips_through_histogram() {
+        let mut histogram = sig_fig_histogram::Histogram::new(2);
+        histogram.observe_n(1.0, 3).unwrap();
+        histogram.observe_n(12.0, 4).unwrap();
+
+        let pb = HistogramPb::from(histogram.clone());
+        let round_trip = pb.try_into_histogram().unwrap();
+
+        assert_eq!(
+            histogram.iter().collect::<Vec<_>>(),
+            round_trip.iter().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn histogram_pb_rejects_invalid_sig_figs() {
+        let pb = HistogramPb::new(0, vec![]);
+
+        assert_eq!(
+            "sig figs out of bounds",
+            pb.try_into_histogram().unwrap_err()
+        );
+    }
+
+    #[test]
+    fn sensor_reading_histogram_packs_and_unpacks() {
+        let reading = SensorReading::Histogram(HistogramPb::new(2, vec![0, 1, 3]));
+        let buf = stack_pack(&reading).to_vec();
+        let mut unpacker = Unpacker::new(&buf);
+
+        let unpacked: SensorReading = unpacker.unpack().unwrap();
+
+        assert_eq!(reading, unpacked);
+        assert_eq!(&[] as &[u8], unpacker.remain());
     }
 }

--- a/biometrics_prometheus/Cargo.toml
+++ b/biometrics_prometheus/Cargo.toml
@@ -9,9 +9,20 @@ repository = "https://github.com/rescrv/blue"
 
 [dependencies]
 libc = { workspace = true }
+biometrics_sys = { workspace = true }
+arrrg = { workspace = true }
+arrrg_derive = { workspace = true }
+getopts = { workspace = true }
 
 biometrics = { workspace = true }
 utf8path = { workspace = true }
 
-[dev-dependencies]
-biometrics_sys = { workspace = true }
+[[bin]]
+name = "with-system-metrics"
+path = "src/bin/with-system-metrics.rs"
+required-features = ["binaries"]
+
+[features]
+default = ["binaries"]
+
+binaries = []

--- a/biometrics_prometheus/README.md
+++ b/biometrics_prometheus/README.md
@@ -7,7 +7,13 @@ biometrics_prometheus provides a Prometheus emitter for biometrics.  It is a cra
 The emitter takes a prefix and appends "<epoch_millis>.prom" to the prefix to determine where to write next.  For
 example, the following will write a path like, `tmp.foo.1726547192.prom`:
 
-```rust
+```rust,no_run
+use std::time::Duration;
+
+use biometrics::{Counter, Emitter as _};
+use biometrics_prometheus::{Emitter, Options};
+use utf8path::Path;
+
 let mut emitter = Emitter::new(Options {
     segment_size: 1024,
     flush_interval: Duration::from_secs(1),
@@ -18,7 +24,7 @@ drop(emitter);
 ```
 
 The file is opened using `create_new` to guarantee it won't overwrite an existing file.  The file is locked before any
-data is written.  Consequently, a reader that uses `flock` after opening the file will be able to read the file only
+data is written.  Consequently, a reader that acquires a lock after opening the file will be able to read the file only
 after all data has been written to the file.  The included `Reader` does exactly that.
 
 There's a pitfall to using `Reader`, however.  If the reader is opened before the writer finishes writing, the reader
@@ -39,6 +45,19 @@ Scope
 -----
 
 The crate is intended to be used as a Prometheus emitter for biometrics.
+
+The `with-system-metrics` binary wraps a command and emits child process
+`biometrics_sys` counters to the default metrics file path.
+Usage:
+
+```text
+with-system-metrics [--poll-in-seconds <seconds>] <command> [args...]
+```
+
+`--poll-in-seconds` controls the interval (in whole seconds) used to
+sample and emit child resource usage while the wrapped command is running.
+When the wrapped command exits, one final sample is emitted immediately.
+It defaults to `1`.
 
 Warts
 -----

--- a/biometrics_prometheus/src/bin/with-system-metrics.rs
+++ b/biometrics_prometheus/src/bin/with-system-metrics.rs
@@ -1,0 +1,192 @@
+use std::os::unix::process::ExitStatusExt;
+use std::process::{self, Command};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use arrrg::CommandLine;
+use biometrics_prometheus::{Emitter, Options};
+use biometrics_sys::BiometricsSys;
+use libc;
+
+const USAGE: &str = "USAGE: with-system-metrics [--poll-in-seconds=<seconds>] <command> [args...]";
+const DEFAULT_POLL_SECONDS: u64 = 1;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct PollOptions {
+    #[arrrg(optional, "Polling interval in seconds.")]
+    poll_in_seconds: Option<u64>,
+}
+
+fn main() {
+    let (options, argv) = PollOptions::from_command_line_relaxed(USAGE);
+    if argv.is_empty() {
+        eprintln!("command is required");
+        process::exit(2);
+    }
+    let mut command = Command::new(&argv[0]);
+    command.args(&argv[1..]);
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            eprintln!("failed to start command: {err}");
+            process::exit(2);
+        }
+    };
+    let poll_in_seconds = options.poll_in_seconds.unwrap_or(DEFAULT_POLL_SECONDS);
+    if poll_in_seconds == 0 {
+        eprintln!("--poll-in-seconds must be a positive integer");
+        process::exit(2);
+    }
+    let interval = Duration::from_secs(poll_in_seconds);
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let monitor = thread::spawn({
+        let interval = interval;
+        move || monitor_child_rusage(stop_rx, interval)
+    });
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(err) => {
+            let _ = stop_tx.send(());
+            eprintln!("failed to wait on command: {err}");
+            process::exit(2);
+        }
+    };
+    let _ = stop_tx.send(());
+    match monitor.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            eprintln!("failed to sample child usage: {err}");
+            process::exit(2);
+        }
+        Err(err) => {
+            eprintln!("monitor thread failed: {err:?}");
+            process::exit(2);
+        }
+    }
+
+    process::exit(child_exit_code(status));
+}
+
+fn monitor_child_rusage(
+    stop_rx: mpsc::Receiver<()>,
+    interval: Duration,
+) -> Result<(), std::io::Error> {
+    let baseline = children_rusage()?;
+    let mut emitter = Emitter::new(Options::default());
+    let mut sys = BiometricsSys::new();
+
+    let emit_sample = |baseline: &libc::rusage,
+                       emitter: &mut Emitter,
+                       sys: &mut BiometricsSys|
+     -> Result<(), std::io::Error> {
+        let usage = children_rusage()?;
+        let delta = rusage_delta(usage, *baseline);
+        let now = now_millis_since_epoch();
+        sys.emit_with_rusage(emitter, now, delta);
+        emitter.flush()
+    };
+
+    loop {
+        match stop_rx.recv_timeout(interval) {
+            Ok(()) => {
+                emit_sample(&baseline, &mut emitter, &mut sys)?;
+                break;
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                emit_sample(&baseline, &mut emitter, &mut sys)?;
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn children_rusage() -> Result<libc::rusage, std::io::Error> {
+    let mut usage = zero_rusage();
+    if unsafe { libc::getrusage(libc::RUSAGE_CHILDREN, &mut usage) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(usage)
+}
+
+fn rusage_delta(current: libc::rusage, baseline: libc::rusage) -> libc::rusage {
+    let ru_utime = timeval_delta(current.ru_utime, baseline.ru_utime);
+    let ru_stime = timeval_delta(current.ru_stime, baseline.ru_stime);
+    libc::rusage {
+        ru_utime,
+        ru_stime,
+        ru_maxrss: current.ru_maxrss - baseline.ru_maxrss,
+        ru_ixrss: current.ru_ixrss - baseline.ru_ixrss,
+        ru_idrss: current.ru_idrss - baseline.ru_idrss,
+        ru_isrss: current.ru_isrss - baseline.ru_isrss,
+        ru_minflt: current.ru_minflt - baseline.ru_minflt,
+        ru_majflt: current.ru_majflt - baseline.ru_majflt,
+        ru_nswap: current.ru_nswap - baseline.ru_nswap,
+        ru_inblock: current.ru_inblock - baseline.ru_inblock,
+        ru_oublock: current.ru_oublock - baseline.ru_oublock,
+        ru_msgsnd: current.ru_msgsnd - baseline.ru_msgsnd,
+        ru_msgrcv: current.ru_msgrcv - baseline.ru_msgrcv,
+        ru_nsignals: current.ru_nsignals - baseline.ru_nsignals,
+        ru_nvcsw: current.ru_nvcsw - baseline.ru_nvcsw,
+        ru_nivcsw: current.ru_nivcsw - baseline.ru_nivcsw,
+    }
+}
+
+fn timeval_delta(current: libc::timeval, baseline: libc::timeval) -> libc::timeval {
+    let mut sec = current.tv_sec - baseline.tv_sec;
+    let mut usec = current.tv_usec - baseline.tv_usec;
+    if usec < 0 {
+        sec -= 1;
+        usec += 1_000_000;
+    }
+    libc::timeval {
+        tv_sec: sec,
+        tv_usec: usec,
+    }
+}
+
+fn child_exit_code(status: process::ExitStatus) -> i32 {
+    status
+        .code()
+        .or_else(|| status.signal().map(|signal| 128 + signal))
+        .unwrap_or(129)
+}
+
+fn now_millis_since_epoch() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(now) => now.as_millis().try_into().unwrap_or(u64::MAX),
+        Err(_) => 0,
+    }
+}
+
+fn zero_rusage() -> libc::rusage {
+    libc::rusage {
+        ru_utime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_stime: libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        },
+        ru_maxrss: 0,
+        ru_ixrss: 0,
+        ru_idrss: 0,
+        ru_isrss: 0,
+        ru_minflt: 0,
+        ru_majflt: 0,
+        ru_nswap: 0,
+        ru_inblock: 0,
+        ru_oublock: 0,
+        ru_msgsnd: 0,
+        ru_msgrcv: 0,
+        ru_nsignals: 0,
+        ru_nvcsw: 0,
+        ru_nivcsw: 0,
+    }
+}

--- a/biometrics_prometheus/src/bin/with-system-metrics.rs
+++ b/biometrics_prometheus/src/bin/with-system-metrics.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use arrrg::CommandLine;
 use biometrics_prometheus::{Emitter, Options};
 use biometrics_sys::BiometricsSys;
-use libc;
 
 const USAGE: &str = "USAGE: with-system-metrics [--poll-in-seconds=<seconds>] <command> [args...]";
 const DEFAULT_POLL_SECONDS: u64 = 1;
@@ -41,10 +40,7 @@ fn main() {
     }
     let interval = Duration::from_secs(poll_in_seconds);
     let (stop_tx, stop_rx) = mpsc::channel();
-    let monitor = thread::spawn({
-        let interval = interval;
-        move || monitor_child_rusage(stop_rx, interval)
-    });
+    let monitor = thread::spawn(move || monitor_child_rusage(stop_rx, interval));
     let status = match child.wait() {
         Ok(status) => status,
         Err(err) => {

--- a/biometrics_prometheus/src/lib.rs
+++ b/biometrics_prometheus/src/lib.rs
@@ -505,7 +505,7 @@ foo 0 42
         static MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
         // SAFETY(rescrv):  Mutex poisoning.
         let _guard = MUTEX.lock().unwrap();
-        if Path::from("tmp.dots.99.prom").exists() {
+        if Path::from("tmp.dots.99.prom").exists().unwrap() {
             remove_file("tmp.dots.99.prom").unwrap();
         }
         let mut emitter = Emitter::new(Options {

--- a/biometrics_prometheus/src/lib.rs
+++ b/biometrics_prometheus/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::os::fd::AsRawFd;
@@ -9,10 +11,14 @@ use utf8path::Path;
 
 ////////////////////////////////////////////// Options /////////////////////////////////////////////
 
+/// Configuration for the file-backed Prometheus emitter.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Options {
+    /// Maximum approximate bytes to write before rotating to a new output segment.
     pub segment_size: usize,
+    /// Maximum approximate time to keep writing one output segment before rotating.
     pub flush_interval: Duration,
+    /// File path prefix.  The emitter appends `<epoch_millis>.prom`.
     pub prefix: Path<'static>,
 }
 
@@ -26,19 +32,26 @@ impl Default for Options {
     }
 }
 
+fn prometheus_name(label: impl fmt::Display) -> String {
+    label.to_string().replace('.', "_")
+}
+
 ////////////////////////////////////////////// Emitter /////////////////////////////////////////////
 
+/// An in-memory emitter that renders Prometheus-compatible text.
 #[derive(Clone, Debug, Default)]
 pub struct SlashMetrics {
     output: Option<String>,
 }
 
 impl SlashMetrics {
+    /// Create an empty in-memory emitter.
     pub fn new() -> Self {
         let output = None;
         Self { output }
     }
 
+    /// Consume this emitter and return the rendered output.
     pub fn take(mut self) -> String {
         self.output.take().unwrap_or_default()
     }
@@ -54,7 +67,7 @@ impl biometrics::Emitter for SlashMetrics {
     type Error = std::io::Error;
 
     fn emit_counter(&mut self, counter: &Counter, now: u64) -> Result<(), std::io::Error> {
-        let label = counter.label().replace(".", "_");
+        let label = prometheus_name(counter.label());
         let reading = counter.read();
         self.write_line(format!(
             "# TYPE {label} counter
@@ -64,7 +77,7 @@ impl biometrics::Emitter for SlashMetrics {
     }
 
     fn emit_gauge(&mut self, gauge: &Gauge, now: u64) -> Result<(), std::io::Error> {
-        let label = gauge.label().replace(".", "_");
+        let label = prometheus_name(gauge.label());
         let reading = gauge.read();
         self.write_line(format!(
             "# TYPE {label} gauge
@@ -74,7 +87,7 @@ impl biometrics::Emitter for SlashMetrics {
     }
 
     fn emit_moments(&mut self, moments: &Moments, now: u64) -> Result<(), std::io::Error> {
-        let label = moments.label().replace(".", "_");
+        let label = prometheus_name(moments.label());
         let reading = moments.read();
         self.write_line(format!(
             "# TYPE {label}_count counter
@@ -97,7 +110,7 @@ impl biometrics::Emitter for SlashMetrics {
     }
 
     fn emit_histogram(&mut self, histogram: &Histogram, now: u64) -> Result<(), std::io::Error> {
-        let label = histogram.label().replace(".", "_");
+        let label = prometheus_name(histogram.label());
         self.write_line(format!("# TYPE {label} histogram\n"))?;
         let mut total = 0;
         let mut acc = 0.0;
@@ -120,6 +133,7 @@ impl biometrics::Emitter for SlashMetrics {
 
 ////////////////////////////////////////////// Emitter /////////////////////////////////////////////
 
+/// A file-backed Prometheus emitter.
 pub struct Emitter {
     options: Options,
     output: Option<BufWriter<File>>,
@@ -130,6 +144,7 @@ pub struct Emitter {
 }
 
 impl Emitter {
+    /// Create a new file-backed emitter.
     pub fn new(options: Options) -> Self {
         let output = None;
         let written = 0;
@@ -146,6 +161,7 @@ impl Emitter {
         }
     }
 
+    /// Flush pending output to the current file.
     pub fn flush(&mut self) -> Result<(), std::io::Error> {
         if let Some(output) = self.output.as_mut() {
             output.flush()?;
@@ -225,23 +241,23 @@ impl biometrics::Emitter for Emitter {
     type Error = std::io::Error;
 
     fn emit_counter(&mut self, counter: &Counter, now: u64) -> Result<(), std::io::Error> {
-        let label = counter.label();
+        let label = prometheus_name(counter.label());
         let reading = counter.read();
-        self.emit_type_once(label, "counter", now)?;
+        self.emit_type_once(&label, "counter", now)?;
         self.write_line(format!("{label} {reading} {now}\n"), now)?;
         Ok(())
     }
 
     fn emit_gauge(&mut self, gauge: &Gauge, now: u64) -> Result<(), std::io::Error> {
-        let label = gauge.label();
+        let label = prometheus_name(gauge.label());
         let reading = gauge.read();
-        self.emit_type_once(label, "gauge", now)?;
+        self.emit_type_once(&label, "gauge", now)?;
         self.write_line(format!("{label} {reading} {now}\n"), now)?;
         Ok(())
     }
 
     fn emit_moments(&mut self, moments: &Moments, now: u64) -> Result<(), std::io::Error> {
-        let label = moments.label();
+        let label = prometheus_name(moments.label());
         let reading = moments.read();
         self.emit_type_once(format!("{label}_count"), "counter", now)?;
         self.emit_type_once(format!("{label}_mean"), "gauge", now)?;
@@ -268,8 +284,8 @@ impl biometrics::Emitter for Emitter {
     }
 
     fn emit_histogram(&mut self, histogram: &Histogram, now: u64) -> Result<(), std::io::Error> {
-        let label = histogram.label();
-        self.emit_type_once(label, "histogram", now)?;
+        let label = prometheus_name(histogram.label());
+        self.emit_type_once(&label, "histogram", now)?;
         self.emit_type_once(format!("{label}_sum"), "gauge", now)?;
         self.emit_type_once(format!("{label}_count"), "counter", now)?;
         self.emit_type_once(format!("{label}_exceeds_max"), "gauge", now)?;
@@ -296,10 +312,12 @@ impl biometrics::Emitter for Emitter {
 
 ////////////////////////////////////////////// Reader //////////////////////////////////////////////
 
+/// A locked reader for one emitted metrics file.
 #[derive(Debug)]
 pub struct Reader(Path<'static>, File);
 
 impl Reader {
+    /// Open a metrics file and wait until the writer releases its lock.
     pub fn open(path: Path) -> Result<Self, std::io::Error> {
         Self::_open(path, libc::F_SETLKW)
     }
@@ -328,10 +346,12 @@ impl Reader {
         Ok(Self(path, file))
     }
 
+    /// Return the path backing this reader.
     pub fn path(&self) -> &Path<'static> {
         &self.0
     }
 
+    /// Remove the file backing this reader.
     pub fn unlink(self) -> Result<(), std::io::Error> {
         std::fs::remove_file(self.path())
     }
@@ -347,11 +367,13 @@ impl std::ops::Deref for Reader {
 
 ////////////////////////////////////////////// Watcher /////////////////////////////////////////////
 
+/// A directory watcher that processes unlocked metrics files.
 pub struct Watcher {
     path: Path<'static>,
 }
 
 impl Watcher {
+    /// Create a new watcher for `path`.
     pub fn new(path: Path) -> Self {
         let path = path.into_owned();
         Self { path }
@@ -370,6 +392,9 @@ impl Watcher {
         for dirent in std::fs::read_dir(&self.path)? {
             let dirent = dirent?;
             let metadata = dirent.metadata()?;
+            if !metadata.is_file() {
+                continue;
+            }
             let path = Path::try_from(dirent.path()).map_err(|_| {
                 std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid path: not UTF-8")
             })?;
@@ -476,6 +501,31 @@ foo 0 42
     }
 
     #[test]
+    fn emitter_sanitizes_metric_names() {
+        static MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        // SAFETY(rescrv):  Mutex poisoning.
+        let _guard = MUTEX.lock().unwrap();
+        if Path::from("tmp.dots.99.prom").exists() {
+            remove_file("tmp.dots.99.prom").unwrap();
+        }
+        let mut emitter = Emitter::new(Options {
+            segment_size: 1024,
+            flush_interval: Duration::from_secs(1),
+            prefix: Path::new("tmp.dots."),
+        });
+        emitter
+            .emit_counter(&Counter::new("foo.bar.baz"), 99)
+            .unwrap();
+        drop(emitter);
+
+        assert_eq!(
+            "# TYPE foo_bar_baz counter\nfoo_bar_baz 0 99\n",
+            read_to_string("tmp.dots.99.prom").unwrap()
+        );
+        remove_file("tmp.dots.99.prom").unwrap();
+    }
+
+    #[test]
     fn reader() {
         let _reader = Reader::open(Path::new("README.md")).unwrap();
     }
@@ -496,7 +546,6 @@ foo 0 42
             found.basename().as_str().starts_with("README.md")
                 || found.basename().as_str().starts_with("Cargo.toml")
                 || found.basename().as_str().starts_with("k8s.metrics")
-                || found.basename().as_str().starts_with("src")
                 || found.basename().as_str().starts_with("tmp.foo.")
                 || found.basename().as_str().starts_with(".gitignore"),
             "found: {found:?}",

--- a/biometrics_prometheus/tests/with-system-metrics.rs
+++ b/biometrics_prometheus/tests/with-system-metrics.rs
@@ -1,0 +1,116 @@
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+use std::time::{Duration, Instant};
+
+#[test]
+fn with_system_metrics_exits_promptly_with_long_poll_interval() -> io::Result<()> {
+    let _guard = test_lock();
+    let bin = env!("CARGO_BIN_EXE_with-system-metrics");
+    let temp_dir = temp_dir_for_test("with-system-metrics-quick-exit")?;
+    fs::create_dir_all(&temp_dir)?;
+
+    let started = Instant::now();
+    let status = Command::new(bin)
+        .args(["--poll-in-seconds", "30", "/bin/sleep", "1"])
+        .current_dir(&temp_dir)
+        .status()?;
+    assert!(status.success(), "with-system-metrics should succeed");
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "poll interval should not block for 30 seconds"
+    );
+
+    let metric_paths = metrics_files(&temp_dir);
+    assert!(
+        !metric_paths.is_empty(),
+        "expected at least one metrics file in {temp_dir:?}"
+    );
+    let mut saw_sys_metric = false;
+    for path in metric_paths {
+        let contents = fs::read_to_string(path)?;
+        if contents.contains("biometrics_sys_utime") {
+            saw_sys_metric = true;
+            break;
+        }
+    }
+    assert!(
+        saw_sys_metric,
+        "expected biometrics_sys metric in emitted output"
+    );
+
+    fs::remove_dir_all(&temp_dir)?;
+    Ok(())
+}
+
+#[test]
+fn with_system_metrics_emits_every_poll_interval() -> io::Result<()> {
+    let _guard = test_lock();
+    let bin = env!("CARGO_BIN_EXE_with-system-metrics");
+    let temp_dir = temp_dir_for_test("with-system-metrics-polling")?;
+    fs::create_dir_all(&temp_dir)?;
+
+    let status = Command::new(bin)
+        .args(["--poll-in-seconds", "1", "/bin/sleep", "3"])
+        .current_dir(&temp_dir)
+        .status()?;
+    assert!(status.success(), "with-system-metrics should succeed");
+
+    let mut samples = 0usize;
+    for path in metrics_files(&temp_dir) {
+        let contents = fs::read_to_string(path)?;
+        samples += contents
+            .lines()
+            .filter(|line| line.starts_with("biometrics_sys_utime "))
+            .count();
+    }
+    assert!(
+        samples >= 2,
+        "expected at least two periodic samples for 3-second run, got {samples}"
+    );
+
+    fs::remove_dir_all(&temp_dir)?;
+    Ok(())
+}
+
+fn temp_dir_for_test(prefix: &str) -> io::Result<std::path::PathBuf> {
+    let mut temp_dir = std::env::temp_dir();
+    let nonce = match SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(since_epoch) => since_epoch.as_nanos(),
+        Err(_) => 0,
+    };
+    temp_dir.push(format!("{prefix}-{}-{}", std::process::id(), nonce));
+    Ok(temp_dir)
+}
+
+fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
+fn metrics_files(temp_dir: &PathBuf) -> Vec<PathBuf> {
+    let mut output = Vec::new();
+    let entries = match fs::read_dir(temp_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return output,
+        Err(err) => panic!("failed to read temp dir: {err}"),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Some(name) = path.file_name() {
+            let name = name.to_string_lossy();
+            if name.starts_with("biometrics.") && name.ends_with(".prom") {
+                output.push(path);
+            }
+        }
+    }
+    output
+}

--- a/biometrics_sys/README.md
+++ b/biometrics_sys/README.md
@@ -1,7 +1,7 @@
 biometrics_sys
 ==============
 
-biometrics_sys provide the rusage of a process in the form of biometrics.
+biometrics_sys provides the rusage of a process in the form of biometrics.
 
 Status
 ------

--- a/biometrics_sys/src/lib.rs
+++ b/biometrics_sys/src/lib.rs
@@ -175,14 +175,18 @@ mod tests {
         sys.emit(&mut emitter, 42);
 
         assert_eq!(9, emitter.readings.len());
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, _, now)| *label == "biometrics.sys.utime" && *now == 42));
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, _, _)| *label == "biometrics.sys.errors"));
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, _, now)| *label == "biometrics.sys.utime" && *now == 42)
+        );
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, _, _)| *label == "biometrics.sys.errors")
+        );
     }
 
     #[test]
@@ -216,21 +220,29 @@ mod tests {
         sys.emit_with_rusage(&mut emitter, 99, usage);
 
         assert_eq!(9, emitter.readings.len());
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, value, _)| *label == "biometrics.sys.utime" && *value == 1_500_000));
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, value, _)| *label == "biometrics.sys.stime" && *value == 2_250_000));
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, value, _)| *label == "biometrics.sys.minflt" && *value == 3));
-        assert!(emitter
-            .readings
-            .iter()
-            .any(|(label, value, _)| *label == "biometrics.sys.nivcsw" && *value == 17));
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, value, _)| *label == "biometrics.sys.utime" && *value == 1_500_000)
+        );
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, value, _)| *label == "biometrics.sys.stime" && *value == 2_250_000)
+        );
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, value, _)| *label == "biometrics.sys.minflt" && *value == 3)
+        );
+        assert!(
+            emitter
+                .readings
+                .iter()
+                .any(|(label, value, _)| *label == "biometrics.sys.nivcsw" && *value == 17)
+        );
     }
 }

--- a/biometrics_sys/src/lib.rs
+++ b/biometrics_sys/src/lib.rs
@@ -1,7 +1,10 @@
+#![doc = include_str!("../README.md")]
+
 use biometrics::{Counter, Emitter};
 
 /////////////////////////////////////////// BiometricsSys //////////////////////////////////////////
 
+/// Emits process resource usage as biometrics counters.
 pub struct BiometricsSys {
     utime: u64,
     stime: u64,
@@ -15,6 +18,7 @@ pub struct BiometricsSys {
 }
 
 impl BiometricsSys {
+    /// Create a new system metrics emitter.
     pub fn new() -> Self {
         Self {
             utime: 0,
@@ -29,9 +33,27 @@ impl BiometricsSys {
         }
     }
 
+    /// Emit resource-usage counters with the provided timestamp.
+    ///
+    /// Emission failures are counted internally and exposed through `biometrics.sys.errors` on
+    /// subsequent calls.
     #[allow(clippy::useless_conversion)]
     pub fn emit<E: Emitter>(&mut self, emitter: &mut E, now: u64) {
         let rusage = self.getrusage();
+        self.emit_with_rusage(emitter, now, rusage);
+    }
+
+    /// Emit counters for an explicit `getrusage` sample.
+    ///
+    /// This is useful when another process wants to capture child process usage and still use
+    /// `BiometricsSys`'s output format.
+    #[allow(clippy::useless_conversion)]
+    pub fn emit_with_rusage<E: Emitter>(
+        &mut self,
+        emitter: &mut E,
+        now: u64,
+        rusage: libc::rusage,
+    ) {
         let errors = self.errors;
         let mut output_counter = |label, count: u64| {
             let counter = Counter::new(label);
@@ -108,5 +130,107 @@ impl BiometricsSys {
 impl Default for BiometricsSys {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/////////////////////////////////////////////// tests //////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use biometrics::Sensor;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingEmitter {
+        readings: Vec<(&'static str, u64, u64)>,
+    }
+
+    impl Emitter for RecordingEmitter {
+        type Error = std::io::Error;
+
+        fn emit_counter(&mut self, counter: &Counter, now: u64) -> Result<(), Self::Error> {
+            self.readings.push((counter.label(), counter.read(), now));
+            Ok(())
+        }
+
+        fn emit_gauge(&mut self, _: &biometrics::Gauge, _: u64) -> Result<(), Self::Error> {
+            unreachable!("biometrics_sys only emits counters")
+        }
+
+        fn emit_moments(&mut self, _: &biometrics::Moments, _: u64) -> Result<(), Self::Error> {
+            unreachable!("biometrics_sys only emits counters")
+        }
+
+        fn emit_histogram(&mut self, _: &biometrics::Histogram, _: u64) -> Result<(), Self::Error> {
+            unreachable!("biometrics_sys only emits counters")
+        }
+    }
+
+    #[test]
+    fn emit_outputs_rusage_counters() {
+        let mut sys = BiometricsSys::new();
+        let mut emitter = RecordingEmitter::default();
+
+        sys.emit(&mut emitter, 42);
+
+        assert_eq!(9, emitter.readings.len());
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, _, now)| *label == "biometrics.sys.utime" && *now == 42));
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, _, _)| *label == "biometrics.sys.errors"));
+    }
+
+    #[test]
+    fn emit_with_child_rusage_counters() {
+        let mut sys = BiometricsSys::new();
+        let mut emitter = RecordingEmitter::default();
+        let usage = libc::rusage {
+            ru_utime: libc::timeval {
+                tv_sec: 1,
+                tv_usec: 500_000,
+            },
+            ru_stime: libc::timeval {
+                tv_sec: 2,
+                tv_usec: 250_000,
+            },
+            ru_maxrss: 0,
+            ru_ixrss: 0,
+            ru_idrss: 0,
+            ru_isrss: 0,
+            ru_minflt: 3,
+            ru_majflt: 5,
+            ru_nswap: 0,
+            ru_inblock: 7,
+            ru_oublock: 11,
+            ru_msgsnd: 0,
+            ru_msgrcv: 0,
+            ru_nsignals: 0,
+            ru_nvcsw: 13,
+            ru_nivcsw: 17,
+        };
+        sys.emit_with_rusage(&mut emitter, 99, usage);
+
+        assert_eq!(9, emitter.readings.len());
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, value, _)| *label == "biometrics.sys.utime" && *value == 1_500_000));
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, value, _)| *label == "biometrics.sys.stime" && *value == 2_250_000));
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, value, _)| *label == "biometrics.sys.minflt" && *value == 3));
+        assert!(emitter
+            .readings
+            .iter()
+            .any(|(label, value, _)| *label == "biometrics.sys.nivcsw" && *value == 17));
     }
 }

--- a/macarunes/src/lib.rs
+++ b/macarunes/src/lib.rs
@@ -29,6 +29,13 @@ static VERIFIER_FIRST_PARTY_SUCCESS: Counter = Counter::new("macaroons.verifier.
 static VERIFIER_THIRD_PARTY_FAILURE: Counter = Counter::new("macaroons.verifier.3rd_party_failure");
 static VERIFIER_THIRD_PARTY_SUCCESS: Counter = Counter::new("macaroons.verifier.3rd_party_success");
 
+pub fn register_biometrics(collector: &biometrics::Collector) {
+    collector.register_counter(&VERIFIER_FIRST_PARTY_FAILURE);
+    collector.register_counter(&VERIFIER_FIRST_PARTY_SUCCESS);
+    collector.register_counter(&VERIFIER_THIRD_PARTY_FAILURE);
+    collector.register_counter(&VERIFIER_THIRD_PARTY_SUCCESS);
+}
+
 /////////////////////////////////////////////// Error //////////////////////////////////////////////
 
 /// The error cases macarunes can encounter.

--- a/meta/src/bin/publish.rs
+++ b/meta/src/bin/publish.rs
@@ -241,13 +241,13 @@ fn prepare_publish(
                     return Ok(None);
                 }
             };
-        if let Some(published_version) = published_version {
-            if &new_version <= published_version {
-                println!(
-                    "{crate_name} {new_version} is not newer than crates.io version {published_version}"
-                );
-                continue;
-            }
+        if let Some(published_version) = published_version
+            && &new_version <= published_version
+        {
+            println!(
+                "{crate_name} {new_version} is not newer than crates.io version {published_version}"
+            );
+            continue;
         }
         if &new_version < current_version {
             println!("{crate_name} {new_version} is older than current version {current_version}");

--- a/meta/src/bin/update-version.rs
+++ b/meta/src/bin/update-version.rs
@@ -384,29 +384,26 @@ fn rewrite_member_manifest(
             return Ok(None);
         }
 
-        if section == "package" {
-            if let Some(version) = new_version {
-                if let Some(replacement) =
-                    rewrite_package_version_line(line, &package.version, version)?
-                {
-                    version_updated = true;
-                    return Ok(Some(replacement));
-                }
-            }
+        if section == "package"
+            && let Some(version) = new_version
+            && let Some(replacement) =
+                rewrite_package_version_line(line, &package.version, version)?
+        {
+            version_updated = true;
+            return Ok(Some(replacement));
         }
 
-        if is_dependency_section(&section) {
-            if let Some(local_names) = local_names {
-                if let Some(replacement) = normalize_dependency_line(line, local_names)? {
-                    edits.push(NormalizationEdit {
-                        path: package.manifest_path.clone(),
-                        line: line_number,
-                        old: line.to_string(),
-                        new: replacement.clone(),
-                    });
-                    return Ok(Some(replacement));
-                }
-            }
+        if is_dependency_section(&section)
+            && let Some(local_names) = local_names
+            && let Some(replacement) = normalize_dependency_line(line, local_names)?
+        {
+            edits.push(NormalizationEdit {
+                path: package.manifest_path.clone(),
+                line: line_number,
+                old: line.to_string(),
+                new: replacement.clone(),
+            });
+            return Ok(Some(replacement));
         }
 
         Ok(None)

--- a/split_channel/src/lib.rs
+++ b/split_channel/src/lib.rs
@@ -71,6 +71,7 @@ pub fn register_biometrics(collector: &mut Collector) {
     collector.register_counter(&SEND_WANT_WRITE);
     collector.register_counter(&RECV_WANT_READ);
     collector.register_counter(&RECV_WANT_WRITE);
+    collector.register_counter(&SEND_SHRINK_BUF);
     polling::register_biometrics(collector);
 }
 

--- a/sync42/src/state_hash_table.rs
+++ b/sync42/src/state_hash_table.rs
@@ -104,6 +104,7 @@ static ARBITRARY_KEY: Counter = Counter::new("sync42.state_hash_table.arbitrary_
 
 /// Register the biometrics for state hash table.
 pub fn register_biometrics(collector: &Collector) {
+    collector.register_counter(&NEW_STATE_HASH_TABLE);
     collector.register_counter(&ENTRY_INSERTED);
     collector.register_counter(&ENTRY_REMOVED);
     collector.register_counter(&ARBITRARY_KEY);


### PR DESCRIPTION
Expand the biometrics suite with first-class histogram support and
round out the crates with documentation, tests, and tooling.

biometrics:
- Deny missing docs and document the public sensor surface.
- Tighten SensorRegistry visibility and simplify emit locking.
- Make Moments algebra robust: add/sub handle empty readings, sub
  asserts on ordering and computes the interval count correctly.
- Fix PlainTextEmitter to terminate histogram lines with a newline.
- Add an internal binaries feature and a biometrics-audit-counters
  binary that checks every static Counter is registered.

biometrics_pb:
- Add HistogramPb plus a SensorReading::Histogram variant with
  conversions to and from sig_fig_histogram::Histogram.
- Derive PartialEq and document the protocol-buffer readings.

biometrics_prometheus:
- Sanitize metric names through a shared prometheus_name helper.
- Skip non-file directory entries in the watcher.
- Add a with-system-metrics binary that wraps a command and emits
  child process biometrics_sys counters.

biometrics_sys:
- Add emit_with_rusage so callers can emit counters for an explicit
  getrusage sample, enabling child-process metrics.

Also fix register_biometrics omissions in macarunes, split_channel,
and sync42 so previously unregistered counters are emitted.

Co-authored-by: AI
