### PR TITLE
fix(stdioredirect): exit cleanly when no command is specified

### DIFF
--- a/stdioredirect/src/bin/stdioredirect.rs
+++ b/stdioredirect/src/bin/stdioredirect.rs
@@ -46,6 +46,10 @@ fn main() {
         eprintln!("mutually exclusive options --close-stderr and --stderr specified");
         std::process::exit(254);
     }
+    if free.is_empty() {
+        eprintln!("no command specified");
+        std::process::exit(253);
+    }
     // HashMap of chars to %-notation.
     let epoch_now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
Running `stdioredirect` without a trailing command causes a panic on `free[0]`:
```
index out of bounds: the len is 0 but the index is 0
```

The proposed fix consists in adding a guard after the other option checks to print a diagnostic and exit with code (253, following above pattern) instead.