### PR TITLE
fix(prototk): reject truncated length-delimited payloads

### DIFF
--- a/buffertk/src/lib.rs
+++ b/buffertk/src/lib.rs
@@ -305,6 +305,17 @@ impl<'a> Unpacker<'a> {
         self.buf
     }
 
+    /// Return the next `by` bytes and advance the buffer.
+    pub fn take(&mut self, by: usize) -> Result<&'a [u8], SError> {
+        if by > self.buf.len() {
+            Err(buffer_too_short(by, self.buf.len()))
+        } else {
+            let (head, tail) = self.buf.split_at(by);
+            self.buf = tail;
+            Ok(head)
+        }
+    }
+
     /// Advance the buffer by `by`.  Saturating.
     pub fn advance(&mut self, by: usize) {
         if by > self.buf.len() {
@@ -690,15 +701,13 @@ where
         match tag {
             10 => {
                 let x: v64 = up.unpack()?;
-                let buf: &[u8] = &up.remain()[..x.into()];
-                up.advance(x.into());
+                let buf: &[u8] = up.take(x.into())?;
                 let (t, _): (T, _) = <T as Unpackable>::unpack(buf)?;
                 Ok((Ok(t), up.remain()))
             }
             18 => {
                 let x: v64 = up.unpack()?;
-                let buf: &[u8] = &up.remain()[..x.into()];
-                up.advance(x.into());
+                let buf: &[u8] = up.take(x.into())?;
                 let (e, _): (E, _) = <E as Unpackable>::unpack(buf)?;
                 Ok((Err(e), up.remain()))
             }
@@ -712,6 +721,27 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum TestResultError {
+        Buffertk(SError),
+        Value(u8),
+    }
+
+    impl From<SError> for TestResultError {
+        fn from(error: SError) -> Self {
+            Self::Buffertk(error)
+        }
+    }
+
+    impl<'a> Unpackable<'a> for TestResultError {
+        type Error = SError;
+
+        fn unpack<'b: 'a>(buf: &'b [u8]) -> Result<(Self, &'b [u8]), SError> {
+            let (value, buf) = u8::unpack(buf)?;
+            Ok((Self::Value(value), buf))
+        }
+    }
 
     #[test]
     fn pack_void() {
@@ -913,5 +943,21 @@ mod tests {
         let mut up = Unpacker::new(exp);
         let got: &[u8] = up.unpack().expect("unpack slice");
         assert_eq!(buf, got);
+    }
+
+    #[test]
+    fn result_rejects_short_ok_payload() {
+        let got =
+            <Result<u8, TestResultError> as Unpackable>::unpack(&[10, 1]).map(|(result, _)| result);
+
+        assert_eq!(Err(TestResultError::Buffertk(buffer_too_short(1, 0))), got);
+    }
+
+    #[test]
+    fn result_rejects_short_err_payload() {
+        let got =
+            <Result<u8, TestResultError> as Unpackable>::unpack(&[18, 1]).map(|(result, _)| result);
+
+        assert_eq!(Err(TestResultError::Buffertk(buffer_too_short(1, 0))), got);
     }
 }

--- a/macarunes/src/lib.rs
+++ b/macarunes/src/lib.rs
@@ -2568,11 +2568,23 @@ signature: [redacted]
     #[test]
     fn macaroon_from_bytes_rejects_trailing_bytes() {
         let mut bytes = root_macaroon().to_bytes();
-        bytes.push(0);
+        bytes.extend_from_slice(&[40, 0]);
 
         assert_eq!(
             Err(Error::InvalidEncoding {
-                what: "1 trailing bytes".to_owned(),
+                what: "2 trailing bytes".to_owned(),
+            }),
+            Macaroon::from_bytes(&bytes)
+        );
+    }
+
+    #[test]
+    fn macaroon_from_bytes_rejects_short_caveat_payload() {
+        let bytes = [34, 2, 26, 1];
+
+        assert_eq!(
+            Err(Error::InvalidEncoding {
+                what: "(error (phase prototk) (code buffer-too-short) (message \"buffer too short\") (required 1) (had 0))".to_owned(),
             }),
             Macaroon::from_bytes(&bytes)
         );
@@ -2610,11 +2622,11 @@ signature: [redacted]
     #[test]
     fn prepared_request_from_bytes_rejects_trailing_bytes() {
         let mut bytes = PreparedRequest::new(root_macaroon(), Vec::new()).to_bytes();
-        bytes.push(0);
+        bytes.extend_from_slice(&[24, 0]);
 
         assert_eq!(
             Err(Error::InvalidEncoding {
-                what: "1 trailing bytes".to_owned(),
+                what: "2 trailing bytes".to_owned(),
             }),
             PreparedRequest::from_bytes(&bytes)
         );

--- a/prototk/src/lib.rs
+++ b/prototk/src/lib.rs
@@ -148,6 +148,16 @@ pub fn error_code(err: &SError) -> Option<&str> {
     }
 }
 
+/// Take a length-delimited payload from an unpacker.
+pub fn take_length_prefixed<'a>(up: &mut Unpacker<'a>) -> Result<&'a [u8], SError> {
+    let length: v64 = up.unpack()?;
+    let length: usize = length.into();
+    if up.remain().len() < length {
+        return Err(buffer_too_short(length, up.remain().len()));
+    }
+    up.take(length)
+}
+
 ///////////////////////////////////////////// WireType /////////////////////////////////////////////
 
 /// WireType represents the different protocol buffers wire types.
@@ -634,8 +644,8 @@ impl<'a> Iterator for FieldIterator<'a, '_> {
                     }
                 };
                 let sz: usize = x.into();
-                if buf.len() < x.pack_sz() + sz {
-                    *self.err = Some(buffer_too_short(sz, buf.len()));
+                if self.up.remain().len() < sz {
+                    *self.err = Some(buffer_too_short(sz, self.up.remain().len()));
                     return None;
                 }
                 self.up.advance(sz);

--- a/prototk/tests/enum.rs
+++ b/prototk/tests/enum.rs
@@ -65,6 +65,30 @@ fn three_kinds_of_enum() {
     assert_eq!(exp, rem, "unpack should not have remaining buffer");
 }
 
+#[test]
+fn enum_named_variant_rejects_short_payload() {
+    let mut up = buffertk::Unpacker::new(&[18, 1]);
+    let got: Result<Error, prototk::SError> = up.unpack();
+
+    assert_eq!(Err(prototk::buffer_too_short(1, 0)), got);
+}
+
+#[test]
+fn enum_named_variant_rejects_truncated_field_inside_payload() {
+    let mut up = buffertk::Unpacker::new(&[18, 3, 10, 3, 1]);
+    let got: Result<Error, prototk::SError> = up.unpack();
+
+    assert_eq!(Err(prototk::buffer_too_short(3, 1)), got);
+}
+
+#[test]
+fn enum_unit_variant_rejects_short_payload() {
+    let mut up = buffertk::Unpacker::new(&[10, 1]);
+    let got: Result<Error, prototk::SError> = up.unpack();
+
+    assert_eq!(Err(prototk::buffer_too_short(1, 0)), got);
+}
+
 ////////////////////////////////////////// EnumWithOption //////////////////////////////////////////
 
 #[derive(Debug, Default, Eq, Message, PartialEq)]

--- a/prototk/tests/message.rs
+++ b/prototk/tests/message.rs
@@ -64,6 +64,14 @@ fn named_struct() {
     assert_eq!(exp, rem, "unpack should not have remaining buffer");
 }
 
+#[test]
+fn named_struct_rejects_truncated_field() {
+    let mut up = buffertk::Unpacker::new(&[10, 3, 1]);
+    let got: Result<NamedStruct, prototk::SError> = up.unpack();
+
+    assert_eq!(Err(prototk::buffer_too_short(3, 1)), got);
+}
+
 /////////////////////////////////////////// UnnamedStruct //////////////////////////////////////////
 
 #[derive(Clone, Debug, Default, Message, PartialEq)]

--- a/prototk_derive/src/lib.rs
+++ b/prototk_derive/src/lib.rs
@@ -701,6 +701,9 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
                     (_, _) => {},
                 }
             }
+            if let Some(error) = error {
+                return Err(error);
+            }
             Ok((ret, &[]))
         }
     }
@@ -757,10 +760,8 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
         }
         quote! {
             (#field_number, ::prototk::WireType::LengthDelimited) => {
-                let length: v64 = ::prototk::unpack_from(&mut up)?;
                 let mut error: Option<::prototk::SError> = None;
-                let local_buf: &'b [u8] = &up.remain()[0..length.into()];
-                up.advance(length.into());
+                let local_buf: &'b [u8] = ::prototk::take_length_prefixed(&mut up)?;
                 let fields = ::prototk::FieldIterator::new(local_buf, &mut error);
                 #(#field_decls;)*
                 for (tag, buf) in fields {
@@ -771,6 +772,9 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
                             return Err(::prototk::unknown_discriminant(num).into());
                         },
                     }
+                }
+                if let Some(error) = error {
+                    return Err(error);
                 }
                 let ret = #ctor {
                     #(#hydration)*
@@ -805,8 +809,7 @@ impl ProtoTKVisitor for UnpackMessageVisitor {
     ) -> TokenStream {
         quote_spanned! { variant.span() =>
             (#field_number, ::prototk::WireType::LengthDelimited) => {
-                let x: v64 = ::prototk::unpack_from(&mut up)?;
-                up.advance(x.into());
+                let _ = ::prototk::take_length_prefixed(&mut up)?;
                 Ok((#ctor, up.remain()))
             },
         }


### PR DESCRIPTION
Unpacking length-delimited fields previously sliced the remaining
buffer with `&buf[..len]` and advanced past it, panicking on
out-of-bounds when the declared length exceeded the available
bytes.  The FieldIterator carried a TODO noting it had panicked
once and gone undebugged.

Add `Unpacker::take`, which returns the next `by` bytes or a
`BufferTooShort` error, and route the generated and hand-written
unpackers through a new `prototk::take_length_prefixed` helper so
malformed input surfaces as an error instead of a panic.  Also
propagate errors accumulated by the inner FieldIterator rather
than silently constructing a default value.

Update macarunes trailing-byte tests for the new well-formed
framing and add coverage in buffertk, prototk, and prototk_derive
for short and truncated payloads.

Co-authored-by: AI
