### PR TITLE
feat(stdioredirect): add Windows support

### DIFF
--- a/stdioredirect/Cargo.toml
+++ b/stdioredirect/Cargo.toml
@@ -14,10 +14,12 @@ binaries = []
 
 [dependencies]
 getopts = { workspace = true }
-libc = { workspace = true }
 
 arrrg = { workspace = true }
 arrrg_derive = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 
 [[bin]]
 name = "stdioredirect"

--- a/stdioredirect/src/bin/stdioredirect.rs
+++ b/stdioredirect/src/bin/stdioredirect.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
-use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::time::SystemTime;
 
 use arrrg::CommandLine;
 
+use stdioredirect::OpenMode;
+#[cfg(unix)]
 use stdioredirect::close_or_dup2;
+#[cfg(not(unix))]
+use stdioredirect::make_stdio;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
 pub struct Options {
@@ -54,39 +58,63 @@ fn main() {
         ('p', format!("{}", std::process::id())),
         ('s', format!("{}", epoch_now.as_secs())),
     ]);
-    // take care of stdin
-    let mut opts = OpenOptions::new();
-    opts.read(true);
-    close_or_dup2(
-        &subs,
-        options.close_stdin,
-        options.stdin,
-        libc::STDIN_FILENO,
-        opts,
-    );
-    // take care of stdout
-    let mut opts = OpenOptions::new();
-    opts.write(true).truncate(true).create(true);
-    close_or_dup2(
-        &subs,
-        options.close_stdout,
-        options.stdout,
-        libc::STDOUT_FILENO,
-        opts,
-    );
-    // take care of stderr
-    let mut opts = OpenOptions::new();
-    opts.write(true).truncate(true).create(true);
-    close_or_dup2(
-        &subs,
-        options.close_stderr,
-        options.stderr,
-        libc::STDERR_FILENO,
-        opts,
-    );
-    // now exec
-    panic!(
-        "{:?}",
-        std::process::Command::new(&free[0]).args(&free[1..]).exec()
-    );
+
+    let mut cmd = std::process::Command::new(&free[0]);
+    cmd.args(&free[1..]);
+
+    #[cfg(unix)]
+    {
+        // take care of stdin
+        close_or_dup2(
+            &subs,
+            options.close_stdin,
+            options.stdin,
+            libc::STDIN_FILENO,
+            OpenMode::Read,
+        );
+        // take care of stdout
+        close_or_dup2(
+            &subs,
+            options.close_stdout,
+            options.stdout,
+            libc::STDOUT_FILENO,
+            OpenMode::Write,
+        );
+        // take care of stderr
+        close_or_dup2(
+            &subs,
+            options.close_stderr,
+            options.stderr,
+            libc::STDERR_FILENO,
+            OpenMode::Write,
+        );
+        // now exec
+        panic!("{:?}", cmd.exec());
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = cmd
+            .stdin(make_stdio(
+                &subs,
+                options.close_stdin,
+                options.stdin,
+                OpenMode::Read,
+            ))
+            .stdout(make_stdio(
+                &subs,
+                options.close_stdout,
+                options.stdout,
+                OpenMode::Write,
+            ))
+            .stderr(make_stdio(
+                &subs,
+                options.close_stderr,
+                options.stderr,
+                OpenMode::Write,
+            ))
+            .status()
+            .expect("failed to execute process");
+        std::process::exit(status.code().unwrap_or(1));
+    }
 }

--- a/stdioredirect/src/lib.rs
+++ b/stdioredirect/src/lib.rs
@@ -2,16 +2,40 @@
 
 use std::collections::HashMap;
 use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 
 use std::path::{Path, PathBuf};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OpenMode {
+    Read,
+    Write,
+}
+
+#[cfg(not(unix))]
+pub fn make_stdio(
+    subs: &HashMap<char, String>,
+    close: bool,
+    file: Option<String>,
+    mode: OpenMode,
+) -> std::process::Stdio {
+    if close {
+        std::process::Stdio::null()
+    } else if let Some(file) = file {
+        std::process::Stdio::from(open_redirect_file(subs, file, mode))
+    } else {
+        std::process::Stdio::inherit()
+    }
+}
+
+#[cfg(unix)]
 pub fn close_or_dup2(
     subs: &HashMap<char, String>,
     close: bool,
     file: Option<String>,
     fd: libc::c_int,
-    opts: OpenOptions,
+    mode: OpenMode,
 ) {
     // take care of stdin
     if close {
@@ -21,23 +45,32 @@ pub fn close_or_dup2(
             libc::close(fd);
         }
     } else if let Some(file) = file {
-        let Some(file) = pct_substitution(subs, &file) else {
-            panic!("could not %-substitute {file}");
-        };
-        if !PathBuf::from(&file)
-            .parent()
-            .unwrap_or(Path::new(".."))
-            .exists()
-        {
-            panic!("could not open {file}: containing directory does not exist");
-        }
-        let file = opts.open(file).expect("file should open");
+        let file = open_redirect_file(subs, file, mode);
         unsafe {
             if libc::dup2(file.as_raw_fd(), fd) < 0 {
                 panic!("could not dup2: {:?}", std::io::Error::last_os_error());
             }
         }
     }
+}
+
+fn open_redirect_file(subs: &HashMap<char, String>, file: String, mode: OpenMode) -> std::fs::File {
+    let Some(file) = pct_substitution(subs, &file) else {
+        panic!("could not %-substitute {file}");
+    };
+    if !PathBuf::from(&file)
+        .parent()
+        .unwrap_or(Path::new(".."))
+        .exists()
+    {
+        panic!("could not open {file}: containing directory does not exist");
+    }
+    let mut opts = OpenOptions::new();
+    match mode {
+        OpenMode::Read => opts.read(true),
+        OpenMode::Write => opts.write(true).truncate(true).create(true),
+    };
+    opts.open(file).expect("file should open")
 }
 
 pub fn pct_substitution(subs: &HashMap<char, String>, input: &str) -> Option<String> {


### PR DESCRIPTION
Introduce a non-Unix code path so `stdioredirect` compiles and runs on Windows, where `execve(2)` is unavailable and `stdio` must be wired up through the `Command` builder instead of `dup2(2)`:
- add `make_stdio`, gated on `#[cfg(not(unix))]`, which converts close/file/inherit options into a `std::process::Stdio` value,
- gate `close_or_dup2` on `#[cfg(unix)]` and restrict the `libc` dependency to Unix targets,
- extract `open_redirect_file` as a shared private helper used by both functions to perform `%`-substitution, parent-directory validation, and file opening,
- replace the `OpenOptions` parameter with an `OpenMode` enum (`Read`/`Write`) to remove the factory-pattern coupling from the public API,
- factor out `Command` construction before the platform `cfg` blocks in the binary.

The Unix path calls `exec()` and the non-Unix path spawns a child and forwards its exit code.

Co-authored-by: AI