### PR TITLE
refactor: Replace buffertk/prototk Error enums with handled::SError

### DIFF
--- a/analogize/src/lib.rs
+++ b/analogize/src/lib.rs
@@ -118,7 +118,7 @@ fn scrunch_error(err: scrunch::Error) -> SError {
         .with_debug_field("cause", err)
 }
 
-fn indicio_error(err: prototk::Error) -> SError {
+fn indicio_error(err: prototk::SError) -> SError {
     error(CODE_INDICIO)
         .with_message("indicio protobuf error")
         .with_string_field("cause", &err.to_string())
@@ -783,7 +783,7 @@ impl AnalogizeDocument<'_> {
 }
 
 impl<'a> Unpackable<'a> for AnalogizeDocument<'a> {
-    type Error = SError;
+    type Error = handled::SError;
 
     fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (stub, buf) = AnalogizeDocumentStub::unpack(buf)

--- a/buffertk/Cargo.toml
+++ b/buffertk/Cargo.toml
@@ -13,6 +13,7 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
+handled = { workspace = true }
 
 [dev-dependencies]
 arrrg = { workspace = true }

--- a/buffertk/src/lib.rs
+++ b/buffertk/src/lib.rs
@@ -4,85 +4,107 @@ use std::fmt::Debug;
 
 mod varint;
 
+pub use handled::{SError, SExpr};
 pub use varint::v64;
 
 /////////////////////////////////////////////// Error //////////////////////////////////////////////
 
-/// All Error conditions within `buffertk`.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Error {
-    /// BufferTooShort indicates that there was a need to pack or unpack more bytes than were
-    /// available in the underlying memory.
-    BufferTooShort {
-        /// Number of bytes required to read the buffer.
-        required: usize,
-        /// Number of bytes available to read.
-        had: usize,
-    },
-    /// VarintOverflow indicates that a varint field did not terminate with a number < 128.
-    VarintOverflow {
-        /// Number of bytes in the varint.
-        bytes: usize,
-    },
-    /// UnsignedOverflow indicates that a value will not fit its intended (unsigned) target.
-    UnsignedOverflow {
-        /// Value that would overflow (typically a u32).
-        value: u64,
-    },
-    /// SignedOverflow indicates that a value will not fit its intended (signed) target.
-    SignedOverflow {
-        /// Value that would overflow (typically an i32).
-        value: i64,
-    },
-    /// TagTooLarge indicates the tag would overflow a 32-bit number.
-    TagTooLarge {
-        /// Value that's too large for a tag.
-        tag: u64,
-    },
-    /// UnknownDiscriminant indicates a variant that is not understood by this code.
-    UnknownDiscriminant {
-        /// Discriminant that's not known.
-        discriminant: u32,
-    },
-    /// NotAChar indicates that the prescribed value was tried to unpack as a char, but it's not a
-    /// char.
-    NotAChar {
-        /// Value that's not a char.
-        value: u32,
-    },
+const PHASE: &str = "buffertk";
+
+/// A buffer did not contain enough bytes to unpack a value.
+pub const CODE_BUFFER_TOO_SHORT: &str = "buffer-too-short";
+/// A varint exceeded the maximum encoded length.
+pub const CODE_VARINT_OVERFLOW: &str = "varint-overflow";
+/// An unsigned value did not fit the requested target type.
+pub const CODE_UNSIGNED_OVERFLOW: &str = "unsigned-overflow";
+/// A signed value did not fit the requested target type.
+pub const CODE_SIGNED_OVERFLOW: &str = "signed-overflow";
+/// A tag exceeded the 32-bit protobuf tag representation.
+pub const CODE_TAG_TOO_LARGE: &str = "tag-too-large";
+/// A discriminant was not recognized.
+pub const CODE_UNKNOWN_DISCRIMINANT: &str = "unknown-discriminant";
+/// A numeric value is not a valid Unicode scalar value.
+pub const CODE_NOT_A_CHAR: &str = "not-a-char";
+/// A serialized string was not valid UTF-8 or not a valid S-expression.
+pub const CODE_STRING_ENCODING: &str = "string-encoding";
+
+fn error(code: &str) -> SError {
+    SError::new(PHASE).with_code(code)
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::BufferTooShort { required, had } => fmt
-                .debug_struct("BufferTooShort")
-                .field("required", required)
-                .field("had", had)
-                .finish(),
-            Error::VarintOverflow { bytes } => fmt
-                .debug_struct("VarintOverflow")
-                .field("bytes", bytes)
-                .finish(),
-            Error::UnsignedOverflow { value } => fmt
-                .debug_struct("UnsignedOverflow")
-                .field("value", value)
-                .finish(),
-            Error::SignedOverflow { value } => fmt
-                .debug_struct("SignedOverflow")
-                .field("value", value)
-                .finish(),
-            Error::TagTooLarge { tag } => {
-                fmt.debug_struct("TagTooLarge").field("tag", tag).finish()
-            }
-            Error::UnknownDiscriminant { discriminant } => fmt
-                .debug_struct("UnknownDiscriminant")
-                .field("discriminant", discriminant)
-                .finish(),
-            Error::NotAChar { value } => {
-                fmt.debug_struct("NotAChar").field("value", value).finish()
-            }
-        }
+/// Construct a buffer-too-short error.
+pub fn buffer_too_short(required: usize, had: usize) -> SError {
+    error(CODE_BUFFER_TOO_SHORT)
+        .with_message("buffer too short")
+        .with_atom_field("required", required)
+        .with_atom_field("had", had)
+}
+
+/// Construct a varint-overflow error.
+pub fn varint_overflow(bytes: usize) -> SError {
+    error(CODE_VARINT_OVERFLOW)
+        .with_message("varint overflow")
+        .with_atom_field("bytes", bytes)
+}
+
+/// Construct an unsigned-overflow error.
+pub fn unsigned_overflow(value: u64) -> SError {
+    error(CODE_UNSIGNED_OVERFLOW)
+        .with_message("unsigned integer overflow")
+        .with_atom_field("value", value)
+}
+
+/// Construct a signed-overflow error.
+pub fn signed_overflow(value: i64) -> SError {
+    error(CODE_SIGNED_OVERFLOW)
+        .with_message("signed integer overflow")
+        .with_atom_field("value", value)
+}
+
+/// Construct a tag-too-large error.
+pub fn tag_too_large(tag: u64) -> SError {
+    error(CODE_TAG_TOO_LARGE)
+        .with_message("tag too large")
+        .with_atom_field("tag", tag)
+}
+
+/// Construct an unknown-discriminant error.
+pub fn unknown_discriminant(discriminant: u32) -> SError {
+    error(CODE_UNKNOWN_DISCRIMINANT)
+        .with_message("unknown discriminant")
+        .with_atom_field("discriminant", discriminant)
+}
+
+/// Construct a not-a-char error.
+pub fn not_a_char(value: u32) -> SError {
+    error(CODE_NOT_A_CHAR)
+        .with_message("not a valid char")
+        .with_atom_field("value", value)
+}
+
+/// Construct a string-encoding error.
+pub fn string_encoding() -> SError {
+    error(CODE_STRING_ENCODING).with_message("string encoding error")
+}
+
+fn error_field<'a>(err: &'a SError, name: &str) -> Option<&'a SExpr> {
+    match err.detail() {
+        SExpr::List(fields) => fields.iter().find_map(|field| match field {
+            SExpr::List(pair) if pair.len() == 2 => match &pair[0] {
+                SExpr::Atom(field_name) if field_name == name => Some(&pair[1]),
+                _ => None,
+            },
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+/// Return the machine-readable code from a `buffertk` error.
+pub fn error_code(err: &SError) -> Option<&str> {
+    match error_field(err, "code") {
+        Some(SExpr::Atom(code)) => Some(code.as_str()),
+        _ => None,
     }
 }
 
@@ -322,19 +344,16 @@ macro_rules! packable_with_to_le_bytes {
         }
 
         impl<'a> Unpackable<'a> for $what {
-            type Error = Error;
+            type Error = crate::SError;
 
-            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
                 const SZ: usize = std::mem::size_of::<$what>();
                 if buf.len() >= SZ {
                     let mut fbuf: [u8; SZ] = [0; SZ];
                     fbuf.copy_from_slice(&buf[0..SZ]);
                     Ok((<$what>::from_le_bytes(fbuf), &buf[SZ..]))
                 } else {
-                    Err(Error::BufferTooShort {
-                        required: SZ,
-                        had: buf.len(),
-                    })
+                    Err(buffer_too_short(SZ, buf.len()))
                 }
             }
         }
@@ -372,9 +391,9 @@ macro_rules! packable_with_to_bits_to_le_bytes {
             }
         }
         impl<'a> Unpackable<'a> for $what {
-            type Error = Error;
+            type Error = crate::SError;
 
-            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
                 const SZ: usize = std::mem::size_of::<$what>();
                 if buf.len() >= SZ {
                     let mut fbuf: [u8; SZ] = [0; SZ];
@@ -384,10 +403,7 @@ macro_rules! packable_with_to_bits_to_le_bytes {
                         &buf[SZ..],
                     ))
                 } else {
-                    Err(Error::BufferTooShort {
-                        required: SZ,
-                        had: buf.len(),
-                    })
+                    Err(buffer_too_short(SZ, buf.len()))
                 }
             }
         }
@@ -410,14 +426,14 @@ impl Packable for char {
 }
 
 impl<'a> Unpackable<'a> for char {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(char, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(char, &'b [u8]), SError> {
         let (c, buf) = u32::unpack(buf)?;
         if let Some(c) = char::from_u32(c) {
             Ok((c, buf))
         } else {
-            Err(Error::NotAChar { value: c })
+            Err(not_a_char(c))
         }
     }
 }
@@ -496,19 +512,44 @@ impl Packable for &[u8] {
 }
 
 impl<'a> Unpackable<'a> for &'a [u8] {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (vsz, buf): (v64, &'b [u8]) = v64::unpack(buf)?;
         let x: usize = vsz.into();
         if x > buf.len() {
-            Err(Error::BufferTooShort {
-                required: x,
-                had: buf.len(),
-            })
+            Err(buffer_too_short(x, buf.len()))
         } else {
             Ok((&buf[0..x], &buf[x..]))
         }
+    }
+}
+
+////////////////////////////////////////////// SError //////////////////////////////////////////////
+
+impl Packable for SError {
+    fn pack_sz(&self) -> usize {
+        let serialized = self.to_string();
+        let bytes: &[u8] = serialized.as_bytes();
+        stack_pack(bytes).pack_sz()
+    }
+
+    fn pack(&self, out: &mut [u8]) {
+        let serialized = self.to_string();
+        let bytes: &[u8] = serialized.as_bytes();
+        stack_pack(bytes).into_slice(out);
+    }
+}
+
+impl<'a> Unpackable<'a> for SError {
+    type Error = crate::SError;
+
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Self::Error> {
+        let mut up = Unpacker::new(buf);
+        let serialized: &'a [u8] = up.unpack()?;
+        let serialized = std::str::from_utf8(serialized).map_err(|_| string_encoding())?;
+        let err = handled::parse(serialized).map_err(|_| string_encoding())?;
+        Ok((SError::from(err), up.remain()))
     }
 }
 
@@ -525,9 +566,9 @@ macro_rules! impl_pack_unpack_tuple {
         }
 
         impl<'a> Unpackable<'a> for () {
-            type Error = Error;
+            type Error = crate::SError;
 
-            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
                 Ok(((), buf))
             }
         }
@@ -630,7 +671,7 @@ where
     T: Unpackable<'a>,
     E: Unpackable<'a>
         + Debug
-        + From<Error>
+        + From<SError>
         + From<<T as Unpackable<'a>>::Error>
         + From<<E as Unpackable<'a>>::Error>,
 {
@@ -643,7 +684,7 @@ where
         let mut up = Unpacker::new(buf);
         let tag: v64 = up.unpack()?;
         if <v64 as Into<u64>>::into(tag) > u32::MAX as u64 {
-            return Err(Error::TagTooLarge { tag: tag.into() }.into());
+            return Err(tag_too_large(tag.into()).into());
         }
         let tag: u32 = tag.try_into().unwrap();
         match tag {
@@ -661,7 +702,7 @@ where
                 let (e, _): (E, _) = <E as Unpackable>::unpack(buf)?;
                 Ok((Err(e), up.remain()))
             }
-            _ => Err(Error::UnknownDiscriminant { discriminant: tag }.into()),
+            _ => Err(unknown_discriminant(tag).into()),
         }
     }
 }
@@ -677,9 +718,29 @@ mod tests {
         let buf: &mut [u8; 0] = &mut [];
         ().pack(buf);
         let mut up = Unpacker::new(buf);
-        let x: Result<(), Error> = up.unpack();
+        let x: Result<(), SError> = up.unpack();
         assert_eq!(Ok(()), x, "human got decode wrong?");
         assert_eq!(0, up.buf.len(), "human got remainder wrong?");
+    }
+
+    #[test]
+    fn handled_error_round_trips() {
+        let err = SError::new("buffertk-test")
+            .with_code("round-trip")
+            .with_message("round trip through buffertk");
+        let buf = stack_pack(&err).to_vec();
+        let mut up = Unpacker::new(&buf);
+        let got: SError = up.unpack().unwrap();
+        assert_eq!(err, got);
+        assert!(up.is_empty());
+    }
+
+    #[test]
+    fn handled_error_rejects_invalid_utf8() {
+        let bytes: &[u8] = &[0xff];
+        let buf = stack_pack(bytes).to_vec();
+        let got = SError::unpack(&buf).unwrap_err();
+        assert_eq!(Some(CODE_STRING_ENCODING), error_code(&got));
     }
 
     macro_rules! test_pack_with_to_le_bytes {
@@ -699,7 +760,7 @@ mod tests {
             {
                 let mut up = Unpacker::new(HUMAN);
                 let x = up.unpack();
-                let expect: Result<$what, Error> = Ok(X);
+                let expect: Result<$what, SError> = Ok(X);
                 assert_eq!(expect, x, "human got implementation wrong?");
                 assert_eq!(0, up.buf.len(), "human got remainder wrong?");
             }
@@ -748,7 +809,7 @@ mod tests {
             {
                 let mut up = Unpacker::new(HUMAN);
                 let x = up.unpack();
-                let expect: Result<$what, Error> = Ok(X);
+                let expect: Result<$what, SError> = Ok(X);
                 assert_eq!(expect, x, "human got implementation wrong?");
                 assert_eq!(0, up.buf.len(), "human got remainder wrong?");
             }
@@ -825,15 +886,15 @@ mod tests {
     fn unpacker() {
         let buf: &[u8] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let mut up = Unpacker::new(buf);
-        let x = up.unpack::<Error, ()>();
+        let x = up.unpack::<SError, ()>();
         assert_eq!(Ok(()), x, "human got () unpacker wrong?");
-        let x = up.unpack::<Error, u8>();
+        let x = up.unpack::<SError, u8>();
         assert_eq!(Ok(1u8), x, "human got u8 unpacker wrong?");
-        let x = up.unpack::<Error, u16>();
+        let x = up.unpack::<SError, u16>();
         assert_eq!(Ok(770u16), x, "human got u16 unpacker wrong?");
-        let x = up.unpack::<Error, u32>();
+        let x = up.unpack::<SError, u32>();
         assert_eq!(Ok(117835012u32), x, "human got u32 unpacker wrong?");
-        let x = up.unpack::<Error, u64>();
+        let x = up.unpack::<SError, u64>();
         assert_eq!(
             Ok(1084818905618843912u64),
             x,

--- a/buffertk/src/varint.rs
+++ b/buffertk/src/varint.rs
@@ -7,9 +7,10 @@
 #![allow(clippy::len_zero)]
 #![allow(clippy::from_over_into)]
 
-use super::Error;
 use super::Packable;
+use super::SError;
 use super::Unpackable;
+use super::{signed_overflow, unsigned_overflow, varint_overflow};
 
 use std::convert::TryInto;
 
@@ -31,12 +32,12 @@ impl From<u8> for v64 {
 }
 
 impl TryInto<u8> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<u8, Error> {
+    fn try_into(self) -> Result<u8, SError> {
         match self.x.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::UnsignedOverflow { value: self.x }),
+            Err(_) => Err(unsigned_overflow(self.x)),
         }
     }
 }
@@ -48,12 +49,12 @@ impl From<u16> for v64 {
 }
 
 impl TryInto<u16> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<u16, Error> {
+    fn try_into(self) -> Result<u16, SError> {
         match self.x.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::UnsignedOverflow { value: self.x }),
+            Err(_) => Err(unsigned_overflow(self.x)),
         }
     }
 }
@@ -65,12 +66,12 @@ impl From<u32> for v64 {
 }
 
 impl TryInto<u32> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<u32, Error> {
+    fn try_into(self) -> Result<u32, SError> {
         match self.x.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::UnsignedOverflow { value: self.x }),
+            Err(_) => Err(unsigned_overflow(self.x)),
         }
     }
 }
@@ -94,13 +95,13 @@ impl From<i8> for v64 {
 }
 
 impl TryInto<i8> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<i8, Error> {
+    fn try_into(self) -> Result<i8, SError> {
         let value: i64 = self.x as i64;
         match value.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::SignedOverflow { value }),
+            Err(_) => Err(signed_overflow(value)),
         }
     }
 }
@@ -112,13 +113,13 @@ impl From<i16> for v64 {
 }
 
 impl TryInto<i16> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<i16, Error> {
+    fn try_into(self) -> Result<i16, SError> {
         let value: i64 = self.x as i64;
         match value.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::SignedOverflow { value }),
+            Err(_) => Err(signed_overflow(value)),
         }
     }
 }
@@ -130,13 +131,13 @@ impl From<i32> for v64 {
 }
 
 impl TryInto<i32> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn try_into(self) -> Result<i32, Error> {
+    fn try_into(self) -> Result<i32, SError> {
         let value: i64 = self.x as i64;
         match value.try_into() {
             Ok(x) => Ok(x),
-            Err(_) => Err(Error::SignedOverflow { value }),
+            Err(_) => Err(signed_overflow(value)),
         }
     }
 }
@@ -196,7 +197,7 @@ impl Packable for v64 {
 }
 
 impl v64 {
-    fn unpack_slow(buf: &[u8]) -> Result<(Self, &[u8]), Error> {
+    fn unpack_slow(buf: &[u8]) -> Result<(Self, &[u8]), SError> {
         let bytes: usize = if buf.len() < 10 { buf.len() } else { 10 };
         let mut ret = 0u64;
         let mut idx = 0;
@@ -212,11 +213,11 @@ impl v64 {
             let ret: v64 = ret.into();
             Ok((ret, &buf[idx..]))
         } else {
-            Err(Error::VarintOverflow { bytes })
+            Err(varint_overflow(bytes))
         }
     }
 
-    fn unpack_size<const SZ: usize>(buf: &[u8]) -> Result<(Self, &[u8]), Error> {
+    fn unpack_size<const SZ: usize>(buf: &[u8]) -> Result<(Self, &[u8]), SError> {
         let mut result = (buf[SZ - 1] as u64) << (7 * (SZ - 1));
         let mut offset = 0;
         for b in buf.iter().take(SZ - 1) {
@@ -228,10 +229,10 @@ impl v64 {
 }
 
 impl<'a> Unpackable<'a> for v64 {
-    type Error = Error;
+    type Error = crate::SError;
 
     #[inline(always)]
-    fn unpack<'b>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error>
+    fn unpack<'b>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError>
     where
         'b: 'a,
     {
@@ -259,7 +260,7 @@ impl<'a> Unpackable<'a> for v64 {
         } else if buf[9] < 128 {
             Self::unpack_size::<10>(buf)
         } else {
-            Err(Error::VarintOverflow { bytes: buf.len() })
+            Err(varint_overflow(buf.len()))
         }
     }
 }
@@ -292,8 +293,8 @@ mod tests {
     fn try_into_u8() {
         let x: u64 = (u8::MAX as u64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<u8, Error> = v.try_into();
-        assert_eq!(Err(Error::UnsignedOverflow { value: x }), x2);
+        let x2: Result<u8, SError> = v.try_into();
+        assert_eq!(Err(unsigned_overflow(x)), x2);
     }
 
     #[test]
@@ -307,8 +308,8 @@ mod tests {
     fn try_into_u16() {
         let x: u64 = (u16::MAX as u64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<u16, Error> = v.try_into();
-        assert_eq!(Err(Error::UnsignedOverflow { value: x }), x2);
+        let x2: Result<u16, SError> = v.try_into();
+        assert_eq!(Err(unsigned_overflow(x)), x2);
     }
 
     #[test]
@@ -322,8 +323,8 @@ mod tests {
     fn try_into_u32() {
         let x: u64 = (u32::MAX as u64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<u32, Error> = v.try_into();
-        assert_eq!(Err(Error::UnsignedOverflow { value: x }), x2);
+        let x2: Result<u32, SError> = v.try_into();
+        assert_eq!(Err(unsigned_overflow(x)), x2);
     }
 
     #[test]
@@ -346,8 +347,8 @@ mod tests {
     fn try_into_i8() {
         let x: i64 = (i8::MAX as i64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<i8, Error> = v.try_into();
-        assert_eq!(Err(Error::SignedOverflow { value: x }), x2);
+        let x2: Result<i8, SError> = v.try_into();
+        assert_eq!(Err(signed_overflow(x)), x2);
     }
 
     #[test]
@@ -363,8 +364,8 @@ mod tests {
     fn try_into_i16() {
         let x: i64 = (i16::MAX as i64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<i16, Error> = v.try_into();
-        assert_eq!(Err(Error::SignedOverflow { value: x }), x2);
+        let x2: Result<i16, SError> = v.try_into();
+        assert_eq!(Err(signed_overflow(x)), x2);
     }
 
     #[test]
@@ -380,8 +381,8 @@ mod tests {
     fn try_into_i32() {
         let x: i64 = (i32::MAX as i64) + 1;
         let v: v64 = v64::from(x);
-        let x2: Result<i32, Error> = v.try_into();
-        assert_eq!(Err(Error::SignedOverflow { value: x }), x2);
+        let x2: Result<i32, SError> = v.try_into();
+        assert_eq!(Err(signed_overflow(x)), x2);
     }
 
     #[test]

--- a/busyrpc/src/buffers.rs
+++ b/busyrpc/src/buffers.rs
@@ -129,10 +129,7 @@ impl RecvBuffer {
                     }
                     if hdr[0] as usize > HEADER_MAX_SIZE - 1 {
                         return Err(rpc_pb::serialization_error(
-                            prototk::Error::BufferTooShort {
-                                required: hdr[*idx] as usize,
-                                had: *idx,
-                            },
+                            prototk::buffer_too_short(hdr[*idx] as usize, *idx),
                             "frame header size invalid",
                         ));
                     }

--- a/busyrpc/src/client.rs
+++ b/busyrpc/src/client.rs
@@ -207,7 +207,7 @@ impl ChannelCriticalSection {
             let resp: rpc_pb::Response = match up.unpack() {
                 Ok(resp) => resp,
                 Err(err) => {
-                    ms.sht.set_error(err.into());
+                    ms.sht.set_error(err);
                     continue 'buffersing;
                 }
             };
@@ -621,14 +621,14 @@ impl<R: Resolver + Send + Sync + 'static> rpc_pb::Client for Client<'_, '_, R> {
                 Ok(resp) => resp,
                 Err(err) => {
                     chandle.kill();
-                    return Err(err.into());
+                    return Err(err);
                 }
             };
             if let Some(rpc_error) = resp.rpc_error {
                 let mut up = Unpacker::new(rpc_error);
                 let rpc_error: rpc_pb::SError = match up.unpack() {
                     Ok(rpc_error) => rpc_error,
-                    Err(unpack_error) => unpack_error.into(),
+                    Err(unpack_error) => unpack_error,
                 };
                 Err(rpc_error)
             } else if let Some(service_error) = resp.service_error {

--- a/handled/Cargo.toml
+++ b/handled/Cargo.toml
@@ -13,9 +13,6 @@ default = ["binaries"]
 binaries = []
 
 [dependencies]
-biometrics = { workspace = true }
-buffertk = { workspace = true }
-prototk = { workspace = true }
 
 [dev-dependencies]
 guacamole = { workspace = true }

--- a/handled/src/lib.rs
+++ b/handled/src/lib.rs
@@ -2,10 +2,6 @@
 
 use std::fmt::Debug;
 
-use buffertk::{Packable, Unpackable, Unpacker, stack_pack};
-use prototk::field_types::{message as proto_message, string as proto_string};
-use prototk::{FieldPackHelper, FieldUnpackHelper, Message, Tag};
-
 /// A symbolic expression: the fundamental data structure for representing structured data.
 ///
 /// S-expressions provide a uniform representation for both code and data, enabling
@@ -301,24 +297,6 @@ impl From<SExpr> for SError {
     }
 }
 
-impl From<buffertk::Error> for SError {
-    fn from(err: buffertk::Error) -> Self {
-        SError::new("buffertk")
-            .with_code("serialization-error")
-            .with_message("buffertk serialization error")
-            .with_string_field("cause", &err.to_string())
-    }
-}
-
-impl From<prototk::Error> for SError {
-    fn from(err: prototk::Error) -> Self {
-        SError::new("prototk")
-            .with_code("serialization-error")
-            .with_message("prototk serialization error")
-            .with_string_field("cause", &err.to_string())
-    }
-}
-
 impl From<std::io::Error> for SError {
     fn from(err: std::io::Error) -> Self {
         SError::new("io")
@@ -336,55 +314,6 @@ impl Default for SError {
             .with_message("default SError value")
     }
 }
-
-impl Packable for SError {
-    fn pack_sz(&self) -> usize {
-        stack_pack(proto_string(&self.to_string())).pack_sz()
-    }
-
-    fn pack(&self, buf: &mut [u8]) {
-        stack_pack(proto_string(&self.to_string())).into_slice(buf);
-    }
-}
-
-impl<'a> Unpackable<'a> for SError {
-    type Error = prototk::Error;
-
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Self::Error> {
-        let mut up = Unpacker::new(buf);
-        let serialized: proto_string<'a> = up.unpack()?;
-        let err = parse(serialized.0).map_err(|_| prototk::Error::StringEncoding)?;
-        Ok((SError::from(err), up.remain()))
-    }
-}
-
-impl FieldPackHelper<'_, proto_message<SError>> for SError {
-    fn field_pack_sz(&self, tag: &Tag) -> usize {
-        stack_pack(tag)
-            .pack(stack_pack(self).length_prefixed())
-            .pack_sz()
-    }
-
-    fn field_pack(&self, tag: &Tag, out: &mut [u8]) {
-        stack_pack(tag)
-            .pack(stack_pack(self).length_prefixed())
-            .into_slice(out);
-    }
-}
-
-impl FieldUnpackHelper<'_, proto_message<SError>> for SError {
-    fn merge_field(&mut self, proto: proto_message<SError>) {
-        *self = proto.unwrap_message();
-    }
-}
-
-impl From<proto_message<SError>> for SError {
-    fn from(proto: proto_message<SError>) -> Self {
-        proto.unwrap_message()
-    }
-}
-
-impl Message<'_> for SError {}
 
 fn field(name: &str, value: SExpr) -> SExpr {
     SExpr::List(vec![SExpr::Atom(name.to_string()), value])

--- a/macarunes/src/lib.rs
+++ b/macarunes/src/lib.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use biometrics::Counter;
 
 use buffertk::{Unpacker, stack_pack};
-use prototk::Error as PrototkError;
+use prototk::SError as PrototkError;
 
 use prototk_derive::Message;
 

--- a/one_two_eight/src/lib.rs
+++ b/one_two_eight/src/lib.rs
@@ -195,19 +195,16 @@ macro_rules! generate_id_prototk {
         }
 
         impl<'a> buffertk::Unpackable<'a> for $what {
-            type Error = prototk::Error;
+            type Error = prototk::SError;
 
-            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), prototk::Error> {
+            fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), prototk::SError> {
                 let mut up = buffertk::Unpacker::new(buf);
                 let tag: buffertk::v64 = up.unpack()?;
                 let v: buffertk::v64 = up.unpack()?;
                 let v: usize = v.into();
                 let rem = up.remain();
                 if rem.len() < v {
-                    return Err(prototk::Error::BufferTooShort {
-                        required: v,
-                        had: rem.len(),
-                    });
+                    return Err(prototk::buffer_too_short(v, rem.len()));
                 }
                 // TODO(rescrv): Have an error if v != 16.
                 let id = $what {

--- a/prototk/Cargo.toml
+++ b/prototk/Cargo.toml
@@ -9,4 +9,5 @@ repository = "https://github.com/rescrv/blue"
 
 [dependencies]
 buffertk = { workspace = true }
+handled = { workspace = true }
 prototk_derive = { workspace = true }

--- a/prototk/README.md
+++ b/prototk/README.md
@@ -15,7 +15,7 @@ Scope
 This library is about serialization and deserialization of messages.  It strives to distil protocol buffers to this:
 
 ```ignore
-use handled::SError;
+use prototk::SError;
 
 #[derive(Debug, Default, Message)]
 pub enum Response {
@@ -50,7 +50,7 @@ Reserved Field Ranges
 
 The error types in my libraries all have diffrent field numbers.  Here is where I track them.
 
-- 262144..262400 prototk::Error
+- 262144..262400 prototk::SError
 - 278528..278784 rpc_pb structured values
 - 294912..295168 macarunes structured values
 - 311296..311552 tuple_key structured values

--- a/prototk/src/field_types.rs
+++ b/prototk/src/field_types.rs
@@ -75,9 +75,9 @@ impl Packable for int32 {
 }
 
 impl<'a> Unpackable<'a> for int32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: i32 = v.try_into()?;
         Ok((int32(x), buf))
@@ -140,9 +140,9 @@ impl Packable for int64 {
 }
 
 impl<'a> Unpackable<'a> for int64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: i64 = v.into();
         Ok((int64(x), buf))
@@ -205,9 +205,9 @@ impl Packable for uint32 {
 }
 
 impl<'a> Unpackable<'a> for uint32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: u32 = v.try_into()?;
         Ok((uint32(x), buf))
@@ -294,9 +294,9 @@ impl Packable for uint64 {
 }
 
 impl<'a> Unpackable<'a> for uint64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: u64 = v.into();
         Ok((uint64(x), buf))
@@ -359,15 +359,15 @@ impl Packable for sint32 {
 }
 
 impl<'a> Unpackable<'a> for sint32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: i64 = unzigzag(v.into());
         let x: i32 = match x.try_into() {
             Ok(x) => x,
             Err(_) => {
-                return Err(Error::SignedOverflow { value: x });
+                return Err(signed_overflow(x));
             }
         };
         Ok((sint32(x), buf))
@@ -430,9 +430,9 @@ impl Packable for sint64 {
 }
 
 impl<'a> Unpackable<'a> for sint64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: i64 = unzigzag(v.into());
         Ok((sint64(x), buf))
@@ -493,9 +493,9 @@ impl Packable for fixed32 {
 }
 
 impl<'a> Unpackable<'a> for fixed32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = u32::unpack(buf)?;
         Ok((fixed32(x), buf))
     }
@@ -555,9 +555,9 @@ impl Packable for fixed64 {
 }
 
 impl<'a> Unpackable<'a> for fixed64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = u64::unpack(buf)?;
         Ok((fixed64(x), buf))
     }
@@ -617,9 +617,9 @@ impl Packable for sfixed32 {
 }
 
 impl<'a> Unpackable<'a> for sfixed32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = i32::unpack(buf)?;
         Ok((sfixed32(x), buf))
     }
@@ -679,9 +679,9 @@ impl Packable for sfixed64 {
 }
 
 impl<'a> Unpackable<'a> for sfixed64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = i64::unpack(buf)?;
         Ok((sfixed64(x), buf))
     }
@@ -741,9 +741,9 @@ impl Packable for float {
 }
 
 impl<'a> Unpackable<'a> for float {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = f32::unpack(buf)?;
         Ok((float(x), buf))
     }
@@ -803,9 +803,9 @@ impl Packable for double {
 }
 
 impl<'a> Unpackable<'a> for double {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (x, buf) = f64::unpack(buf)?;
         Ok((double(x), buf))
     }
@@ -866,9 +866,9 @@ impl Packable for Bool {
 }
 
 impl<'a> Unpackable<'a> for Bool {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let (v, buf) = v64::unpack(buf)?;
         let x: u64 = v.into();
         let b = x != 0;
@@ -977,18 +977,15 @@ impl Packable for bytes<'_> {
 }
 
 impl<'a> Unpackable<'a> for bytes<'a> {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let v: v64 = up.unpack()?;
         let v: usize = v.into();
         let rem = up.remain();
         if rem.len() < v {
-            return Err(Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            });
+            return Err(buffer_too_short(v, rem.len()));
         }
         Ok((Self(&rem[..v]), &rem[v..]))
     }
@@ -1049,30 +1046,21 @@ impl Packable for bytes16 {
 }
 
 impl<'a> Unpackable<'a> for bytes16 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let v: v64 = up.unpack()?;
         let v: usize = v.into();
         let rem = up.remain();
         if rem.len() < v {
-            return Err(Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            });
+            return Err(buffer_too_short(v, rem.len()));
         }
         if v < 16 {
-            return Err(Error::BufferTooShort {
-                required: 16,
-                had: v,
-            });
+            return Err(buffer_too_short(16, v));
         }
         if v != 16 {
-            return Err(Error::WrongLength {
-                required: 16,
-                had: v,
-            });
+            return Err(wrong_length(16, v));
         }
         let mut ret = [0u8; 16];
         ret[..16].copy_from_slice(&rem[..16]);
@@ -1134,30 +1122,21 @@ impl Packable for bytes32 {
 }
 
 impl<'a> Unpackable<'a> for bytes32 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let v: v64 = up.unpack()?;
         let v: usize = v.into();
         let rem = up.remain();
         if rem.len() < v {
-            return Err(Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            });
+            return Err(buffer_too_short(v, rem.len()));
         }
         if v < 32 {
-            return Err(Error::BufferTooShort {
-                required: 32,
-                had: v,
-            });
+            return Err(buffer_too_short(32, v));
         }
         if v != 32 {
-            return Err(Error::WrongLength {
-                required: 32,
-                had: v,
-            });
+            return Err(wrong_length(32, v));
         }
         let mut ret = [0u8; 32];
         ret[..32].copy_from_slice(&rem[..32]);
@@ -1226,30 +1205,21 @@ impl Packable for bytes64 {
 }
 
 impl<'a> Unpackable<'a> for bytes64 {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let v: v64 = up.unpack()?;
         let v: usize = v.into();
         let rem = up.remain();
         if rem.len() < v {
-            return Err(Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            });
+            return Err(buffer_too_short(v, rem.len()));
         }
         if v < 64 {
-            return Err(Error::BufferTooShort {
-                required: 64,
-                had: v,
-            });
+            return Err(buffer_too_short(64, v));
         }
         if v != 64 {
-            return Err(Error::WrongLength {
-                required: 64,
-                had: v,
-            });
+            return Err(wrong_length(64, v));
         }
         let mut ret = [0u8; 64];
         ret[..64].copy_from_slice(&rem[..64]);
@@ -1358,24 +1328,21 @@ impl Packable for string<'_> {
 }
 
 impl<'a> Unpackable<'a> for string<'a> {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let v: v64 = up.unpack()?;
         let v: usize = v.into();
         let rem = up.remain();
         if rem.len() < v {
-            return Err(Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            });
+            return Err(buffer_too_short(v, rem.len()));
         }
         let x: &'a [u8] = &rem[..v];
         let s: &'a str = match std::str::from_utf8(x) {
             Ok(s) => s,
             Err(_) => {
-                return Err(Error::StringEncoding);
+                return Err(string_encoding());
             }
         };
         Ok((string(s), &rem[v..]))
@@ -1422,7 +1389,7 @@ impl<M: Packable> Packable for message<M> {
 impl<'a, M> Unpackable<'a> for message<M>
 where
     M: Unpackable<'a>,
-    <M as Unpackable<'a>>::Error: From<buffertk::Error>,
+    <M as Unpackable<'a>>::Error: From<buffertk::SError>,
 {
     type Error = M::Error;
 
@@ -1438,11 +1405,7 @@ where
         let rem = up.remain();
         // TODO(rescrv): this pattern multiple times; try to move to Unpacker.
         if rem.len() < v {
-            return Err(buffertk::Error::BufferTooShort {
-                required: v,
-                had: rem.len(),
-            }
-            .into());
+            return Err(buffertk::buffer_too_short(v, rem.len()).into());
         }
         let buf: &'b [u8] = &rem[..v];
         let rem: &'b [u8] = &rem[v..];

--- a/prototk/src/lib.rs
+++ b/prototk/src/lib.rs
@@ -9,760 +9,144 @@ pub use zigzag::unzigzag;
 pub use zigzag::zigzag;
 
 use buffertk::{Packable, Unpackable, Unpacker, stack_pack, v64};
+pub use handled::SError;
 
 /////////////////////////////////////////////// Error //////////////////////////////////////////////
 
-/// Error captures the possible error conditions for packing and unpacking.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub enum Error {
-    /// The default error is succes.
-    #[default]
-    Success,
-    /// BufferTooShort indicates that there was a need to pack or unpack more bytes than were
-    /// available in the underlying memory.
-    BufferTooShort {
-        /// The number of bytes required to unpack.
-        required: usize,
-        /// The number of bytes available to unpack.
-        had: usize,
-    },
-    /// InvalidFieldNumber indicates that the field is not a user-assignable field.
-    InvalidFieldNumber {
-        /// The u32 field number that's invalid.
-        field_number: u32,
-        /// A human-readable description of why the field number is invalid.
-        what: String,
-    },
-    /// UnhandledWireType indicates that the wire_type is not understood by this process and cannot
-    /// be skipped.
-    UnhandledWireType {
-        /// The wire type that's not handled.
-        wire_type: u32,
-    },
-    /// TagTooLarge indicates the tag would overflow a 32-bit number.
-    TagTooLarge {
-        /// The tag that's too large.
-        tag: u64,
-    },
-    /// VarintOverflow indicates that a varint field did not terminate with a number < 128.
-    VarintOverflow {
-        /// The number of bytes witnessed in the varint.
-        bytes: usize,
-    },
-    /// UnsignedOverflow indicates that a value will not fit its intended (unsigned) target.
-    UnsignedOverflow {
-        /// The u64 that doesn't fit a u32.
-        value: u64,
-    },
-    /// SignedOverflow indicates that a value will not fit its intended (signed) target.
-    SignedOverflow {
-        /// The i64 that doesn't fit an i32.
-        value: i64,
-    },
-    /// WrongLength indicates that a bytes32 did not have 32 bytes.
-    WrongLength {
-        /// The required number of bytes for the type.
-        required: usize,
-        /// The number of bytes the type claims to be.
-        had: usize,
-    },
-    /// StringEncoding indicates that a value is not UTF-8 friendly.
-    StringEncoding,
-    /// UnknownDiscriminant indicates a variant that is not understood by this code.
-    UnknownDiscriminant {
-        /// The discriminant that's not handled by this process.
-        discriminant: u32,
-    },
-    /// NotAChar indicates that the prescribed value was tried to unpack as a char, but it's not a
-    /// char.
-    NotAChar {
-        /// Value that's not a char.
-        value: u32,
-    },
+const PHASE: &str = "prototk";
+
+/// A default `prototk` error value.
+pub const CODE_SUCCESS: &str = "success";
+/// A buffer did not contain enough bytes to unpack a value.
+pub const CODE_BUFFER_TOO_SHORT: &str = "buffer-too-short";
+/// A field number is not user-assignable.
+pub const CODE_INVALID_FIELD_NUMBER: &str = "invalid-field-number";
+/// A wire type is not understood by this process.
+pub const CODE_UNHANDLED_WIRE_TYPE: &str = "unhandled-wire-type";
+/// A tag exceeded the 32-bit protobuf tag representation.
+pub const CODE_TAG_TOO_LARGE: &str = "tag-too-large";
+/// A varint exceeded the maximum encoded length.
+pub const CODE_VARINT_OVERFLOW: &str = "varint-overflow";
+/// An unsigned value did not fit the requested target type.
+pub const CODE_UNSIGNED_OVERFLOW: &str = "unsigned-overflow";
+/// A signed value did not fit the requested target type.
+pub const CODE_SIGNED_OVERFLOW: &str = "signed-overflow";
+/// A fixed-size bytes field had the wrong length.
+pub const CODE_WRONG_LENGTH: &str = "wrong-length";
+/// A serialized string was not valid UTF-8 or not a valid S-expression.
+pub const CODE_STRING_ENCODING: &str = "string-encoding";
+/// A discriminant was not recognized.
+pub const CODE_UNKNOWN_DISCRIMINANT: &str = "unknown-discriminant";
+/// A numeric value is not a valid Unicode scalar value.
+pub const CODE_NOT_A_CHAR: &str = "not-a-char";
+
+fn error(code: &str) -> SError {
+    SError::new(PHASE).with_code(code)
 }
 
-impl Display for Error {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), std::fmt::Error> {
-        match self {
-            Error::Success => fmt.debug_struct("SerializationError").finish(),
-            Error::BufferTooShort { required, had } => fmt
-                .debug_struct("BufferTooShort")
-                .field("required", required)
-                .field("had", had)
-                .finish(),
-            Error::InvalidFieldNumber { field_number, what } => fmt
-                .debug_struct("InvalidFieldNumber")
-                .field("field_number", field_number)
-                .field("what", what)
-                .finish(),
-            Error::UnhandledWireType { wire_type } => fmt
-                .debug_struct("UnhandledWireType")
-                .field("wire_type", wire_type)
-                .finish(),
-            Error::TagTooLarge { tag } => {
-                fmt.debug_struct("TagTooLarge").field("tag", tag).finish()
-            }
-            Error::VarintOverflow { bytes } => fmt
-                .debug_struct("VarintOverflow")
-                .field("bytes", bytes)
-                .finish(),
-            Error::UnsignedOverflow { value } => fmt
-                .debug_struct("UnsignedOverflow")
-                .field("value", value)
-                .finish(),
-            Error::SignedOverflow { value } => fmt
-                .debug_struct("SignedOverflow")
-                .field("value", value)
-                .finish(),
-            Error::WrongLength { required, had } => fmt
-                .debug_struct("WrongLength")
-                .field("required", required)
-                .field("had", had)
-                .finish(),
-            Error::StringEncoding => fmt.debug_struct("StringEncoding").finish(),
-            Error::UnknownDiscriminant { discriminant } => fmt
-                .debug_struct("UnknownDiscriminant")
-                .field("discriminant", discriminant)
-                .finish(),
-            Error::NotAChar { value } => {
-                fmt.debug_struct("NotAChar").field("value", value).finish()
-            }
-        }
-    }
+/// Construct a default `prototk` error value.
+pub fn success() -> SError {
+    error(CODE_SUCCESS).with_message("success")
 }
 
-impl From<buffertk::Error> for Error {
-    fn from(x: buffertk::Error) -> Self {
-        match x {
-            buffertk::Error::BufferTooShort { required, had } => {
-                Error::BufferTooShort { required, had }
-            }
-            buffertk::Error::VarintOverflow { bytes } => Error::VarintOverflow { bytes },
-            buffertk::Error::UnsignedOverflow { value } => Error::UnsignedOverflow { value },
-            buffertk::Error::SignedOverflow { value } => Error::SignedOverflow { value },
-            buffertk::Error::TagTooLarge { tag } => Error::TagTooLarge { tag },
-            buffertk::Error::UnknownDiscriminant { discriminant } => {
-                Error::UnknownDiscriminant { discriminant }
-            }
-            buffertk::Error::NotAChar { value } => Error::NotAChar { value },
-        }
+/// Construct a buffer-too-short error.
+pub fn buffer_too_short(required: usize, had: usize) -> SError {
+    error(CODE_BUFFER_TOO_SHORT)
+        .with_message("buffer too short")
+        .with_atom_field("required", required)
+        .with_atom_field("had", had)
+}
+
+/// Construct an invalid-field-number error.
+pub fn invalid_field_number(field_number: u32, what: impl AsRef<str>) -> SError {
+    error(CODE_INVALID_FIELD_NUMBER)
+        .with_message("invalid field number")
+        .with_atom_field("field_number", field_number)
+        .with_string_field("what", what.as_ref())
+}
+
+/// Construct an unhandled-wire-type error.
+pub fn unhandled_wire_type(wire_type: u32) -> SError {
+    error(CODE_UNHANDLED_WIRE_TYPE)
+        .with_message("unhandled wire type")
+        .with_atom_field("wire_type", wire_type)
+}
+
+/// Construct a tag-too-large error.
+pub fn tag_too_large(tag: u64) -> SError {
+    error(CODE_TAG_TOO_LARGE)
+        .with_message("tag too large")
+        .with_atom_field("tag", tag)
+}
+
+/// Construct a varint-overflow error.
+pub fn varint_overflow(bytes: usize) -> SError {
+    error(CODE_VARINT_OVERFLOW)
+        .with_message("varint overflow")
+        .with_atom_field("bytes", bytes)
+}
+
+/// Construct an unsigned-overflow error.
+pub fn unsigned_overflow(value: u64) -> SError {
+    error(CODE_UNSIGNED_OVERFLOW)
+        .with_message("unsigned integer overflow")
+        .with_atom_field("value", value)
+}
+
+/// Construct a signed-overflow error.
+pub fn signed_overflow(value: i64) -> SError {
+    error(CODE_SIGNED_OVERFLOW)
+        .with_message("signed integer overflow")
+        .with_atom_field("value", value)
+}
+
+/// Construct a wrong-length error.
+pub fn wrong_length(required: usize, had: usize) -> SError {
+    error(CODE_WRONG_LENGTH)
+        .with_message("wrong length")
+        .with_atom_field("required", required)
+        .with_atom_field("had", had)
+}
+
+/// Construct a string-encoding error.
+pub fn string_encoding() -> SError {
+    error(CODE_STRING_ENCODING).with_message("string encoding error")
+}
+
+/// Construct an unknown-discriminant error.
+pub fn unknown_discriminant(discriminant: u32) -> SError {
+    error(CODE_UNKNOWN_DISCRIMINANT)
+        .with_message("unknown discriminant")
+        .with_atom_field("discriminant", discriminant)
+}
+
+/// Construct a not-a-char error.
+pub fn not_a_char(value: u32) -> SError {
+    error(CODE_NOT_A_CHAR)
+        .with_message("not a valid char")
+        .with_atom_field("value", value)
+}
+
+fn error_field<'a>(err: &'a SError, name: &str) -> Option<&'a handled::SExpr> {
+    match err.detail() {
+        handled::SExpr::List(fields) => fields.iter().find_map(|field| match field {
+            handled::SExpr::List(pair) if pair.len() == 2 => match &pair[0] {
+                handled::SExpr::Atom(field_name) if field_name == name => Some(&pair[1]),
+                _ => None,
+            },
+            _ => None,
+        }),
+        _ => None,
     }
 }
 
-impl Packable for Error {
-    fn pack_sz(&self) -> usize {
-        match self {
-            Error::Success => {
-                let prototk_empty: &[u8] = &[];
-                stack_pack(field_types::bytes::field_packer(
-                    FieldNumber::must(262144),
-                    &prototk_empty,
-                ))
-                .pack_sz()
-            }
-            Error::BufferTooShort { required, had } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    required,
-                ));
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(2), had));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262145),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::InvalidFieldNumber { field_number, what } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    field_number,
-                ));
-                let pa = pa.pack(field_types::string::field_packer(
-                    FieldNumber::must(2),
-                    what,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262146),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::UnhandledWireType { wire_type } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    wire_type,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262147),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::TagTooLarge { tag } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(1), tag));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262148),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::VarintOverflow { bytes } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    bytes,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262149),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::UnsignedOverflow { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262150),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::SignedOverflow { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::int64::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262151),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::WrongLength { required, had } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    required,
-                ));
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(2), had));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262152),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::StringEncoding => {
-                let prototk_empty: &[u8] = &[];
-                stack_pack(field_types::bytes::field_packer(
-                    FieldNumber::must(262153),
-                    &prototk_empty,
-                ))
-                .pack_sz()
-            }
-            Error::UnknownDiscriminant { discriminant } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    discriminant,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262154),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-            Error::NotAChar { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262155),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .pack_sz()
-            }
-        }
-    }
-
-    fn pack(&self, buf: &mut [u8]) {
-        match self {
-            Error::Success => {
-                let prototk_empty: &[u8] = &[];
-                stack_pack(field_types::bytes::field_packer(
-                    FieldNumber::must(262144),
-                    &prototk_empty,
-                ))
-                .into_slice(buf);
-            }
-            Error::BufferTooShort { required, had } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    required,
-                ));
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(2), had));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262145),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::InvalidFieldNumber { field_number, what } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    field_number,
-                ));
-                let pa = pa.pack(field_types::string::field_packer(
-                    FieldNumber::must(2),
-                    what,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262146),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::UnhandledWireType { wire_type } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    wire_type,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262147),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::TagTooLarge { tag } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(1), tag));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262148),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::VarintOverflow { bytes } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    bytes,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262149),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::UnsignedOverflow { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262150),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::SignedOverflow { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::int64::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262151),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::WrongLength { required, had } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint64::field_packer(
-                    FieldNumber::must(1),
-                    required,
-                ));
-                let pa = pa.pack(field_types::uint64::field_packer(FieldNumber::must(2), had));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262152),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::StringEncoding => {
-                let prototk_empty: &[u8] = &[];
-                stack_pack(field_types::bytes::field_packer(
-                    FieldNumber::must(262153),
-                    &prototk_empty,
-                ))
-                .into_slice(buf);
-            }
-            Error::UnknownDiscriminant { discriminant } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    discriminant,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262154),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-            Error::NotAChar { value } => {
-                let pa = stack_pack(());
-                let pa = pa.pack(field_types::uint32::field_packer(
-                    FieldNumber::must(1),
-                    value,
-                ));
-                stack_pack(Tag {
-                    field_number: FieldNumber::must(262155),
-                    wire_type: WireType::LengthDelimited,
-                })
-                .pack(pa.length_prefixed())
-                .into_slice(buf);
-            }
-        }
+/// Return the machine-readable code from a `prototk` error.
+pub fn error_code(err: &SError) -> Option<&str> {
+    match error_field(err, "code") {
+        Some(handled::SExpr::Atom(code)) => Some(code.as_str()),
+        _ => None,
     }
 }
-
-impl<'a> Unpackable<'a> for Error {
-    type Error = Error;
-
-    fn unpack<'b>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error>
-    where
-        'b: 'a,
-    {
-        let mut up = Unpacker::new(buf);
-        let tag: Tag = up.unpack()?;
-        let num: u32 = tag.field_number.into();
-        let wire_type: WireType = tag.wire_type;
-        match (num, wire_type) {
-            (262144, WireType::LengthDelimited) => {
-                let x: v64 = up.unpack()?;
-                up.advance(x.into());
-                Ok((Error::Success, up.remain()))
-            }
-            (262145, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_required: field_types::uint64 =
-                    field_types::uint64::default();
-                let mut prototk_field_had: field_types::uint64 = field_types::uint64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_required, _) = Unpackable::unpack(buf)?;
-                        }
-                        (2, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_had, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::BufferTooShort {
-                    required: prototk_field_required.into(),
-                    had: prototk_field_had.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262146, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_field_number: field_types::uint32 =
-                    field_types::uint32::default();
-                let mut prototk_field_what: field_types::string = field_types::string::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint32::WIRE_TYPE) => {
-                            (prototk_field_field_number, _) = Unpackable::unpack(buf)?;
-                        }
-                        (2, field_types::string::WIRE_TYPE) => {
-                            (prototk_field_what, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::InvalidFieldNumber {
-                    field_number: prototk_field_field_number.into(),
-                    what: prototk_field_what.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262147, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_wire_type: field_types::uint32 =
-                    field_types::uint32::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint32::WIRE_TYPE) => {
-                            (prototk_field_wire_type, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::UnhandledWireType {
-                    wire_type: prototk_field_wire_type.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262148, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_tag: field_types::uint64 = field_types::uint64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_tag, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::TagTooLarge {
-                    tag: prototk_field_tag.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262149, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_bytes: field_types::uint64 = field_types::uint64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_bytes, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::VarintOverflow {
-                    bytes: prototk_field_bytes.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262150, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_value: field_types::uint64 = field_types::uint64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_value, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::UnsignedOverflow {
-                    value: prototk_field_value.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262151, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_value: field_types::int64 = field_types::int64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::int64::WIRE_TYPE) => {
-                            (prototk_field_value, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::SignedOverflow {
-                    value: prototk_field_value.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262152, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_required: field_types::uint64 =
-                    field_types::uint64::default();
-                let mut prototk_field_had: field_types::uint64 = field_types::uint64::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_required, _) = Unpackable::unpack(buf)?;
-                        }
-                        (2, field_types::uint64::WIRE_TYPE) => {
-                            (prototk_field_had, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::WrongLength {
-                    required: prototk_field_required.into(),
-                    had: prototk_field_had.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262153, WireType::LengthDelimited) => {
-                let x: v64 = up.unpack()?;
-                up.advance(x.into());
-                Ok((Error::StringEncoding, up.remain()))
-            }
-            (262154, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_discriminant: field_types::uint32 =
-                    field_types::uint32::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint32::WIRE_TYPE) => {
-                            (prototk_field_discriminant, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::UnknownDiscriminant {
-                    discriminant: prototk_field_discriminant.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            (262155, WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<Error> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
-                let fields = FieldIterator::new(local_buf, &mut error);
-                let mut prototk_field_value: field_types::uint32 = field_types::uint32::default();
-                for (tag, buf) in fields {
-                    let num: u32 = tag.field_number.into();
-                    match (num, tag.wire_type) {
-                        (1, field_types::uint32::WIRE_TYPE) => {
-                            (prototk_field_value, _) = Unpackable::unpack(buf)?;
-                        }
-                        (_, _) => {
-                            return Err(Error::UnknownDiscriminant { discriminant: num });
-                        }
-                    }
-                }
-                let ret = Error::NotAChar {
-                    value: prototk_field_value.into(),
-                };
-                Ok((ret, up.remain()))
-            }
-            _ => Err(Error::UnknownDiscriminant { discriminant: num }),
-        }
-    }
-}
-
-impl FieldPackHelper<'_, field_types::message<Error>> for Error {
-    fn field_pack_sz(&self, tag: &Tag) -> usize {
-        stack_pack(tag)
-            .pack(stack_pack(self).length_prefixed())
-            .pack_sz()
-    }
-
-    fn field_pack(&self, tag: &Tag, out: &mut [u8]) {
-        stack_pack(tag)
-            .pack(stack_pack(self).length_prefixed())
-            .into_slice(out);
-    }
-}
-
-impl FieldUnpackHelper<'_, field_types::message<Error>> for Error {
-    fn merge_field(&mut self, proto: field_types::message<Error>) {
-        *self = proto.unwrap_message();
-    }
-}
-
-impl From<field_types::message<Error>> for Error {
-    fn from(proto: field_types::message<Error>) -> Self {
-        proto.unwrap_message()
-    }
-}
-
-impl Message<'_> for Error {}
 
 ///////////////////////////////////////////// WireType /////////////////////////////////////////////
 
@@ -783,15 +167,13 @@ pub enum WireType {
 
 impl WireType {
     /// Possibly create a new WireType from the tag bits.
-    pub fn new(tag_bits: u32) -> Result<WireType, Error> {
+    pub fn new(tag_bits: u32) -> Result<WireType, SError> {
         match tag_bits {
             0 => Ok(WireType::Varint),
             1 => Ok(WireType::SixtyFour),
             2 => Ok(WireType::LengthDelimited),
             5 => Ok(WireType::ThirtyTwo),
-            _ => Err(Error::UnhandledWireType {
-                wire_type: tag_bits,
-            }),
+            _ => Err(unhandled_wire_type(tag_bits)),
         }
     }
 
@@ -837,24 +219,18 @@ impl FieldNumber {
     }
 
     /// Create a new [FieldNumber] if `field_number` is valid and not reserved.
-    pub fn new(field_number: u32) -> Result<FieldNumber, Error> {
+    pub fn new(field_number: u32) -> Result<FieldNumber, SError> {
         if field_number < FIRST_FIELD_NUMBER {
-            return Err(Error::InvalidFieldNumber {
+            return Err(invalid_field_number(
                 field_number,
-                what: "field number must be positive integer".to_string(),
-            });
+                "field number must be positive integer",
+            ));
         }
         if field_number > LAST_FIELD_NUMBER {
-            return Err(Error::InvalidFieldNumber {
-                field_number,
-                what: "field number too large".to_string(),
-            });
+            return Err(invalid_field_number(field_number, "field number too large"));
         }
         if (FIRST_RESERVED_FIELD_NUMBER..=LAST_RESERVED_FIELD_NUMBER).contains(&field_number) {
-            return Err(Error::InvalidFieldNumber {
-                field_number,
-                what: "field is reserved".to_string(),
-            });
+            return Err(invalid_field_number(field_number, "field is reserved"));
         }
         Ok(FieldNumber { field_number })
     }
@@ -931,14 +307,14 @@ impl Packable for Tag {
 }
 
 impl<'a> Unpackable<'a> for Tag {
-    type Error = Error;
+    type Error = crate::SError;
 
-    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), Error> {
+    fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
         let mut up = Unpacker::new(buf);
         let tag: v64 = up.unpack()?;
         let tag: u64 = tag.into();
         if tag > u32::MAX as u64 {
-            return Err(Error::TagTooLarge { tag });
+            return Err(tag_too_large(tag));
         }
         let tag: u32 = tag as u32;
         let f: u32 = tag >> 3;
@@ -1195,12 +571,12 @@ where
 // TODO(rescrv): This panicked once and I didn't debug it.  Fix that.
 pub struct FieldIterator<'a, 'b> {
     up: Unpacker<'a>,
-    err: &'b mut Option<Error>,
+    err: &'b mut Option<SError>,
 }
 
 impl<'a, 'b> FieldIterator<'a, 'b> {
     /// Create a new field iterator that will return tags and their byte strings.
-    pub fn new(buf: &'a [u8], err: &'b mut Option<Error>) -> Self {
+    pub fn new(buf: &'a [u8], err: &'b mut Option<SError>) -> Self {
         Self {
             up: Unpacker::new(buf),
             err,
@@ -1242,10 +618,7 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
             WireType::SixtyFour => {
                 let buf: &[u8] = self.up.remain();
                 if buf.len() < 8 {
-                    *self.err = Some(Error::BufferTooShort {
-                        required: 8,
-                        had: buf.len(),
-                    });
+                    *self.err = Some(buffer_too_short(8, buf.len()));
                     return None;
                 }
                 self.up.advance(8);
@@ -1262,10 +635,7 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
                 };
                 let sz: usize = x.into();
                 if buf.len() < x.pack_sz() + sz {
-                    *self.err = Some(Error::BufferTooShort {
-                        required: sz,
-                        had: buf.len(),
-                    });
+                    *self.err = Some(buffer_too_short(sz, buf.len()));
                     return None;
                 }
                 self.up.advance(sz);
@@ -1274,10 +644,7 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
             WireType::ThirtyTwo => {
                 let buf: &[u8] = self.up.remain();
                 if buf.len() < 4 {
-                    *self.err = Some(Error::BufferTooShort {
-                        required: 4,
-                        had: buf.len(),
-                    });
+                    *self.err = Some(buffer_too_short(4, buf.len()));
                     return None;
                 }
                 self.up.advance(4);
@@ -1287,18 +654,66 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
     }
 }
 
+////////////////////////////////////////////// Unpack //////////////////////////////////////////////
+
+/// Unpack `T` from `buf`, converting its native unpack error into [SError].
+pub fn unpack_as<'a, T>(buf: &'a [u8]) -> Result<(T, &'a [u8]), SError>
+where
+    T: Unpackable<'a>,
+    <T as Unpackable<'a>>::Error: Into<SError>,
+{
+    T::unpack(buf).map_err(Into::into)
+}
+
+/// Unpack `T` from an [Unpacker], converting its native unpack error into [SError].
+pub fn unpack_from<'a, T>(up: &mut Unpacker<'a>) -> Result<T, SError>
+where
+    T: Unpackable<'a>,
+    <T as Unpackable<'a>>::Error: Into<SError>,
+{
+    let before = up.remain();
+    let (t, after) = T::unpack(before).map_err(Into::into)?;
+    up.advance(before.len() - after.len());
+    Ok(t)
+}
+
 ////////////////////////////////////////////// Message /////////////////////////////////////////////
 
 /// A protocol buffers messsage.
 pub trait Message<'a>:
     Default
     + buffertk::Packable
-    + buffertk::Unpackable<'a, Error = Error>
+    + buffertk::Unpackable<'a, Error: Into<SError> + From<buffertk::SError>>
     + FieldPackHelper<'a, field_types::message<Self>>
     + FieldUnpackHelper<'a, field_types::message<Self>>
     + 'a
-where
-    <Self as Unpackable<'a>>::Error: Into<Error>,
-    Error: From<Self::Error>,
 {
 }
+
+impl FieldPackHelper<'_, field_types::message<SError>> for SError {
+    fn field_pack_sz(&self, tag: &Tag) -> usize {
+        stack_pack(tag)
+            .pack(stack_pack(self).length_prefixed())
+            .pack_sz()
+    }
+
+    fn field_pack(&self, tag: &Tag, out: &mut [u8]) {
+        stack_pack(tag)
+            .pack(stack_pack(self).length_prefixed())
+            .into_slice(out);
+    }
+}
+
+impl FieldUnpackHelper<'_, field_types::message<SError>> for SError {
+    fn merge_field(&mut self, proto: field_types::message<SError>) {
+        *self = proto.unwrap_message();
+    }
+}
+
+impl From<field_types::message<SError>> for SError {
+    fn from(proto: field_types::message<SError>) -> Self {
+        proto.unwrap_message()
+    }
+}
+
+impl Message<'_> for SError {}

--- a/prototk/src/lib.rs
+++ b/prototk/src/lib.rs
@@ -609,7 +609,7 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
                 let x: v64 = match self.up.unpack() {
                     Ok(x) => x,
                     Err(e) => {
-                        *self.err = Some(e.into());
+                        *self.err = Some(e);
                         return None;
                     }
                 };
@@ -629,7 +629,7 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
                 let x: v64 = match self.up.unpack() {
                     Ok(x) => x,
                     Err(e) => {
-                        *self.err = Some(e.into());
+                        *self.err = Some(e);
                         return None;
                     }
                 };

--- a/prototk/tests/error.rs
+++ b/prototk/tests/error.rs
@@ -4,134 +4,97 @@ extern crate prototk_derive;
 
 use buffertk::stack_pack;
 
-use prototk::Error;
+use prototk::SError;
 
 #[derive(Clone, Debug, Default, Eq, Message, PartialEq)]
 struct WrappedError {
     #[prototk(1, message)]
-    err: Error,
+    err: SError,
 }
 
-fn test_helper(err: Error, s: &str, exp: &[u8]) {
-    assert_eq!(s, format!("{err:?}"));
+fn test_helper(err: SError, code: &str) {
+    assert_eq!(Some(code), prototk::error_code(&err));
     let we = WrappedError { err };
 
-    // test packing
     let buf: Vec<u8> = stack_pack(&we).to_vec();
-    let got: &[u8] = &buf;
-    assert_eq!(exp, got, "buffer did not match expectations");
-
-    // test unpacking
-    let mut up = buffertk::Unpacker::new(exp);
+    let mut up = buffertk::Unpacker::new(&buf);
     let got: WrappedError = up.unpack().unwrap();
     assert_eq!(we, got, "unpacker failed");
-
-    // test remainder
-    let exp: &[u8] = &[];
-    let rem: &[u8] = up.remain();
-    assert_eq!(exp, rem, "unpack should not have remaining buffer");
+    assert!(up.is_empty(), "unpack should not have remaining buffer");
 }
 
 #[test]
 fn success() {
-    test_helper(Error::Success, "Success", &[10u8, 5, 130, 128, 128, 1, 0]);
+    test_helper(prototk::success(), prototk::CODE_SUCCESS);
 }
 
 #[test]
 fn buffer_too_short() {
     test_helper(
-        Error::BufferTooShort {
-            required: 42,
-            had: 24,
-        },
-        "BufferTooShort { required: 42, had: 24 }",
-        &[10u8, 9, 138, 128, 128, 1, 4, 8, 42, 16, 24],
+        prototk::buffer_too_short(42, 24),
+        prototk::CODE_BUFFER_TOO_SHORT,
     );
 }
 
 #[test]
 fn invalid_field_number() {
     test_helper(
-        Error::InvalidFieldNumber {
-            field_number: 13,
-            what: "13".to_string(),
-        },
-        "InvalidFieldNumber { field_number: 13, what: \"13\" }",
-        &[10u8, 11, 146, 128, 128, 1, 6, 8, 13, 18, 2, 49, 51],
+        prototk::invalid_field_number(13, "13"),
+        prototk::CODE_INVALID_FIELD_NUMBER,
     );
 }
 
 #[test]
 fn unhandled_wire_type() {
     test_helper(
-        Error::UnhandledWireType { wire_type: 42 },
-        "UnhandledWireType { wire_type: 42 }",
-        &[10u8, 7, 154, 128, 128, 1, 2, 8, 42],
+        prototk::unhandled_wire_type(42),
+        prototk::CODE_UNHANDLED_WIRE_TYPE,
     );
 }
 
 #[test]
 fn tag_too_large() {
     test_helper(
-        Error::TagTooLarge { tag: 8589934592u64 },
-        "TagTooLarge { tag: 8589934592 }",
-        &[10u8, 11, 162, 128, 128, 1, 6, 8, 128, 128, 128, 128, 32],
+        prototk::tag_too_large(8589934592u64),
+        prototk::CODE_TAG_TOO_LARGE,
     );
 }
 
 #[test]
 fn varint_overflow() {
-    test_helper(
-        Error::VarintOverflow { bytes: 11 },
-        "VarintOverflow { bytes: 11 }",
-        &[10u8, 7, 170, 128, 128, 1, 2, 8, 11],
-    )
+    test_helper(prototk::varint_overflow(11), prototk::CODE_VARINT_OVERFLOW);
 }
 
 #[test]
 fn unsigned_overflow() {
     test_helper(
-        Error::UnsignedOverflow { value: 1u64 << 32 },
-        "UnsignedOverflow { value: 4294967296 }",
-        &[10u8, 11, 178, 128, 128, 1, 6, 8, 128, 128, 128, 128, 16],
-    )
+        prototk::unsigned_overflow(1u64 << 32),
+        prototk::CODE_UNSIGNED_OVERFLOW,
+    );
 }
 
 #[test]
 fn signed_overflow() {
     test_helper(
-        Error::SignedOverflow { value: 1i64 << 32 },
-        "SignedOverflow { value: 4294967296 }",
-        &[10u8, 11, 186, 128, 128, 1, 6, 8, 128, 128, 128, 128, 16],
-    )
+        prototk::signed_overflow(1i64 << 32),
+        prototk::CODE_SIGNED_OVERFLOW,
+    );
 }
 
 #[test]
 fn wrong_length() {
-    test_helper(
-        Error::WrongLength {
-            required: 32,
-            had: 16,
-        },
-        "WrongLength { required: 32, had: 16 }",
-        &[10u8, 9, 194, 128, 128, 1, 4, 8, 32, 16, 16],
-    )
+    test_helper(prototk::wrong_length(32, 16), prototk::CODE_WRONG_LENGTH);
 }
 
 #[test]
 fn string_encoding() {
-    test_helper(
-        Error::StringEncoding {},
-        "StringEncoding",
-        &[10u8, 5, 202, 128, 128, 1, 0],
-    )
+    test_helper(prototk::string_encoding(), prototk::CODE_STRING_ENCODING);
 }
 
 #[test]
 fn unknown_discriminant() {
     test_helper(
-        Error::UnknownDiscriminant { discriminant: 42 },
-        "UnknownDiscriminant { discriminant: 42 }",
-        &[10u8, 7, 210, 128, 128, 1, 2, 8, 42],
-    )
+        prototk::unknown_discriminant(42),
+        prototk::CODE_UNKNOWN_DISCRIMINANT,
+    );
 }

--- a/prototk/tests/result.rs
+++ b/prototk/tests/result.rs
@@ -4,7 +4,7 @@ extern crate prototk_derive;
 
 use buffertk::stack_pack;
 
-use prototk::Error;
+use prototk::SError;
 
 #[derive(Clone, Debug, Default, Eq, Message, PartialEq)]
 struct Foo {
@@ -18,19 +18,19 @@ struct Foo {
 #[allow(dead_code)]
 struct Bar {
     #[prototk(1, message)]
-    res: Result<Foo, Error>,
+    res: Result<Foo, SError>,
 }
 
 impl Default for Bar {
     fn default() -> Self {
         Self {
-            res: Err(Error::default()),
+            res: Err(prototk::success()),
         }
     }
 }
 
 // TODO(rescrv): de-dupe this
-fn test_helper(res: Result<Foo, Error>, exp: &[u8]) {
+fn test_helper(res: Result<Foo, SError>, exp: &[u8]) {
     // test packing
     let buf: Vec<u8> = stack_pack(&res).to_vec();
     let got: &[u8] = &buf;
@@ -38,7 +38,7 @@ fn test_helper(res: Result<Foo, Error>, exp: &[u8]) {
 
     // test unpacking
     let mut up = buffertk::Unpacker::new(exp);
-    let got: Result<Foo, Error> = up.unpack().unwrap();
+    let got: Result<Foo, SError> = up.unpack().unwrap();
     assert_eq!(res, got, "unpacker failed");
 
     // test remainder
@@ -55,7 +55,14 @@ fn result_ok() {
 #[test]
 fn result_err() {
     test_helper(
-        Err(Error::UnknownDiscriminant { discriminant: 33 }),
-        &[18, 7, 210, 128, 128, 1, 2, 8, 33],
+        Err(prototk::unknown_discriminant(33)),
+        &[
+            18, 103, 102, 40, 101, 114, 114, 111, 114, 32, 40, 112, 104, 97, 115, 101, 32, 112,
+            114, 111, 116, 111, 116, 107, 41, 32, 40, 99, 111, 100, 101, 32, 117, 110, 107, 110,
+            111, 119, 110, 45, 100, 105, 115, 99, 114, 105, 109, 105, 110, 97, 110, 116, 41, 32,
+            40, 109, 101, 115, 115, 97, 103, 101, 32, 34, 117, 110, 107, 110, 111, 119, 110, 32,
+            100, 105, 115, 99, 114, 105, 109, 105, 110, 97, 110, 116, 34, 41, 32, 40, 100, 105,
+            115, 99, 114, 105, 109, 105, 110, 97, 110, 116, 32, 51, 51, 41, 41,
+        ],
     );
 }

--- a/prototk_derive/src/lib.rs
+++ b/prototk_derive/src/lib.rs
@@ -96,9 +96,9 @@ pub fn derive_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
         }
 
         impl #exp_impl_generics buffertk::Unpackable<#lifetime> for #ty_name #ty_generics #where_clause {
-            type Error = ::prototk::Error;
+            type Error = ::prototk::SError;
 
-            fn unpack<'b>(buf: &'b [u8]) -> std::result::Result<(Self, &'b [u8]), ::prototk::Error>
+            fn unpack<'b>(buf: &'b [u8]) -> std::result::Result<(Self, &'b [u8]), ::prototk::SError>
                 where
                     'b: #lifetime,
             {
@@ -682,7 +682,8 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     ) -> TokenStream {
         quote_spanned! { field.span() =>
             (#field_number, ::prototk::field_types::#field_type::WIRE_TYPE) => {
-                let (prototk_tmp, _): (::prototk::field_types::#field_type, _) = Unpackable::unpack(field_value)?;
+                let (prototk_tmp, _): (::prototk::field_types::#field_type, _) =
+                    ::prototk::unpack_as(field_value)?;
                 ret.#field_ident.merge_field(prototk_tmp);
             },
         }
@@ -691,7 +692,7 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     fn struct_snippet(&mut self, _ty_name: &syn::Ident, fields: &[TokenStream]) -> TokenStream {
         quote! {
             let mut ret = Self::default();
-            let mut error: Option<::prototk::Error> = None;
+            let mut error: Option<::prototk::SError> = None;
             let fields = ::prototk::FieldIterator::new(buf, &mut error);
             for (tag, field_value) in fields {
                 let num: u32 = tag.field_number.into();
@@ -743,7 +744,8 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
             field_decls.push(decl);
             let block = quote! {
                 (#enum_number, ::prototk::field_types::#enum_type::WIRE_TYPE) => {
-                    let enum_value: ::prototk::field_types::#enum_type = Unpackable::unpack(buf)?.0;
+                    let enum_value: ::prototk::field_types::#enum_type =
+                        ::prototk::unpack_as(buf)?.0;
                     #field_name.merge_field(enum_value);
                 },
             };
@@ -755,8 +757,8 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
         }
         quote! {
             (#field_number, ::prototk::WireType::LengthDelimited) => {
-                let length: v64 = up.unpack()?;
-                let mut error: Option<::prototk::Error> = None;
+                let length: v64 = ::prototk::unpack_from(&mut up)?;
+                let mut error: Option<::prototk::SError> = None;
                 let local_buf: &'b [u8] = &up.remain()[0..length.into()];
                 up.advance(length.into());
                 let fields = ::prototk::FieldIterator::new(local_buf, &mut error);
@@ -766,7 +768,7 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
                     match (num, tag.wire_type) {
                         #(#field_blocks)*
                         (_, _) => {
-                            return Err(::prototk::Error::UnknownDiscriminant { discriminant: num }.into());
+                            return Err(::prototk::unknown_discriminant(num).into());
                         },
                     }
                 }
@@ -787,7 +789,8 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     ) -> TokenStream {
         quote_spanned! { variant.span() =>
             (#field_number, ::prototk::field_types::#field_type::WIRE_TYPE) => {
-                let tmp: ::prototk::field_types::#field_type = up.unpack()?;
+                let tmp: ::prototk::field_types::#field_type =
+                    ::prototk::unpack_from(&mut up)?;
                 #[allow(clippy::useless_conversion)]
                 Ok((#ctor(tmp.into_native().into()), up.remain()))
             },
@@ -802,7 +805,7 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     ) -> TokenStream {
         quote_spanned! { variant.span() =>
             (#field_number, ::prototk::WireType::LengthDelimited) => {
-                let x: v64 = up.unpack()?;
+                let x: v64 = ::prototk::unpack_from(&mut up)?;
                 up.advance(x.into());
                 Ok((#ctor, up.remain()))
             },
@@ -812,13 +815,13 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     fn enum_snippet(&mut self, _ty_name: &syn::Ident, variants: &[TokenStream]) -> TokenStream {
         quote! {
             let mut up = ::buffertk::Unpacker::new(buf);
-            let tag: ::prototk::Tag = up.unpack()?;
+            let tag: ::prototk::Tag = ::prototk::unpack_from(&mut up)?;
             let num: u32 = tag.field_number.into();
             let wire_type: ::prototk::WireType = tag.wire_type;
             match (num, wire_type) {
                 #(#variants)*
                 _ => {
-                    return Err(::prototk::Error::UnknownDiscriminant { discriminant: num }.into());
+                    return Err(::prototk::unknown_discriminant(num).into());
                 },
             }
         }

--- a/rpc_pb/examples/common.rs
+++ b/rpc_pb/examples/common.rs
@@ -10,7 +10,7 @@ pub enum Error {
     #[prototk(2, message)]
     Serialization {
         #[prototk(1, message)]
-        err: prototk::Error,
+        err: prototk::SError,
         #[prototk(2, string)]
         context: String,
     },
@@ -23,29 +23,11 @@ pub enum Error {
     },
 }
 
-impl From<buffertk::Error> for Error {
-    fn from(err: buffertk::Error) -> Error {
-        Error::Serialization {
-            err: err.into(),
-            context: "buffertk unpack error".to_string(),
-        }
-    }
-}
-
-impl From<prototk::Error> for Error {
-    fn from(err: prototk::Error) -> Error {
-        Error::Serialization {
-            err,
-            context: "prototk unpack error".to_string(),
-        }
-    }
-}
-
 impl From<rpc_pb::SError> for Error {
     fn from(err: rpc_pb::SError) -> Error {
         Error::Transport {
             err,
-            context: "prototk unpack error".to_string(),
+            context: "rpc error".to_string(),
         }
     }
 }

--- a/rpc_pb/src/lib.rs
+++ b/rpc_pb/src/lib.rs
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     fn serialization_error_round_trips() {
-        do_test(serialization_error(prototk::Error::Success, "Some context"));
+        do_test(serialization_error(prototk::success(), "Some context"));
     }
 
     #[test]

--- a/sst/src/block.rs
+++ b/sst/src/block.rs
@@ -93,7 +93,7 @@ impl Block {
         let mut up = Unpacker::new(&bytes[bytes.len() - 4..]);
         let num_restarts: u32 = up
             .unpack()
-            .map_err(|e: buffertk::Error| unpack_block_restarts(e.into()))?;
+            .map_err(|e: buffertk::SError| unpack_block_restarts(e.into()))?;
         let num_restarts: usize = num_restarts as usize;
         // Footer size.
         // |tag 10|v64 of num bytes|packed num_restarts u32s|tag 11|fixed32 capstone|

--- a/sst/src/block.rs
+++ b/sst/src/block.rs
@@ -93,7 +93,7 @@ impl Block {
         let mut up = Unpacker::new(&bytes[bytes.len() - 4..]);
         let num_restarts: u32 = up
             .unpack()
-            .map_err(|e: buffertk::SError| unpack_block_restarts(e.into()))?;
+            .map_err(|e: buffertk::SError| unpack_block_restarts(e))?;
         let num_restarts: usize = num_restarts as usize;
         // Footer size.
         // |tag 10|v64 of num bytes|packed num_restarts u32s|tag 11|fixed32 capstone|

--- a/sst/src/lib.rs
+++ b/sst/src/lib.rs
@@ -594,43 +594,43 @@ fn corruption_fsync_failed() -> SError {
     error(CODE_CORRUPTION_FSYNC_FAILED)
 }
 
-fn unpack_final_block_offset(error: prototk::Error) -> SError {
+fn unpack_final_block_offset(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_FINAL_BLOCK_OFFSET, error.to_string())
 }
 
-fn unpack_final_block(error: prototk::Error) -> SError {
+fn unpack_final_block(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_FINAL_BLOCK, error.to_string())
 }
 
-fn unpack_table_entry(error: prototk::Error) -> SError {
+fn unpack_table_entry(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_TABLE_ENTRY, error.to_string())
 }
 
-fn unpack_block_metadata(error: prototk::Error) -> SError {
+fn unpack_block_metadata(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_BLOCK_METADATA, error.to_string())
 }
 
-fn unpack_key_value_pair(error: prototk::Error, offset: usize) -> SError {
+fn unpack_key_value_pair(error: prototk::SError, offset: usize) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_KEY_VALUE_PAIR, error.to_string())
         .with_atom_field(FIELD_OFFSET, offset)
 }
 
-fn unpack_block_restarts(error: prototk::Error) -> SError {
+fn unpack_block_restarts(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_BLOCK_RESTARTS, error.to_string())
 }
 
-fn unpack_key_value_entry_prototk(error: prototk::Error) -> SError {
+fn unpack_key_value_entry_prototk(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_KEY_VALUE_ENTRY, error.to_string())
 }
 
-fn unpack_log_header(error: prototk::Error) -> SError {
+fn unpack_log_header(error: prototk::SError) -> SError {
     UNPACK_ERROR.click();
     error_with_message(CODE_UNPACK_LOG_HEADER, error.to_string())
 }
@@ -1418,7 +1418,7 @@ impl<W: Clone + Seek + Write + FileExt> Sst<W> {
         let mut up = Unpacker::new(&buf);
         let final_block_offset: u64 = up
             .unpack()
-            .map_err(|e: buffertk::Error| unpack_final_block_offset(e.into()))?;
+            .map_err(|e: buffertk::SError| unpack_final_block_offset(e.into()))?;
         // Read and parse the final block
         if file_size < final_block_offset {
             CORRUPTION.click();

--- a/sst/src/lib.rs
+++ b/sst/src/lib.rs
@@ -1418,7 +1418,7 @@ impl<W: Clone + Seek + Write + FileExt> Sst<W> {
         let mut up = Unpacker::new(&buf);
         let final_block_offset: u64 = up
             .unpack()
-            .map_err(|e: buffertk::SError| unpack_final_block_offset(e.into()))?;
+            .map_err(|e: buffertk::SError| unpack_final_block_offset(e))?;
         // Read and parse the final block
         if file_size < final_block_offset {
             CORRUPTION.click();


### PR DESCRIPTION
Delete the hand-written Error enums in buffertk and prototk along with
their Packable/Unpackable/Message impls, and route all serialization
errors through handled::SError instead.  Errors are now built with small
constructor functions (buffer_too_short, varint_overflow, tag_too_large,
and friends) that attach a machine-readable code and structured fields,
and SError is serialized as its S-expression string form.

Key changes:

- buffertk: own the SError Packable/Unpackable impl and re-export
  handled::{SError, SExpr}; drop the local Error enum.
- prototk: re-export handled::SError, expose error_code plus typed
  constructors, and add unpack_as/unpack_from helpers that convert
  native unpack errors into SError.
- prototk_derive: emit unpack_as/unpack_from and unknown_discriminant
  in place of the removed prototk::Error variants.
- handled: drop the buffertk/prototk/biometrics dependencies and the
  prototk-specific From and Message impls, breaking the dependency cycle.
- Update busyrpc, macarunes, one_two_eight, rpc_pb, sst, and analogize
  callers to the new constructors and SError type.

Tests now assert on error codes and round-trip behavior rather than on
the previous Debug strings and exact byte encodings.

Co-authored-by: AI
