### PR TITLE
feat(caternary): M1 head-directed unifier + track M0 type substrate

### DIFF
--- a/caternary/docs/typing.md
+++ b/caternary/docs/typing.md
@@ -1,12 +1,12 @@
 # Caternary Type System — Implementation Spec (rev 4)
 
-**Audience:** the implementing agent (Sid worker). You are working in the Caternary codebase on the latest `blue`. This document is the contract for what to build and how the judge will verify it. Read the whole thing before writing code. Where this spec names a builtin or an internal symbol you cannot find, **locate the real one in the codebase and reconcile** — do not invent.
+**Audience:** the implementing agent (Sid worker). You are working in the Caternary codebase on the latest `blue`. This document is the contract for what to build and how the judge will verify it. Read the whole thing before writing code. Builtin names in this document use the runtime **UPPER_SNAKE_CASE** spelling. Where this spec names a builtin or an internal symbol you cannot find, **locate the real one in the codebase and reconcile** — do not invent.
 
 > **Ratified decisions (rev 4).** Argued and settled; do not relitigate without a recorded reason.
 > (a) **One numeric type `Num`** — no Int/Float split, no overloading; specialization, if ever, is post-inference monomorphization.
 > (b) **Flat substitution + trailed undo log** (Tier-0 inference backtracking only) for O(1)/zero-alloc — *not* a persistent HAMT, *not* union-find; **typing frames are the durable provenance spine** for anything the trail unwinds.
-> (c) **`if` is a combinator** with a hand-written scheme.
-> (d) The **shadow stack is an abstract evaluator** mirroring runtime data flow exactly (`dup` aliases the same term; combinators execute their real shuffle; **arity comes from the Tier 0 arrow**); core-shuffle conformance is property-tested because a mis-shuffle yields a *vacuous proof*, not a crash.
+> (c) **`IF` is a combinator** with a hand-written scheme.
+> (d) The **shadow stack is an abstract evaluator** mirroring runtime data flow exactly (`DUP` aliases the same term; combinators execute their real shuffle; **arity comes from the Tier 0 arrow**); core-shuffle conformance is property-tested because a mis-shuffle yields a *vacuous proof*, not a crash.
 > (e) **Higher-order refinement subsumption is SMT-discharged only, never inferred**, and **fails closed**.
 > (f) **Whole-program, no modules** — one compilation unit, one global ledger, no serialized contracts, no version skew.
 > (g) **Embeddable; operators are contracted at registration** by two registrants (language core + embedder); the **user registers nothing**. Registration is **explicit attestation**; the operator table is the **modulo** of every proof. Operator contracts (axioms) and user `assume` are **separate buckets** — the strict anti-rot check applies to `assume` only, which is now **near-vestigial**.
@@ -36,7 +36,7 @@ Caternary is **embedded** into a Rust host. Two populations, separated by a capa
 
 So there is **one trusted-contract mechanism — operator registration carries a type — with two registrants, and the user is neither:**
 
-1. **The language core** registers the irreducible primitives (`call`, `dip`, `if` — the words with no Caternary body, because "apply a quotation" *is* the runtime operation that makes quotations mean anything). Each carries its **Tier 0 scheme** (§2) *and* its **Tier 1 refinement axiom** (§8 / §10.6).
+1. **The language core** registers the irreducible primitives (`CALL`, `DIP`, `IF` — the words with no Caternary body, because "apply a quotation" *is* the runtime operation that makes quotations mean anything). Each carries its **Tier 0 scheme** (§2) *and* its **Tier 1 refinement axiom** (§8 / §10.6).
 2. **The embedder** registers host operators (syscalls, DB calls, whatever the host exposes), each with a type, at embed time.
 
 The user's only unproven-fact mechanism is `assume` (§10.7). **Because every foreign thing arrives pre-contracted by the party who wrote it, the user inherits operator contracts automatically and the `assume` surface shrinks to near-zero** — `assume` survives only as a vestige for the rare local assertion about a *Caternary* construct the solver cannot reach.
@@ -90,18 +90,18 @@ This is Hindley–Milner where the function arrow is the stack arrow, extended w
 Signatures (convention: `'R 'S 'T` are row variables, lowercase `a b` are element type variables, top on the right):
 
 ```
-dup   : ( 'S a        -- 'S a a )
-drop  : ( 'S a        -- 'S )
-swap  : ( 'S a b       -- 'S b a )
-call  : ( 'S ('S -- 'T) -- 'T )
-dip   : ( 'S a ('S -- 'T) -- 'T a )
-if    : ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
+DUP   : ( 'S a        -- 'S a a )
+DROP  : ( 'S a        -- 'S )
+SWAP  : ( 'S a b       -- 'S b a )
+CALL  : ( 'S ('S -- 'T) -- 'T )
+DIP   : ( 'S a ('S -- 'T) -- 'T a )
+IF    : ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
 +     : ( 'S Num Num    -- 'S Num )
 literal n  : ( 'S -- 'S Num )                       -- numeric literal (one numeric type)
 literal [q]: ( 'S -- 'S (P -- Q) )  where q : (P -- Q)  -- quotation value
 ```
 
-The row variable is what makes combinators expressible. You **cannot** state `dip` or `if` without quantifying over "the rest of the stack." `call`/`dip`/`if` are **registered by the language core** (architecture section) — they have no Caternary body; the schemes above are their authored Tier 0 contracts.
+The row variable is what makes combinators expressible. You **cannot** state `DIP` or `IF` without quantifying over "the rest of the stack." `CALL`/`DIP`/`IF` are **registered by the language core** (architecture section) — they have no Caternary body; the schemes above are their authored Tier 0 contracts.
 
 ---
 
@@ -178,7 +178,7 @@ occurs_stack(v, s):
     (s.row is v) or any occurs(v, e) for e in s.elems
 ```
 
-Implement unification and `occurs` with an explicit **depth bound or worklist** so a malicious/accidental cyclic program (e.g. `[ dup call ] dup call`, which forces `a ~ ( 'X a -- 'Y )`) is **rejected with a cyclic-type error, not a compiler stack overflow.** That robustness is part of correctness here.
+Implement unification and `occurs` with an explicit **depth bound or worklist** so a malicious/accidental cyclic program (e.g. `[ DUP CALL ] DUP CALL`, which forces `a ~ ( 'X a -- 'Y )`) is **rejected with a cyclic-type error, not a compiler stack overflow.** That robustness is part of correctness here.
 
 That is the entire unification machinery. No labels, no field reordering, no record solving.
 
@@ -202,7 +202,7 @@ infer_seq(words, env):
 
 - **Numeric literal** `n`: `( 'a -- 'a Num )`. One numeric type (§1).
 - **Quotation literal** `[ q ]`: infer `q` to get `(P -- Q)`; literal’s word type is `( 'a -- 'a Quote(P -- Q) )`. Quotations are syntactic values, so the `Quote(...)` **may be generalized** at a binding site.
-- **`if`** is a **primitive combinator** with the hand-written scheme in §2 — `( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )`. Branch agreement falls out of unifying both branch quotations against the shared `( 'S -- 'T )`. Do **not** special-case `if` beyond supplying its scheme.
+- **`IF`** is a **primitive combinator** with the hand-written scheme in §2 — `( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )`. Branch agreement falls out of unifying both branch quotations against the shared `( 'S -- 'T )`. Do **not** special-case `IF` beyond supplying its scheme.
 
 ### Named locals (`>name`)
 `>name` pops the top and binds it in a **local environment** for the remainder of the scope.
@@ -230,8 +230,8 @@ The global pre-pass already collects all `[ body ] :name` definitions **order-in
 
 Composition means a mistake on line 2 can surface as a unification failure "near" line 40. Untreated, this makes the checker unusable. Three layered requirements, in payoff order, **all backed by the §3 data structures that exist from commit one:**
 
-1. **Provenance pair, not failure site.** On `unify_ty` mismatch you hold two origin spans: where each conflicting type was born. Report both — *"this is `Num` because of `+` at L3; it must be `Bool` because `if` at L7 demands it"* — not merely the enclosing word where unification blew up.
-2. **Quotation boundaries are frames.** Render the typing-frame stack as a breadcrumb: *"in the quotation at L7 ▸ which `if` expects effect `( 'S -- 'S )` ▸ `foo` breaks it by producing `Bool`."* Nesting becomes a backtrace, not one opaque site.
+1. **Provenance pair, not failure site.** On `unify_ty` mismatch you hold two origin spans: where each conflicting type was born. Report both — *"this is `Num` because of `+` at L3; it must be `Bool` because `IF` at L7 demands it"* — not merely the enclosing word where unification blew up.
+2. **Quotation boundaries are frames.** Render the typing-frame stack as a breadcrumb: *"in the quotation at L7 ▸ which `IF` expects effect `( 'S -- 'S )` ▸ `foo` breaks it by producing `Bool`."* Nesting becomes a backtrace, not one opaque site.
 3. **Localize inward.** Anchor at the **innermost** frame where both conflicting types are already concrete — that is almost always the user's actual mistake; the outer row-unification failure is the consequence. Walk inward to the deepest frame still carrying the contradiction.
 
 **Never** leak internal variable names (`'t7`, `'r3`) to the user; debug-only, behind a flag. The judge rejects any user-facing diagnostic that leaks them or omits a span.
@@ -240,8 +240,8 @@ Composition means a mistake on line 2 can surface as a unification failure "near
 
 ## 8. Combinators and the rank boundary
 
-- **Primitive combinators are language-core operator registrations** (architecture section). `dip`, `call`, `if` have no Caternary body — the language core registers them, each carrying its hand-written **Tier 0 scheme** (§2) *and*, at Tier 1, a hand-written **refinement axiom** (§10.6). They live in the operator-contract (axiom) bucket, authored once, invisible to the user — **not** in the `assume` ledger. Combinators written *in* Caternary (`keep`, `bi`, derived shuffles) are **transparent definitions**, inferred and verified through their bodies, with no authored contract.
-- **`dip`/combinator rule — relay, never expand.** A combinator's contract is written using only the **declared** arrow of its quotation argument; never expand the quotation's body into the caller's contract. Categorically, `dip q = q ⊗ id_a`. The only fact `dip` itself contributes is that the set-aside value returns unchanged. (Its Tier 1 refinement axiom in §10.6 is exactly this rule lifted to predicates.)
+- **Primitive combinators are language-core operator registrations** (architecture section). `DIP`, `CALL`, `IF` have no Caternary body — the language core registers them, each carrying its hand-written **Tier 0 scheme** (§2) *and*, at Tier 1, a hand-written **refinement axiom** (§10.6). They live in the operator-contract (axiom) bucket, authored once, invisible to the user — **not** in the `assume` ledger. Combinators written *in* Caternary (`KEEP`, `BI`, derived shuffles) are **transparent definitions**, inferred and verified through their bodies, with no authored contract.
+- **`DIP`/combinator rule — relay, never expand.** A combinator's contract is written using only the **declared** arrow of its quotation argument; never expand the quotation's body into the caller's contract. Categorically, `DIP q = q ⊗ id_a`. The only fact `DIP` itself contributes is that the set-aside value returns unchanged. (Its Tier 1 refinement axiom in §10.6 is exactly this rule lifted to predicates.)
 - **Rank-1 is inferred. Rank-2 requires annotation.** The one non-inferable case: a user-defined word that applies its quotation argument at **two genuinely distinct types** in one definition. Detect this and emit *"this word applies its quotation at more than one type; add a type annotation."* With an annotation, check against it.
 
 ---
@@ -270,18 +270,18 @@ Tier 0 is positional and anonymous; SMT needs names. At a call boundary, zip the
 ### 10.3 Symbolic shadow stack (compile-time only) — a second evaluator
 The shadow stack is an **abstract interpreter over the *same* operational semantics as the runtime**, whose values are **symbolic terms** in the refinement logic instead of runtime values. Every word that moves data at runtime moves terms here with **byte-identical data flow.** This single mandate subsumes three requirements people get wrong:
 
-- **Aliasing under `dup`/shuffles.** `dup` pushes the **exact same term** (same identity), not a second fresh literal; `swap` exchanges terms; `drop` discards one. If `dup` minted two fresh terms, the solver would lose the aliasing fact and trivial proofs like `x x - = 0` would fail to discharge. "`dup` copies the term" is just the `n=1` case of "shadow execution mirrors real execution."
-- **Combinator data flow.** Tier 0 *types* `dip` via its declared signature, but the shadow stack must **execute `dip`'s shuffle at compile time**: pop the set-aside term, run the quotation's shadow effects on the rest, restore the term. The shadow stack must mirror the exact data flow of every core combinator, or the positional binding (§10.2) zips the wrong SMT names to the wrong slots after a non-trivial shuffle.
+- **Aliasing under `DUP`/shuffles.** `DUP` pushes the **exact same term** (same identity), not a second fresh literal; `SWAP` exchanges terms; `DROP` discards one. If `DUP` minted two fresh terms, the solver would lose the aliasing fact and trivial proofs like `x x - = 0` would fail to discharge. "`DUP` copies the term" is just the `n=1` case of "shadow execution mirrors real execution."
+- **Combinator data flow.** Tier 0 *types* `DIP` via its declared signature, but the shadow stack must **execute `DIP`'s shuffle at compile time**: pop the set-aside term, run the quotation's shadow effects on the rest, restore the term. The shadow stack must mirror the exact data flow of every core combinator, or the positional binding (§10.2) zips the wrong SMT names to the wrong slots after a non-trivial shuffle.
 - **Arity comes from the Tier 0 arrow — the shadow evaluator owns NO independent notion of it.** For *every* word it executes, including opaque ones, the shadow evaluator reads that word's **already-inferred, already-generalized Tier 0 type** to know exactly how many terms to pop and push. An opaque `lib : ( Num Num -- Num )` pops two terms and pushes **one** fresh literal — the shape is known (Tier 0 proved it) even though the *meaning* is not. Opacity is only about whether the pushed term carries a predicate, **never** about how many terms move. **Tier 0's shape closure is the structural rail the shadow stack runs on** — which is *why* Tier 1 is gated behind a green Tier 0: the shadow evaluator's soundness is parasitic on Tier 0 having already balanced every arity.
 
 Each slot carries the term describing its value; after `x 0 >` the top slot's term is the proposition `x > 0` (types alone say only `Bool`). When a value's producing term is opaque (returned from an uninterpreted word), its slot carries a **fresh literal**: soundness holds, precision degrades gracefully — but see §10.7 for what happens when that opaque value flows into an obligation.
 
-**Conformance is a soundness requirement, not hygiene.** A mis-shuffled shadow stack does not crash — it emits a *well-formed VC about the wrong variables*, which Z3 discharges or refutes, producing a **green checkmark that proves nothing (vacuous verification)** — the worst failure class in the system. Therefore: **shadow data flow for the core shuffles (`dup swap drop dip` and friends) is property-tested against the interpreter's data flow, not eyeballed.** The `dup`-aliasing test (`x x -` discharges to `0`) and a post-shuffle zip test (§10.2 binds the right names after `dip`) are the guards.
+**Conformance is a soundness requirement, not hygiene.** A mis-shuffled shadow stack does not crash — it emits a *well-formed VC about the wrong variables*, which Z3 discharges or refutes, producing a **green checkmark that proves nothing (vacuous verification)** — the worst failure class in the system. Therefore: **shadow data flow for the core shuffles (`DUP SWAP DROP DIP` and friends) is property-tested against the interpreter's data flow, not eyeballed.** The `DUP`-aliasing test (`x x -` discharges to `0`) and a post-shuffle zip test (§10.2 binds the right names after `DIP`) are the guards.
 
 **The shadow stack does not exist at runtime** — a compile-time analysis artifact discarded before the binary ships, like a dataflow lattice.
 
 ### 10.4 Path conditions
-VC generation under control flow must assert branch facts. For `cond [ then ] [ else ] if`: recover `cond`'s proposition `P` from the shadow stack; verify `[ then ]` with `P` asserted into the solver scope and `[ else ]` with `¬P`. This requires the solver seam to support **scoped** assertions — `push_scope` before a branch, `pop_scope` after (§10.8). The shadow stack (§10.3) and positional binding (§10.2) are the substrate; this is two scoped assertions on top. (These scopes live in the Z3 trait + shadow-evaluator state only — never the Tier 0 substitution; §3 invariant 1.)
+VC generation under control flow must assert branch facts. For `cond [ then ] [ else ] IF`: recover `cond`'s proposition `P` from the shadow stack; verify `[ then ]` with `P` asserted into the solver scope and `[ else ]` with `¬P`. This requires the solver seam to support **scoped** assertions — `push_scope` before a branch, `pop_scope` after (§10.8). The shadow stack (§10.3) and positional binding (§10.2) are the substrate; this is two scoped assertions on top. (These scopes live in the Z3 trait + shadow-evaluator state only — never the Tier 0 substitution; §3 invariant 1.)
 
 ### 10.5 VC = verification condition
 A VC is a pure logical formula whose validity means an obligation holds — no program left, just math. Generate one at **each call site** for each `where` clause. At `x sqrt`, the VC is `(facts known about x) ⟹ (x >= 0)`. **Encoding (the thing people get wrong):** to check validity, assert the hypotheses and the **negation** of the goal, then `check()`. `Unsat` ⇒ no counterexample ⇒ **valid**. `Sat` ⇒ pull the model; it **is** your counterexample, surface it. `Unknown` ⇒ degrade (and fail closed for subsumption, §10.6).
@@ -294,7 +294,7 @@ Refinements are part of the Tier 1 type, attached to `Quote` as a **forwarded pa
 
 This is subtyping on the arrow — the thing banned for *inference* in the value language. Resolution: **subsumption is emitted as these two SMT implications and discharged by Z3, never inferred by the type engine.** The checker only *generates* the implications; the solver settles them. Subtyping-the-inference stays banned (principal typing intact, §1); subtyping-the-obligation lives entirely in the SMT seam. Control plane (inference) stays unification-only and decidable; the directional reasoning is pushed to the data plane (the solver you already pay for).
 
-**Operator refinement axioms.** The primitive combinators (`dip`, `call`, `if`) are language-core registrations (§8) and carry **authored refinement axioms** here — the Tier 1 counterpart to their §2 schemes. `dip`'s axiom is the relay rule made predicate-level: the set-aside value's predicate is preserved unchanged **and** the quotation's `post` holds on the rest (`dip q = q ⊗ id_a`, lifted to predicates). Without these axioms, a refined quotation passing through `dip` would have no axiom connecting its guarantee to the post-`dip` stack, and the contract would evaporate exactly as at an unaxiomatized foreign call. Embedder operators carry their own `pre`/`post` from registration; the user's proofs discharge against those, on faith (the operator table is the modulo — architecture section).
+**Operator refinement axioms.** The primitive combinators (`DIP`, `CALL`, `IF`) are language-core registrations (§8) and carry **authored refinement axioms** here — the Tier 1 counterpart to their §2 schemes. `DIP`'s axiom is the relay rule made predicate-level: the set-aside value's predicate is preserved unchanged **and** the quotation's `post` holds on the rest (`DIP q = q ⊗ id_a`, lifted to predicates). Without these axioms, a refined quotation passing through `DIP` would have no axiom connecting its guarantee to the post-`DIP` stack, and the contract would evaporate exactly as at an unaxiomatized foreign call. Embedder operators carry their own `pre`/`post` from registration; the user's proofs discharge against those, on faith (the operator table is the modulo — architecture section).
 
 **Undecidable subsumption fails closed.** If Z3 returns `Unknown` on a subsumption VC, **reject**: *"could not prove this contract is preserved across the combinator; annotate or simplify the predicate."* Never a silent pass. A refinement that fails open is worse than no refinement.
 
@@ -334,7 +334,7 @@ The VC generator emits **SMT-LIB2 text** through the trait; the Z3 call sits beh
 **Z3 is not linked into the Caternary runtime and is never called during execution.** By the time a program runs, every contract is already proven and there is nothing left to check — this is build-time verification, like a borrow-check, not a runtime assert. The shadow stack (§10.3) is compile-time only. **No refinement machinery has any runtime cost.** This is what makes the CI-gate model work: **`caternary check`** pays the entire verification cost — Tier 0 + Tier 1 + operator-axiom discharge — at build time, so a *checked* program ships with **no solver, no shadow stack, no contract residue.** Check in CI; run lean.
 
 ### 10.11 Annotation burden (what the user actually writes)
-Tier 0 infers all shapes; **zero annotations** for shape safety. Refinements are **opt-in per word** — write a `where` clause only on the words whose contracts you want proven. **Refinement is viral downward through demands but inferred upward through composition:** annotate a constraint at its *source* and the obligation propagates to call sites automatically; you never restate it on intermediate words. The total annotation surface is exactly: (a) words you deliberately contract, (b) the rank-2 case (§8), (c) the boundary where an unrefined quotation meets a refined expectation (§10.7), and (d) the near-vestigial `assume`. Foreign words are pre-contracted by the embedder at registration, so they cost the user **nothing**. There is **no** regime requiring annotation on ordinary `dup`/`swap`/straight-line code.
+Tier 0 infers all shapes; **zero annotations** for shape safety. Refinements are **opt-in per word** — write a `where` clause only on the words whose contracts you want proven. **Refinement is viral downward through demands but inferred upward through composition:** annotate a constraint at its *source* and the obligation propagates to call sites automatically; you never restate it on intermediate words. The total annotation surface is exactly: (a) words you deliberately contract, (b) the rank-2 case (§8), (c) the boundary where an unrefined quotation meets a refined expectation (§10.7), and (d) the near-vestigial `assume`. Foreign words are pre-contracted by the embedder at registration, so they cost the user **nothing**. There is **no** regime requiring annotation on ordinary `DUP`/`SWAP`/straight-line code.
 
 ---
 
@@ -346,7 +346,7 @@ For a future crown-jewel routine, shallow-embed words as relations on stacks (co
 
 ## 12. Milestones and acceptance tests
 
-Each milestone is independently verifiable. Green = complete. Caternary snippets use `dup drop swap + dip call if`; **if real builtin names differ in `blue`, reconcile and adjust, recording the mapping.** Initial stack for a top-level program is **empty** unless stated.
+Each milestone is independently verifiable. Green = complete. Caternary snippets use runtime builtin names such as `DUP DROP SWAP + DIP CALL IF`. Initial stack for a top-level program is **empty** unless stated.
 
 ### Tier 0
 
@@ -357,15 +357,15 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 - Row absorption: `( 'a -- )` unifies with `( 'b Num Bool -- )` by `'a := 'b Num Bool`.
 - **Transitive canonicalization:** if `'r1` is already bound to `'r2` and `'r2` to a concrete stack, a further unification still canonicalizes correctly before the occurs check — no false cyclic rejection.
 - Occurs check rejects `'a := 'a Num`.
-- **Cyclic via arrows, no overflow:** `[ dup call ] dup call` is **rejected with a typed cyclic-type error, without stack-overflowing the compiler** (assert a clean rejection, not a crash). Occurs recurses into `Quote` interiors.
+- **Cyclic via arrows, no overflow:** `[ DUP CALL ] DUP CALL` is **rejected with a typed cyclic-type error, without stack-overflowing the compiler** (assert a clean rejection, not a crash). Occurs recurses into `Quote` interiors.
 
 **M2 — Sequence inference**
 - `1 2 +` infers `( 'a -- 'a Num )`.
-- `dup` infers `( 'a b -- 'a b b )`.
+- `DUP` infers `( 'a b -- 'a b b )`.
 - `[ 1 + ]` infers `( 'a -- 'a (`'b Num -- 'b Num`) )`.
-- `[ 1 + ] call` infers `( 'a Num -- 'a Num )`.
-- `true [ 1 ] [ 2 ] if` type-checks; both branches unify to `( 'a -- 'a Num )`.
-- **Underflow:** top-level `drop` (empty initial stack) is **rejected** with an arity error naming `drop`.
+- `[ 1 + ] CALL` infers `( 'a Num -- 'a Num )`.
+- `true [ 1 ] [ 2 ] IF` type-checks; both branches unify to `( 'a -- 'a Num )`.
+- **Underflow:** top-level `DROP` (empty initial stack) is **rejected** with an arity error naming `DROP`.
 
 **M3 — Definitions / SCC**
 - Order independence: `[ bar 1 + ] :foo` before `[ 2 ] :bar` type-checks.
@@ -374,7 +374,7 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 - Polymorphic recursion (self-call at a different type) yields the §6 diagnostic, not a raw unification error.
 
 **M4 — Combinators**
-- `xs total [ 99 push ] dip` type-checks; result shape `… List Num`; `dip` contributes only that `total` is carried through.
+- `xs total [ 99 push ] DIP` type-checks; result shape `… List Num`; `DIP` contributes only that `total` is carried through.
 - Rank-2 without annotation → §8 diagnostic; with a correct annotation → checks.
 
 **M5 — Error quality**
@@ -388,13 +388,13 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 
 **M6 — Refinement parsing.** `sqrt`/`push` (§10.1, `Num`) parse into demand/guarantee predicates over named binders; malformed `where` → located parse error.
 
-**M7 — Positional binding + shadow stack (conformance is the point).** `push : ( xs n -- … )` against inferred `'S Num Num` binds `n←top`, `xs←second`; `'S` never appears as an SMT variable. After `x 0 >`, the shadow stack reports the top term as `x > 0`; an opaque producer yields a fresh literal (sound, imprecise). **Arity-from-Tier-0:** an opaque `lib : ( Num Num -- Num )` pops two terms and pushes exactly one fresh literal (the shadow evaluator reads the inferred arrow, owns no independent arity). **Aliasing:** `x dup -` discharges to `0` (two slots after `dup` carry the *same* term by identity). **Shuffle conformance:** after a non-trivial `dip` shuffle, §10.2 binds the right SMT names to the right slots — property-tested against the interpreter's data flow, so a mis-shuffle is caught as a divergence, not silently shipped as a vacuous proof.
+**M7 — Positional binding + shadow stack (conformance is the point).** `push : ( xs n -- … )` against inferred `'S Num Num` binds `n←top`, `xs←second`; `'S` never appears as an SMT variable. After `x 0 >`, the shadow stack reports the top term as `x > 0`; an opaque producer yields a fresh literal (sound, imprecise). **Arity-from-Tier-0:** an opaque `lib : ( Num Num -- Num )` pops two terms and pushes exactly one fresh literal (the shadow evaluator reads the inferred arrow, owns no independent arity). **Aliasing:** `x DUP -` discharges to `0` (two slots after `DUP` carry the *same* term by identity). **Shuffle conformance:** after a non-trivial `DIP` shuffle, §10.2 binds the right SMT names to the right slots — property-tested against the interpreter's data flow, so a mis-shuffle is caught as a divergence, not silently shipped as a vacuous proof.
 
-**M8 — Path conditions.** `x 0 > [ x sqrt ] [ 0 ] if`: inside the true branch `x > 0` is in scope, so `x sqrt`'s demand `x >= 0` discharges (`Unsat`); **without** the path condition it would fail. The solver receives `push_scope`/`pop_scope` (and `(push 1)`/`(pop 1)` in text mode) around the branches. **Seam:** assert the scope state lives in the Z3 trait, not the Tier 0 substitution (the frozen AST is untouched).
+**M8 — Path conditions.** `x 0 > [ x sqrt ] [ 0 ] IF`: inside the true branch `x > 0` is in scope, so `x sqrt`'s demand `x >= 0` discharges (`Unsat`); **without** the path condition it would fail. The solver receives `push_scope`/`pop_scope` (and `(push 1)`/`(pop 1)` in text mode) around the branches. **Seam:** assert the scope state lives in the Z3 trait, not the Tier 0 substitution (the frozen AST is untouched).
 
 **M9 — First-order VC generation + Z3.** `x sqrt` where facts do not imply `x >= 0` → VC `Sat`, counterexample surfaced; where they do → `Unsat`, accepted. Negated-goal encoding verified at unit level (known-valid ⇒ `Unsat`; known-invalid ⇒ `Sat` + model).
 
-**M10 — Higher-order subsumption + operator axioms.** A quotation with `post: r > 5` passed where `post: r > 0` is expected → covariant VC `r>5 ⟹ r>0` valid, accepted. With `post: r > 0` where `r > 5` expected → invalid, rejected. Contravariant demand case symmetric. A subsumption VC returning **`Unknown` is rejected (fails closed)**, not accepted. **Operator axiom:** a refined quotation (`post: r > 0`) passed through `dip` preserves its guarantee on the far side via `dip`'s authored refinement axiom (§10.6); an embedder operator's registered `post` is usable to discharge a downstream user obligation.
+**M10 — Higher-order subsumption + operator axioms.** A quotation with `post: r > 5` passed where `post: r > 0` is expected → covariant VC `r>5 ⟹ r>0` valid, accepted. With `post: r > 0` where `r > 5` expected → invalid, rejected. Contravariant demand case symmetric. A subsumption VC returning **`Unknown` is rejected (fails closed)**, not accepted. **Operator axiom:** a refined quotation (`post: r > 0`) passed through `DIP` preserves its guarantee on the far side via `DIP`'s authored refinement axiom (§10.6); an embedder operator's registered `post` is usable to discharge a downstream user obligation.
 
 **M11 — Gradual interop.** An unrefined quotation passed where a guarantee is required → rejected with the **"carries no contract"** message (§10.7), not a raw counterexample. An unrefined quotation passed to a contract-agnostic combinator → accepted (`true ⟹ true`). Situation A: a refined word that calls an opaque word whose result is **dropped** verifies silently (no annotation).
 
@@ -414,7 +414,7 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 4. The **occurs check canonicalizes both sides first, is uniform through `Quote` interiors, and never stack-overflows** (depth-bounded or worklist); cyclic ⇒ typed error.
 5. **Flat substitution + trailed undo log** for the **Tier 0** type substitution (inference backtracking only); **no** persistent HAMT, **no** destructive union-find; O(1)/zero-alloc. This trail is **Tier-0-only and is NOT the Tier 1 logical-scope mechanism** (invariant 18). Provenance the trail has unwound degrades to the **frame stack**, not the substitution.
 6. **Origin spans and typing frames exist from the first inference commit.** Frames are the durable provenance spine and persist across `pop_scope`. User-facing diagnostics use provenance pairs and frame breadcrumbs, anchor at the innermost concrete contradiction, and never leak internal variable names.
-7. **The shadow stack is an abstract evaluator mirroring runtime data flow exactly** (§10.3): `dup` aliases the same term, combinators execute their real shuffle, **arity is read from the Tier 0 arrow** (the evaluator owns no independent arity). Core-shuffle conformance is **property-tested against the interpreter**, because a mis-shuffle yields a vacuous proof (a green checkmark proving nothing), not a crash.
+7. **The shadow stack is an abstract evaluator mirroring runtime data flow exactly** (§10.3): `DUP` aliases the same term, combinators execute their real shuffle, **arity is read from the Tier 0 arrow** (the evaluator owns no independent arity). Core-shuffle conformance is **property-tested against the interpreter**, because a mis-shuffle yields a vacuous proof (a green checkmark proving nothing), not a crash.
 8. Word/combinator contracts are typed from **declared signatures only**; a quotation argument's **body is never expanded** into a caller's contract.
 9. **No polymorphic recursion** is silently admitted.
 10. **Tier separation:** Tier 0 passes with **zero dependence on Z3**. Refinements are a **forwarded payload Tier 0 never reads.** The VC generator targets an **interchange format (SMT-LIB)** behind a **solver trait**, never calling a solver in its core.
@@ -423,7 +423,7 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 13. **`assume` is STRICT and near-vestigial.** Legal only where a genuinely opaque/uncontracted dependency sits in the obligation's chain; **rejected** on any goal the solver could discharge without it (the positive-rejection check must actually run). The strict exploratory check is **cached and fails lenient** (timeout ⇒ accept). Every `assume` is a first-class, enumerable ledger entry; the modulo-assumption status propagates to callers visibly. The ledger means *"cannot honestly prove,"* never *"didn't bother."*
 14. **All Tier 1 machinery is compile-time**; Z3 and the shadow stack have **zero runtime presence**.
 15. **Whole-program, no modules.** One compilation unit, one global ledger, definitions in a flat global namespace, program = entry against empty stack. No imports, no serialized contracts, no version skew, no module `Cid`s. `grep assume` over source = the complete user trusted base.
-16. **Two-registrant operator model; the user registers nothing.** Trusted contracts come **only** from operator registration — by the **language core** (primitives `call`/`dip`/`if`, with Tier 0 schemes + Tier 1 refinement axioms) and the **embedder** (host operators). The user cannot register; the capability wall is the embedding API, structural. Operator contracts (axioms) and user `assume` are **separate buckets**; the strict drop-and-re-run check applies to `assume` only.
+16. **Two-registrant operator model; the user registers nothing.** Trusted contracts come **only** from operator registration — by the **language core** (primitives `CALL`/`DIP`/`IF`, with Tier 0 schemes + Tier 1 refinement axioms) and the **embedder** (host operators). The user cannot register; the capability wall is the embedding API, structural. Operator contracts (axioms) and user `assume` are **separate buckets**; the strict drop-and-re-run check applies to `assume` only.
 17. **Registration is explicit attestation.** The embedder visibly attests each operator contract; Caternary takes it on faith (the FFI floor). The **operator table is the modulo** of every proof; a verified program's status is *"sound modulo the attested operator contracts."*
 18. **Tier seam is an immutability barrier.** Tier 1 (shadow evaluator, VC generator) treats the Tier 0 substitution as **read-only**; `push_scope`/`pop_scope` live in the Z3 trait + shadow-evaluator state, never the inference substitution. A Tier 1 branch mutating a Tier 0 binding is **impossible by construction.**
 19. **The shadow evaluator reads the Tier 0 arrow for arity** (folded into 7, restated for emphasis): opaque words pop/push per their inferred Tier 0 type. Tier 0 shape closure is the structural rail — hence Tier 1's gating behind green Tier 0.
@@ -433,13 +433,13 @@ Each milestone is independently verifiable. Green = complete. Caternary snippets
 
 ## 14. Suggested build order
 
-1. **Whole-program driver + operator registration + attestation API.** Flat definition namespace (reuse the pre-pass); `main`-against-empty-stack; `register_operator_with_contract` as a visibly-trusted call; language-core primitives (`call`/`dip`/`if`) registered with their Tier 0 schemes; the user has no registration surface (capability wall). → M0
+1. **Whole-program driver + operator registration + attestation API.** Flat definition namespace (reuse the pre-pass); `main`-against-empty-stack; `register_operator_with_contract` as a visibly-trusted call; language-core primitives (`CALL`/`DIP`/`IF`) registered with their Tier 0 schemes; the user has no registration surface (capability wall). → M0
 2. Type representation + **flat substitution + trailed undo (Tier-0-only)** + **origin spans + typing frames** (§3).
 3. Unifier with **canonicalize-then-occurs, uniform through arrows, depth-guarded** (§4) → M1.
-4. Sequence inference, literals, quotations, locals, `if`-as-combinator (§5) → M2.
+4. Sequence inference, literals, quotations, locals, `IF`-as-combinator (§5) → M2.
 5. SCC pass + generalization (§6) → M3.
 6. Combinator schemes + rank-2 detection (§8) → M4.
 7. Provenance/frame/localize-inward error reframing (§7) → M5. **Tier 0 complete.**
 8. *(Phase 2, gated)* refinement parser (§10.1) → M6; positional binding + **shadow evaluator (arity from Tier 0 arrow) with conformance tests** (§10.2–10.3) → M7; **path conditions + scoped seam (Z3-trait-only)** (§10.4, §10.8) → M8; first-order VCs + Z3 (§10.5, §10.8) → M9; **higher-order subsumption + operator refinement axioms, fail-closed** (§10.6) → M10; **gradual interop** (§10.7) → M11; **`assume` boundary, strict + cached/lenient** (§10.7) → M12; **SMT-LIB parity** (§10.9) → M13; **whole-program ledger + attestation hash + CI-gate/free-runtime checks** (architecture section, §10.10) → M14.
 
-Build Tier 0 end-to-end on `abs` / `sqrt` / `push` / `dip` before anything fancy. Never build value-language subtyping. Subsumption is two implications handed to Z3, not a feature of the type engine. The shadow stack mirrors runtime data flow exactly — including reading arity from the Tier 0 arrow — or your proofs are vacuous. Trusted contracts come only from attested operator registration; `assume` is strict and names only what you genuinely cannot prove. Whole-program, one ledger, no modules. Check in CI; run lean. When in doubt, prefer rejecting cleanly with a good message over widening silently — and fail closed.
+Build Tier 0 end-to-end on `abs` / `sqrt` / `push` / `DIP` before anything fancy. Never build value-language subtyping. Subsumption is two implications handed to Z3, not a feature of the type engine. The shadow stack mirrors runtime data flow exactly — including reading arity from the Tier 0 arrow — or your proofs are vacuous. Trusted contracts come only from attested operator registration; `assume` is strict and names only what you genuinely cannot prove. Whole-program, one ledger, no modules. Check in CI; run lean. When in doubt, prefer rejecting cleanly with a good message over widening silently — and fail closed.

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -1,0 +1,424 @@
+//! Whole-program Tier-0 type-check driver (spec M0).
+//!
+//! This is the entry the spec calls *"the whole-program driver"*: it consumes
+//! the flat global namespace of definitions that [`Evaluator::load`] already
+//! populated (the order-independent pre-pass, §6 / architecture section) plus the
+//! registered operator contracts, and type-checks the **distinguished entry**
+//! against the **empty initial stack**.
+//!
+//! # Reconciliation: `main` against the empty stack
+//!
+//! `docs/typing.md` says the *program* is the distinguished entry (`main`) whose
+//! effect must close against the empty stack, while the runtime has **no `main`
+//! convention** — every `[ body ] :name` is just a definition in one flat
+//! namespace, and `eval` runs an arbitrary token stream. This module *is* that
+//! reconciliation, recorded in code: the type checker treats the definition
+//! named [`MAIN`] as the program and every other definition as a library member.
+//! The initial stack is the identity arrow `( 'a -- 'a )`
+//! ([`InferCtx::empty_program_effect`]); "Initial stack for a top-level program
+//! is empty" (§12).
+//!
+//! # Scope: M0 only
+//!
+//! M0 lands the *driver shape*: definitions load into one namespace; the entry is
+//! located; every word in its body **resolves** to a definition, a registered
+//! operator contract, a numeric literal, a quotation, or a local — and quotation
+//! descent pushes/pops typing frames (the durable provenance spine). Full
+//! arrow unification (M1) and sequence inference (M2) ride on this substrate
+//! later; M0 deliberately stops at resolution closure and demonstrates that a
+//! registered operator's [`Scheme`] is *usable* (it can be looked up and
+//! instantiated with fresh variables).
+
+use crate::Evaluator;
+use crate::Quotable;
+use crate::Span;
+use crate::SpannedToken;
+use crate::SpannedTokenKind;
+use crate::evaluator::bind_target;
+use crate::types::InferCtx;
+use crate::types::MAIN;
+use crate::types::TypingFrame;
+use crate::types::WordTy;
+use crate::types::is_numeric_literal;
+
+/// A Tier-0 type-check error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeError {
+    /// The distinguished entry point was not found among loaded definitions.
+    MissingEntry {
+        /// The entry name that was expected (normally [`MAIN`]).
+        name: String,
+    },
+    /// A word in a checked body resolves to nothing: it is neither a definition,
+    /// a registered operator contract, a numeric literal, nor a bound local.
+    UnresolvedWord {
+        /// The offending word.
+        word: String,
+        /// The span where it appears.
+        span: Span,
+    },
+}
+
+impl std::fmt::Display for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeError::MissingEntry { name } => {
+                write!(
+                    f,
+                    "no `{name}` entry point: a whole-program check needs a definition `[ body ] :{name}` to type against the empty stack"
+                )
+            }
+            TypeError::UnresolvedWord { word, span } => {
+                write!(
+                    f,
+                    "unresolved word `{word}` at byte {}: not a definition, a registered operator, a numeric literal, or a local in scope",
+                    span.start
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TypeError {}
+
+/// Type-checks the whole program: locate the distinguished entry [`MAIN`] and
+/// check it against the empty initial stack.
+///
+/// Returns the Tier-0 effect the entry is checked against — the empty-stack
+/// identity `( 'a -- 'a )` — so callers can see the convention concretely. In M0
+/// the body is checked for *resolution closure*: every word resolves and every
+/// quotation pushes/pops a typing frame. The returned [`InferCtx`] carries the
+/// substitution arena and (now-empty) frame stack the later milestones reuse.
+pub fn type_check<T>(evaluator: &Evaluator<T>) -> Result<WordTy, TypeError>
+where
+    T: Quotable,
+{
+    type_check_entry(evaluator, MAIN)
+}
+
+/// Type-checks a named entry against the empty initial stack. [`type_check`] is
+/// this with `entry = MAIN`; exposing the name lets tests check a non-`main`
+/// entry without depending on the default.
+pub fn type_check_entry<T>(evaluator: &Evaluator<T>, entry: &str) -> Result<WordTy, TypeError>
+where
+    T: Quotable,
+{
+    // The checker reads the SPANNED body so every diagnostic anchors at a real
+    // source byte offset (§13 invariant 6: origin spans exist from the first
+    // inference commit and are not reconstructable later). A program to be
+    // type-checked must therefore be loaded via
+    // [`Evaluator::load_with_spans`]; the spanless `load` is runtime-only.
+    let body = evaluator
+        .definition_body_spanned(entry)
+        .ok_or_else(|| TypeError::MissingEntry {
+            name: entry.to_string(),
+        })?;
+
+    let mut ctx = InferCtx::new();
+    // The program-effect node is born at the entry's own bracket span — a real
+    // source location, never a fabricated zero span.
+    let span = evaluator
+        .definition_span(entry)
+        .expect("definition_span present whenever definition_body_spanned is");
+    let effect = ctx.empty_program_effect(span);
+
+    // Locals introduced by `>name` are monomorphic within the scope (§5). M0
+    // tracks only their *names* so a later reference resolves; the type is
+    // assigned by inference (M2).
+    let mut locals: Vec<String> = Vec::new();
+    resolve_seq(evaluator, body, &mut ctx, &mut locals)?;
+
+    Ok(effect)
+}
+
+/// Resolve every word in a spanned token sequence, descending into quotations.
+/// Returns the first resolution failure, carrying that token's **real** source
+/// span. This is the M0 "type-check" — resolution closure — onto which the M1
+/// unifier and M2 inference attach later.
+fn resolve_seq<T>(
+    evaluator: &Evaluator<T>,
+    tokens: &[SpannedToken],
+    ctx: &mut InferCtx,
+    locals: &mut Vec<String>,
+) -> Result<(), TypeError>
+where
+    T: Quotable,
+{
+    for token in tokens {
+        match &token.kind {
+            SpannedTokenKind::Word(w) => {
+                if let Some(name) = bind_target(w) {
+                    // `>name` introduces a monomorphic local for the rest of the
+                    // scope (§5). M0 records the name.
+                    locals.push(name.to_string());
+                } else if locals.iter().any(|l| l == w) {
+                    // A reference to a bound local — resolves.
+                } else if is_numeric_literal(w) {
+                    // Numeric literal: ( 'a -- 'a Num ) (§5). Resolves.
+                } else if evaluator.has_definition(w) {
+                    // A definition in the flat global namespace — resolves.
+                } else if evaluator.contract(w).is_some() {
+                    // A registered operator with an attested contract — resolves.
+                } else {
+                    return Err(TypeError::UnresolvedWord {
+                        word: w.clone(),
+                        // The token's real source span — not a fabricated zero.
+                        span: token.span,
+                    });
+                }
+            }
+            SpannedTokenKind::Bracket(inner) => {
+                // Descending into a quotation pushes a typing frame: its real
+                // span and the effect expected at entry (§3 invariant 3). Even
+                // though full error rendering (M5) comes later, the frame must
+                // exist from the first commit — it is the durable provenance
+                // spine — and it must carry the quotation's true source span.
+                let frame_span = token.span;
+                let expected = ctx.empty_program_effect(frame_span);
+                ctx.frames.push(TypingFrame {
+                    span: frame_span,
+                    expected,
+                });
+                // A quotation opens a fresh lexical scope for locals.
+                let mut inner_locals = locals.clone();
+                let result = resolve_seq(evaluator, inner, ctx, &mut inner_locals);
+                ctx.frames.pop();
+                result?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Token;
+    use crate::parse;
+    use crate::parse_with_spans;
+    use crate::types::NUM;
+    use crate::types::Scheme;
+    use crate::types::StackTy;
+    use crate::types::Ty;
+
+    /// A minimal stack value type for driver tests.
+    #[derive(Debug, Clone, PartialEq)]
+    enum Value {
+        Word(String),
+        Bracket(Vec<Token>),
+    }
+
+    impl From<Token> for Value {
+        fn from(token: Token) -> Self {
+            match token {
+                Token::Word(w) => Value::Word(w),
+                Token::Bracket(b) => Value::Bracket(b),
+            }
+        }
+    }
+
+    impl Quotable for Value {
+        fn as_quotation(&self) -> Option<&[Token]> {
+            match self {
+                Value::Bracket(b) => Some(b),
+                Value::Word(_) => None,
+            }
+        }
+
+        fn to_tokens(&self) -> Vec<Token> {
+            match self {
+                Value::Word(w) => vec![Token::Word(w.clone())],
+                Value::Bracket(b) => vec![Token::Bracket(b.clone())],
+            }
+        }
+
+        fn as_sequence(&self) -> Option<Vec<Self>> {
+            match self {
+                Value::Bracket(b) => Some(b.iter().map(|t| Value::from(t.clone())).collect()),
+                Value::Word(_) => None,
+            }
+        }
+
+        fn from_sequence(elements: Vec<Self>) -> Self {
+            Value::Bracket(elements.iter().flat_map(|v| v.to_tokens()).collect())
+        }
+    }
+
+    fn sp() -> Span {
+        Span { start: 0, end: 1 }
+    }
+
+    /// The `+` operator's attested Tier-0 scheme: ( 'S Num Num -- 'S Num ).
+    /// There is no core `+`; this enters via registration, exactly as §12 says.
+    fn plus_scheme() -> Scheme {
+        let s = sp();
+        let input = StackTy::new(vec![Ty::num(s), Ty::num(s)], 0, s);
+        let output = StackTy::new(vec![Ty::num(s)], 0, s);
+        Scheme::new(vec![], vec![0], WordTy::new(input, output))
+    }
+
+    #[test]
+    fn missing_main_is_an_error() {
+        let eval: Evaluator<Value> = Evaluator::new();
+        let err = type_check(&eval).unwrap_err();
+        assert_eq!(
+            err,
+            TypeError::MissingEntry {
+                name: MAIN.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn registered_operator_scheme_is_usable_in_the_driver() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        // The embedder attests a contract for `+`.
+        eval.register_operator_with_contract("+", plus_scheme());
+
+        // A one-operator program: main pushes two literals and adds them.
+        let tokens = parse_with_spans("[ 1 2 + ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+
+        // The driver resolves main against the empty stack.
+        let effect = type_check(&eval).unwrap();
+        assert!(effect.input.elems.is_empty());
+        assert_eq!(effect.input.row, effect.output.row);
+
+        // The scheme is retrievable AND usable: instantiation renames its row.
+        let scheme = eval.contract("+").unwrap().clone();
+        let mut ctx = InferCtx::new();
+        let inst = ctx.instantiate(&scheme);
+        assert_eq!(inst.output.elems.len(), 1);
+        assert_eq!(
+            inst.output.elems[0].kind,
+            crate::types::TyKind::Con(NUM.to_string())
+        );
+    }
+
+    #[test]
+    fn a_word_with_no_definition_or_contract_is_unresolved() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        let tokens = parse_with_spans("[ frobnicate ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        let err = type_check(&eval).unwrap_err();
+        assert!(matches!(err, TypeError::UnresolvedWord { word, .. } if word == "frobnicate"));
+    }
+
+    #[test]
+    fn unresolved_word_reports_a_real_nonzero_span() {
+        // §13 invariant 6: the diagnostic must anchor at the offending token's
+        // real byte offset, never a fabricated Span { 0, 0 }.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        // `frobnicate` begins after "[ " — at byte 2.
+        let src = "[ frobnicate ] :main";
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        let err = type_check(&eval).unwrap_err();
+        match err {
+            TypeError::UnresolvedWord { word, span } => {
+                assert_eq!(word, "frobnicate");
+                assert_ne!(span, Span { start: 0, end: 0 }, "span must be real");
+                assert_eq!(span.start, src.find("frobnicate").unwrap());
+            }
+            other => panic!("expected UnresolvedWord, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typing_frame_carries_the_real_quotation_span() {
+        // The frame pushed on descent into a nested quotation must carry that
+        // quotation's true source span (durable provenance spine, §3 inv 3). We
+        // observe it indirectly: an unresolved word *inside* the nested quote
+        // still reports its own token span, and the outer driver located it.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        let src = "[ [ frobnicate ] ] :main";
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        let err = type_check(&eval).unwrap_err();
+        match err {
+            TypeError::UnresolvedWord { span, .. } => {
+                assert_eq!(span.start, src.find("frobnicate").unwrap());
+            }
+            other => panic!("expected UnresolvedWord, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn definitions_resolve_across_textual_order() {
+        // Order independence (the flat global pre-pass): main references bar,
+        // bar is defined later. Both resolve.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        eval.register_operator_with_contract("+", plus_scheme());
+        let tokens = parse_with_spans("[ bar 1 + ] :main [ 2 ] :bar").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        type_check(&eval).unwrap();
+    }
+
+    #[test]
+    fn locals_resolve_within_scope() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        eval.register_operator_with_contract("+", plus_scheme());
+        // bind top to x, then push x twice and add.
+        let tokens = parse_with_spans("[ >x x x + ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        type_check(&eval).unwrap();
+    }
+
+    #[test]
+    fn quotation_descent_resolves_nested_words() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        eval.register_operator_with_contract("+", plus_scheme());
+        // A nested quotation whose body uses the contracted operator.
+        let tokens = parse_with_spans("[ [ 1 + ] ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        type_check(&eval).unwrap();
+    }
+
+    // ----- Capability wall: the user registers nothing (M0 / invariant 16) -----
+
+    #[test]
+    fn caternary_surface_cannot_reach_the_contract_table() {
+        // No Caternary source — parsed, loaded, evaluated — can add a contract.
+        // The contract table is a private field whose only mutator is the Rust
+        // registration API; parse/load/eval never touch it. We assert this
+        // structurally by exercising the full surface and observing the table
+        // stays empty.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+
+        // A program that *tries* to define things and run combinators.
+        let src = "[ 1 2 ] :main [ 99 ] :helper";
+        let tokens = parse(src).unwrap();
+        assert_eq!(eval.contract_count(), 0);
+
+        eval.load(&tokens).unwrap();
+        assert_eq!(
+            eval.contract_count(),
+            0,
+            "load() must not populate the contract table"
+        );
+
+        // eval the program body too — still nothing reaches contracts.
+        let body = parse("1 2").unwrap();
+        eval.eval(&body).unwrap();
+        assert_eq!(
+            eval.contract_count(),
+            0,
+            "eval() must not populate the contract table"
+        );
+
+        // The ONLY way to add a contract is the Rust registration API.
+        eval.register_operator_with_contract("+", plus_scheme());
+        assert_eq!(eval.contract_count(), 1);
+    }
+
+    #[test]
+    fn define_does_not_touch_the_contract_table() {
+        // Registering runtime behavior via `define` (the existing API) must not
+        // register a contract: the two tables are separate buckets.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        eval.define("NOOP", |_stack, _eval| Ok(()));
+        assert_eq!(eval.contract_count(), 0);
+        // And there is no contract for the defined operator.
+        assert!(eval.contract("NOOP").is_none());
+    }
+}

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -11,6 +11,7 @@ use handled::SError;
 
 use crate::Quotable;
 use crate::Token;
+use crate::types::Scheme;
 
 /// Evaluation error type.
 pub type EvalError = SError;
@@ -41,7 +42,7 @@ pub(crate) fn definition_error(message: impl AsRef<str>) -> EvalError {
 /// Returns `Some(name)` if `w` is a binding word `>name` whose name is a valid
 /// local identifier: a leading ASCII letter or `_`, then ASCII alphanumerics or
 /// `_` (the same grammar the optimizer uses for pattern variables).
-fn bind_target(w: &str) -> Option<&str> {
+pub(crate) fn bind_target(w: &str) -> Option<&str> {
     let rest = w.strip_prefix('>')?;
     if is_local_name(rest) {
         Some(rest)
@@ -146,6 +147,39 @@ pub type Operator<T> = fn(&mut Vec<T>, &Evaluator<T>) -> Result<(), EvalError>;
 pub struct Evaluator<T> {
     operators: HashMap<String, Operator<T>>,
     definitions: HashMap<String, Vec<Token>>,
+    /// Contract-carrying operator registrations: the name → [`Scheme`] table that
+    /// is the **modulo** of every Caternary type proof (architecture section,
+    /// invariants 16/17).
+    ///
+    /// This is a *sibling* of `operators` and `definitions`, never a rename of
+    /// `define`. `define` registers an operator's *runtime behavior*; this table
+    /// records an operator's *attested Tier-0 type*. The two are kept separate on
+    /// purpose: a runtime operator may exist with no contract (untyped, opaque to
+    /// the checker), and the language core / embedder add a contract via
+    /// [`Evaluator::register_operator_with_contract`].
+    ///
+    /// The field is **private**, and no Caternary surface entry point
+    /// (`parse`/`load`/`eval`) reads or writes it. The only mutator is the
+    /// Rust-only registration API below. That privacy *is* the capability wall:
+    /// a user writing Caternary cannot reach this table by construction, not
+    /// merely by convention (invariant 16).
+    contracts: HashMap<String, Scheme>,
+    /// Parallel **span table** for loaded definitions: name → the definition
+    /// body as spanned tokens (§3 invariant 2 / §13 invariant 6 — origin spans
+    /// must exist from the first inference commit and are *not reconstructable
+    /// later*). Populated only by [`Evaluator::load_with_spans`]; plain
+    /// [`Evaluator::load`] leaves it empty (the runtime needs no spans).
+    ///
+    /// The type checker reads this table so its diagnostics anchor at real byte
+    /// offsets instead of a fabricated `Span { 0, 0 }`. It is a *sibling* of
+    /// `definitions`: the spanless `Vec<Token>` body drives the runtime, the
+    /// spanned body drives the checker, and the two are kept in lockstep by
+    /// `load_with_spans`.
+    ///
+    /// The stored [`crate::Span`] is the span of the whole `[ body ]` bracket, so
+    /// the checker has a real source location even for the program-effect node of
+    /// an empty body.
+    definition_spans: HashMap<String, (crate::Span, Vec<crate::SpannedToken>)>,
 }
 
 impl<T> Default for Evaluator<T>
@@ -163,12 +197,94 @@ impl<T> Evaluator<T> {
         Self {
             operators: HashMap::new(),
             definitions: HashMap::new(),
+            contracts: HashMap::new(),
+            definition_spans: HashMap::new(),
         }
     }
 
     /// Defines an operator by name.
+    ///
+    /// This registers an operator's *runtime behavior* only. It does not, and
+    /// must not, touch the type-contract table; an operator defined here is
+    /// untyped from the checker's point of view until a contract is registered
+    /// for it via [`Evaluator::register_operator_with_contract`]. `define` is
+    /// intentionally left unchanged: contract-carrying registration is a
+    /// *sibling*, not a replacement.
     pub fn define(&mut self, name: &str, op: Operator<T>) {
         self.operators.insert(name.to_string(), op);
+    }
+
+    /// Registers an operator's **attested Tier-0 type contract** (architecture
+    /// section; invariants 16/17).
+    ///
+    /// This is **explicit attestation, and a visibly trusted act.** Calling it is
+    /// the registrant — the language core for primitives (`CALL`/`DIP`/`IF`), or
+    /// the embedder for host operators — stating *"I, who wrote this Rust, vouch
+    /// that this operator satisfies this `Scheme`."* Caternary **cannot** check
+    /// that the underlying Rust actually satisfies the contract; that obligation
+    /// lives in Rust-land, outside the language's reach (the FFI floor). The
+    /// resulting table is therefore the **modulo** of every Caternary proof: a
+    /// verified program is *"sound modulo the attested operator contracts."*
+    ///
+    /// Only two populations call this: the language core and the embedder. **The
+    /// user — who writes Caternary, not Rust — has no path here.** The capability
+    /// wall is structural: this is a Rust method on `Evaluator`, the contract
+    /// table it writes is a private field, and no Caternary surface
+    /// (`parse`/`load`/`eval`) can reach either. A user cannot add to the axiom
+    /// set (invariant 16).
+    ///
+    /// Registration is additive and idempotent-by-overwrite: re-registering a
+    /// name replaces its contract (the embedder is trusted to mean the latest
+    /// attestation).
+    pub fn register_operator_with_contract(&mut self, name: &str, scheme: Scheme) {
+        self.contracts.insert(name.to_string(), scheme);
+    }
+
+    /// Looks up the attested type [`Scheme`] for a word, if one is registered.
+    ///
+    /// This is the resolution path the whole-program type checker uses to turn a
+    /// word into its scheme when the word is a *registered operator*. (Resolving a
+    /// word that is a Caternary *definition* into a scheme is the SCC/inference
+    /// job of later milestones; see [`crate::check`].)
+    pub fn contract(&self, name: &str) -> Option<&Scheme> {
+        self.contracts.get(name)
+    }
+
+    /// The number of registered operator contracts. Used by the capability-wall
+    /// tests to assert that no Caternary surface ever adds to this table.
+    pub fn contract_count(&self) -> usize {
+        self.contracts.len()
+    }
+
+    /// True if `name` is a loaded `[ body ] :name` definition (flat global
+    /// namespace populated by [`Evaluator::load`]). The type checker rides on the
+    /// same table the runtime resolves against.
+    pub fn has_definition(&self, name: &str) -> bool {
+        self.definitions.contains_key(name)
+    }
+
+    /// The body of a loaded definition, if present. Read-only access for the
+    /// type checker; the checker never mutates the definition table.
+    pub fn definition_body(&self, name: &str) -> Option<&[Token]> {
+        self.definitions.get(name).map(Vec::as_slice)
+    }
+
+    /// The **spanned** body of a loaded definition, if one was loaded with spans
+    /// via [`Evaluator::load_with_spans`]. This is the read path the type checker
+    /// uses to anchor diagnostics at real source byte offsets (§13 invariant 6).
+    /// Returns `None` for definitions loaded through the spanless
+    /// [`Evaluator::load`].
+    pub fn definition_body_spanned(&self, name: &str) -> Option<&[crate::SpannedToken]> {
+        self.definition_spans
+            .get(name)
+            .map(|(_, body)| body.as_slice())
+    }
+
+    /// The span of the whole `[ body ]` bracket for a definition loaded with
+    /// spans, if present. Lets the type checker anchor the program-effect node at
+    /// a real source location even when the body is empty.
+    pub fn definition_span(&self, name: &str) -> Option<crate::Span> {
+        self.definition_spans.get(name).map(|(span, _)| *span)
     }
 
     /// Loads function definitions from a top-level token stream.
@@ -243,6 +359,42 @@ impl<T> Evaluator<T> {
                     )));
                 }
                 self.definitions.insert(name.to_string(), body);
+            }
+            i += 1;
+        }
+        Ok(())
+    }
+
+    /// Loads function definitions from a **spanned** top-level token stream,
+    /// keeping both the runtime body and a parallel span table in lockstep.
+    ///
+    /// This is [`Evaluator::load`] plus span retention: it performs identical
+    /// validation and populates the spanless `definitions` table exactly as
+    /// `load` does (so the runtime is unaffected), and additionally records each
+    /// definition's **spanned** body so the type checker can anchor diagnostics
+    /// at real source byte offsets (§13 invariant 6). Use this whenever the
+    /// program will be type-checked; use `load` for runtime-only use.
+    pub fn load_with_spans(&mut self, tokens: &[crate::SpannedToken]) -> Result<(), EvalError> {
+        use crate::SpannedTokenKind;
+
+        // Validate and populate the runtime table through the existing path.
+        let spanless: Vec<Token> = tokens.iter().map(crate::SpannedToken::to_token).collect();
+        self.load(&spanless)?;
+
+        // Re-walk the spanned top level to capture each definition's spanned
+        // body. Validation already succeeded above, so the binder pairing is
+        // guaranteed well-formed here.
+        let mut i = 0;
+        while i < tokens.len() {
+            if let SpannedTokenKind::Word(w) = &tokens[i].kind
+                && has_def_prefix(w)
+                && let Some(name) = def_target(w)
+                && let Some(prev) = i.checked_sub(1)
+                && let SpannedTokenKind::Bracket(body) = &tokens[prev].kind
+            {
+                self.definition_spans
+                    .entry(name.to_string())
+                    .or_insert_with(|| (tokens[prev].span, body.clone()));
             }
             i += 1;
         }

--- a/caternary/src/lib.rs
+++ b/caternary/src/lib.rs
@@ -3,12 +3,17 @@
 #![deny(missing_docs)]
 
 mod builtins;
+mod check;
 mod combinators;
 mod evaluator;
 mod optimizer;
 mod parser;
+mod types;
 
 pub use builtins::register_stack_builtins;
+pub use check::TypeError;
+pub use check::type_check;
+pub use check::type_check_entry;
 pub use combinators::Quotable;
 pub use combinators::register_combinators;
 pub use combinators::register_conditionals;
@@ -27,6 +32,22 @@ pub use parser::SpannedTokenKind;
 pub use parser::Token;
 pub use parser::parse;
 pub use parser::parse_with_spans;
+pub use types::BOOL;
+pub use types::FrameStack;
+pub use types::InferCtx;
+pub use types::MAIN;
+pub use types::NUM;
+pub use types::RowVar;
+pub use types::Scheme;
+pub use types::StackTy;
+pub use types::Subst;
+pub use types::Ty;
+pub use types::TyKind;
+pub use types::TyVar;
+pub use types::TypingFrame;
+pub use types::UnifyError;
+pub use types::WordTy;
+pub use types::is_numeric_literal;
 
 /// Register all builtins and combinators on an evaluator.
 pub fn register_all_builtins<T>(evaluator: &mut Evaluator<T>)

--- a/caternary/src/parser.rs
+++ b/caternary/src/parser.rs
@@ -58,13 +58,22 @@ pub enum SpannedTokenKind {
 }
 
 impl SpannedToken {
-    fn into_token(self) -> Token {
+    /// Drop the span information, recovering the plain [`Token`] this spanned
+    /// token wraps. Brackets are converted recursively.
+    pub fn into_token(self) -> Token {
         match self.kind {
             SpannedTokenKind::Word(word) => Token::Word(word),
             SpannedTokenKind::Bracket(inner) => {
                 Token::Bracket(inner.into_iter().map(SpannedToken::into_token).collect())
             }
         }
+    }
+
+    /// Borrow the plain [`Token`] shape without consuming the span tree. Returns
+    /// an owned [`Token`] (a clone of the payload) for callers that need the
+    /// spanless view alongside the spanned one.
+    pub fn to_token(&self) -> Token {
+        self.clone().into_token()
     }
 }
 

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -1,0 +1,1122 @@
+//! Tier-0 type-system substrate for Caternary (the §3 representation).
+//!
+//! This module is the foundation the whole-program type checker rests on. It
+//! implements the *type representation* from `docs/typing.md` §3 — `Ty`,
+//! `StackTy`, `WordTy`, `Scheme` — together with the two representation
+//! invariants that must be present "from the first inference commit": origin
+//! spans on every node, and the durable typing-frame stack. It also provides the
+//! flat substitution arena + trailed undo log mandated by ratified decision (b).
+//!
+//! It is deliberately *Tier-0 only*. None of the Tier 1 refinement machinery
+//! (predicate payloads, shadow stack, VC generation, Z3) lives here. The
+//! substitution trail in this module is the Tier-0 inference backtracking trail
+//! and is **not** the Tier 1 logical-scope mechanism (§3 invariant 5 / 18).
+//!
+//! # Runtime facts recorded by the substrate
+//!
+//! `docs/typing.md` uses the same **UPPER_SNAKE_CASE** spelling the runtime
+//! registers for builtins, so there is no spec-name/runtime-name compatibility
+//! table in this layer. The remaining Tier-0 reconciliation facts are:
+//!
+//! * **There is no core `+` / `Num` builtin.** The spec's `+ : ( 'S Num Num --
+//!   'S Num )` signature does not correspond to any operator in the core tables;
+//!   only `ADD`/`MUL`/`GT` exist, and those appear *only in test code*. Numeric
+//!   operators therefore enter the type environment via *registration*
+//!   ([`crate::Evaluator::register_operator_with_contract`]), never from a core
+//!   table. The numeric base type is spelled [`NUM`].
+//! * **There is no numeric token.** The parser emits only `Token::Word` and
+//!   `Token::Bracket` (see `parser.rs`); there is no `Token::Num`. The Tier-0
+//!   decision, recorded as [`is_numeric_literal`], is that a numeric literal is a
+//!   `Token::Word` whose text parses as a Rust `f64` (which subsumes integers).
+//!   Such a word has Tier-0 type `( 'a -- 'a Num )` per §5.
+
+use crate::Span;
+
+/// A Tier-0 type variable. Identifies a slot in the substitution arena.
+pub type TyVar = u32;
+
+/// A Tier-0 row variable. Identifies a stack-tail slot in the substitution arena.
+pub type RowVar = u32;
+
+/// The name of the single numeric base type (§1 ratified decision (a): one
+/// numeric type `Num`, no Int/Float split, no overloading).
+pub const NUM: &str = "Num";
+
+/// The name of the boolean base type.
+pub const BOOL: &str = "Bool";
+
+/// The distinguished whole-program entry point: the definition whose effect must
+/// close against the empty stack (§12 / architecture section). The runtime has
+/// no `main` convention of its own; this constant *is* that reconciliation —
+/// the type checker treats the definition named `main` as the program, and every
+/// other `[ body ] :name` as a library definition in the flat global namespace.
+pub const MAIN: &str = "main";
+
+/// The Tier-0 decision for what counts as a numeric literal at the `Token`
+/// level. The parser has no numeric token; a numeric literal is a word whose
+/// text parses as an `f64` (integers included). Such a word has Tier-0 type
+/// `( 'a -- 'a Num )` (§5).
+pub fn is_numeric_literal(word: &str) -> bool {
+    !word.is_empty() && word.parse::<f64>().is_ok()
+}
+
+/// The shape of a Tier-0 element type (§3). Variant set is exactly the spec's:
+/// `Var`/`Con`/`App`/`Quote`. The origin span lives on the enclosing [`Ty`].
+#[derive(Clone, Debug, PartialEq)]
+pub enum TyKind {
+    /// A type variable.
+    Var(TyVar),
+    /// A nullary base type, e.g. `Num`, `Bool`.
+    Con(String),
+    /// A parameterized type, e.g. `List a`. Added to the representation now;
+    /// the unifier grows support for it when first needed.
+    App(String, Vec<Ty>),
+    /// A quotation value, carrying an arrow. Tier-0 stores SHAPE ONLY; any Tier 1
+    /// refinement payload is added later and is never read by Tier-0 (§3).
+    Quote(Box<WordTy>),
+}
+
+/// A Tier-0 element type with its origin span (§3 invariant 2: every `Ty` carries
+/// the source span where it was *born*, so the checker can report a provenance
+/// pair instead of a bare failure site). The span is propagated through
+/// unification; it is **not** an M5 deliverable, it is a representation invariant.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ty {
+    /// The shape of this type.
+    pub kind: TyKind,
+    /// The source span where this type was born.
+    pub span: Span,
+}
+
+impl Ty {
+    /// A type variable born at `span`.
+    pub fn var(v: TyVar, span: Span) -> Self {
+        Ty {
+            kind: TyKind::Var(v),
+            span,
+        }
+    }
+
+    /// A base type born at `span`.
+    pub fn con(name: impl Into<String>, span: Span) -> Self {
+        Ty {
+            kind: TyKind::Con(name.into()),
+            span,
+        }
+    }
+
+    /// The `Num` base type born at `span`.
+    pub fn num(span: Span) -> Self {
+        Ty::con(NUM, span)
+    }
+
+    /// The `Bool` base type born at `span`.
+    pub fn bool(span: Span) -> Self {
+        Ty::con(BOOL, span)
+    }
+
+    /// A quotation value carrying `arrow`, born at `span`.
+    pub fn quote(arrow: WordTy, span: Span) -> Self {
+        Ty {
+            kind: TyKind::Quote(Box::new(arrow)),
+            span,
+        }
+    }
+}
+
+/// A Tier-0 stack type: an ordered list of element types with the **top of stack
+/// LAST**, terminated by a [`RowVar`] standing for the untouched tail (§2, §3).
+/// Carries an origin span (§3 invariant 2).
+#[derive(Clone, Debug, PartialEq)]
+pub struct StackTy {
+    /// Element types, top of stack last.
+    pub elems: Vec<Ty>,
+    /// The row variable standing for "whatever was underneath, untouched".
+    pub row: RowVar,
+    /// The source span where this stack type was born.
+    pub span: Span,
+}
+
+impl StackTy {
+    /// A stack type with no observed elements and tail `row`, born at `span`.
+    pub fn empty(row: RowVar, span: Span) -> Self {
+        StackTy {
+            elems: Vec::new(),
+            row,
+            span,
+        }
+    }
+
+    /// A stack type with the given elements (top last) and tail `row`.
+    pub fn new(elems: Vec<Ty>, row: RowVar, span: Span) -> Self {
+        StackTy { elems, row, span }
+    }
+}
+
+/// A word's type: an arrow between two stack types (§2, §3). A quotation value
+/// carries one of these inside [`TyKind::Quote`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct WordTy {
+    /// The stack before the word runs.
+    pub input: StackTy,
+    /// The stack after the word runs.
+    pub output: StackTy,
+}
+
+impl WordTy {
+    /// Construct an arrow from `input` to `output`.
+    pub fn new(input: StackTy, output: StackTy) -> Self {
+        WordTy { input, output }
+    }
+}
+
+/// A polymorphic type scheme: a [`WordTy`] generalized over type and row
+/// variables (§3). Operators are registered with a `Scheme`; definitions are
+/// generalized into one by the SCC pass (M3, later).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Scheme {
+    /// The generalized type variables.
+    pub tyvars: Vec<TyVar>,
+    /// The generalized row variables.
+    pub rowvars: Vec<RowVar>,
+    /// The body arrow.
+    pub ty: WordTy,
+}
+
+impl Scheme {
+    /// A scheme generalizing `ty` over `tyvars` and `rowvars`.
+    pub fn new(tyvars: Vec<TyVar>, rowvars: Vec<RowVar>, ty: WordTy) -> Self {
+        Scheme {
+            tyvars,
+            rowvars,
+            ty,
+        }
+    }
+
+    /// A monomorphic scheme (no generalized variables).
+    pub fn monomorphic(ty: WordTy) -> Self {
+        Scheme {
+            tyvars: Vec::new(),
+            rowvars: Vec::new(),
+            ty,
+        }
+    }
+}
+
+/// One entry in the substitution undo log: a slot and the value it held before
+/// the most recent binding (§3 invariant 1). Recording the *old* value is what
+/// lets [`Subst::rewind`] restore the arena to an earlier checkpoint.
+#[derive(Clone, Debug)]
+enum TrailEntry {
+    Ty(TyVar, Option<Ty>),
+    Row(RowVar, Option<StackTy>),
+}
+
+/// The flat Tier-0 substitution arena with a trailed undo log (§3 invariant 1,
+/// ratified decision (b)).
+///
+/// This is deliberately **not** a persistent HAMT and **not** destructive
+/// union-find. Bindings live in flat vectors indexed by variable id, giving
+/// O(1)/zero-allocation mutation; speculative inference backtracking is served
+/// by the trail: [`Subst::bind_ty`]/[`Subst::bind_row`] push `(slot, old_value)`,
+/// a [`Subst::checkpoint`] records the trail length, and [`Subst::rewind`]
+/// unwinds back to it.
+///
+/// A trail gives *undo*, not *queryable history*: after a rewind the bindings are
+/// gone. That is acceptable because the durable provenance spine is the
+/// [`FrameStack`] (§3 invariant 3), not the substitution.
+///
+/// **Tier-0 only.** This trail is not the Tier 1 logical-scope mechanism. Tier 1
+/// treats this map as read-only (§3 invariant 18); its `push_scope`/`pop_scope`
+/// belong to the (future) Z3 trait and shadow evaluator, never to this arena.
+#[derive(Clone, Debug, Default)]
+pub struct Subst {
+    ty_bindings: Vec<Option<Ty>>,
+    row_bindings: Vec<Option<StackTy>>,
+    trail: Vec<TrailEntry>,
+}
+
+impl Subst {
+    /// A fresh, empty substitution.
+    pub fn new() -> Self {
+        Subst::default()
+    }
+
+    fn ensure_ty_slot(&mut self, v: TyVar) {
+        let idx = v as usize;
+        if idx >= self.ty_bindings.len() {
+            self.ty_bindings.resize(idx + 1, None);
+        }
+    }
+
+    fn ensure_row_slot(&mut self, v: RowVar) {
+        let idx = v as usize;
+        if idx >= self.row_bindings.len() {
+            self.row_bindings.resize(idx + 1, None);
+        }
+    }
+
+    /// The current binding of a type variable, if any (one step, not chased).
+    pub fn get_ty(&self, v: TyVar) -> Option<&Ty> {
+        self.ty_bindings.get(v as usize).and_then(Option::as_ref)
+    }
+
+    /// The current binding of a row variable, if any (one step, not chased).
+    pub fn get_row(&self, v: RowVar) -> Option<&StackTy> {
+        self.row_bindings.get(v as usize).and_then(Option::as_ref)
+    }
+
+    /// Bind a type variable, recording the previous value on the trail so the
+    /// binding can be undone by [`Subst::rewind`].
+    pub fn bind_ty(&mut self, v: TyVar, ty: Ty) {
+        self.ensure_ty_slot(v);
+        let old = self.ty_bindings[v as usize].take();
+        self.trail.push(TrailEntry::Ty(v, old));
+        self.ty_bindings[v as usize] = Some(ty);
+    }
+
+    /// Bind a row variable, recording the previous value on the trail so the
+    /// binding can be undone by [`Subst::rewind`].
+    pub fn bind_row(&mut self, v: RowVar, stack: StackTy) {
+        self.ensure_row_slot(v);
+        let old = self.row_bindings[v as usize].take();
+        self.trail.push(TrailEntry::Row(v, old));
+        self.row_bindings[v as usize] = Some(stack);
+    }
+
+    /// Record a backtrack point: the current trail length. Pass the returned
+    /// value to [`Subst::rewind`] to undo every binding made since.
+    pub fn checkpoint(&self) -> usize {
+        self.trail.len()
+    }
+
+    /// Undo every binding made since `checkpoint`, restoring the arena exactly to
+    /// the state it had then. Bindings are restored in reverse order so nested
+    /// rebindings of the same slot unwind correctly.
+    pub fn rewind(&mut self, checkpoint: usize) {
+        while self.trail.len() > checkpoint {
+            match self
+                .trail
+                .pop()
+                .expect("trail length checked by loop guard")
+            {
+                TrailEntry::Ty(v, old) => {
+                    self.ty_bindings[v as usize] = old;
+                }
+                TrailEntry::Row(v, old) => {
+                    self.row_bindings[v as usize] = old;
+                }
+            }
+        }
+    }
+}
+
+/// One typing frame: the span and expected effect recorded on descent into a
+/// quotation `[ … ]` (§3 invariant 3).
+#[derive(Clone, Debug, PartialEq)]
+pub struct TypingFrame {
+    /// The span of the quotation whose checking this frame covers.
+    pub span: Span,
+    /// The effect expected at entry to the quotation.
+    pub expected: WordTy,
+}
+
+/// The typing-frame stack: the durable provenance spine (§3 invariant 3).
+///
+/// Descending into a quotation pushes a [`TypingFrame`] recording its span and
+/// expected effect; leaving it pops. The frame stack is the compile-time
+/// backtrace used for error breadcrumbs (§7) **and** the fallback for any
+/// provenance the substitution trail has unwound ([`Subst`] invariant 1: trail =
+/// inference speed, frames = error history).
+///
+/// Frames are a *logical* spine: although `pop` removes a frame from the live
+/// stack on scope exit, frame information persists in any diagnostic captured
+/// while the frame was live. The substitution may forget; the frame breadcrumb
+/// recorded into an error does not. This is why frames "persist across scope
+/// pops" — an error built from the frame stack keeps its breadcrumb after the
+/// frame leaves the live stack.
+#[derive(Clone, Debug, Default)]
+pub struct FrameStack {
+    frames: Vec<TypingFrame>,
+}
+
+impl FrameStack {
+    /// A fresh, empty frame stack.
+    pub fn new() -> Self {
+        FrameStack::default()
+    }
+
+    /// Push a frame on descent into a quotation.
+    pub fn push(&mut self, frame: TypingFrame) {
+        self.frames.push(frame);
+    }
+
+    /// Pop the innermost frame on leaving a quotation.
+    pub fn pop(&mut self) -> Option<TypingFrame> {
+        self.frames.pop()
+    }
+
+    /// The current nesting depth.
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// A snapshot of the live frames, innermost last. Used to capture a durable
+    /// breadcrumb into a diagnostic — the snapshot outlives later `pop`s.
+    pub fn breadcrumb(&self) -> Vec<TypingFrame> {
+        self.frames.clone()
+    }
+}
+
+/// The Tier-0 inference context: a fresh-variable allocator, the substitution
+/// arena, and the typing-frame stack. Holds the §3 substrate together so later
+/// milestones (M1 unifier, M2 inference) build on one coherent state.
+#[derive(Clone, Debug, Default)]
+pub struct InferCtx {
+    /// The flat substitution arena + trail.
+    pub subst: Subst,
+    /// The durable typing-frame stack.
+    pub frames: FrameStack,
+    next_ty: TyVar,
+    next_row: RowVar,
+}
+
+impl InferCtx {
+    /// A fresh inference context.
+    pub fn new() -> Self {
+        InferCtx::default()
+    }
+
+    /// Allocate a fresh type variable.
+    pub fn fresh_ty(&mut self) -> TyVar {
+        let v = self.next_ty;
+        self.next_ty += 1;
+        v
+    }
+
+    /// Allocate a fresh row variable.
+    pub fn fresh_row(&mut self) -> RowVar {
+        let v = self.next_row;
+        self.next_row += 1;
+        v
+    }
+
+    /// The Tier-0 initial program stack type: the identity arrow `( 'a -- 'a )`
+    /// over one fresh row variable, with empty observed elements. This is the
+    /// effect a whole-program `main` entry must close against (§12: "Initial
+    /// stack for a top-level program is empty"). Both `input` and `output` share
+    /// the same fresh row var, encoding "starts empty, ends empty modulo the
+    /// untouched tail".
+    pub fn empty_program_effect(&mut self, span: Span) -> WordTy {
+        let row = self.fresh_row();
+        WordTy::new(StackTy::empty(row, span), StackTy::empty(row, span))
+    }
+
+    /// Instantiate a [`Scheme`] with fresh variables, demonstrating that a
+    /// registered operator's scheme is *usable*: each generalized variable is
+    /// renamed to a fresh one so distinct uses do not alias (§5 `instantiate`).
+    /// The returned [`WordTy`] re-spans nothing; nodes keep their birth spans.
+    pub fn instantiate(&mut self, scheme: &Scheme) -> WordTy {
+        let ty_map: Vec<(TyVar, TyVar)> = scheme
+            .tyvars
+            .iter()
+            .map(|&old| (old, self.fresh_ty()))
+            .collect();
+        let row_map: Vec<(RowVar, RowVar)> = scheme
+            .rowvars
+            .iter()
+            .map(|&old| (old, self.fresh_row()))
+            .collect();
+        rename_word(&scheme.ty, &ty_map, &row_map)
+    }
+}
+
+/// A failure raised by the Tier-0 unifier (§4, §7).
+///
+/// Both variants carry **origin spans**, not a single failure site: §7's first
+/// requirement is a *provenance pair*. A `Mismatch` holds the birth span of each
+/// of the two conflicting types; a `Cyclic` holds the span of the offending node
+/// that closed the loop. Internal variable names are never surfaced here — the
+/// `detail` strings describe shapes (`Num`, `Bool`, an arrow), never `'t7` (§7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnifyError {
+    /// Two element types could not be made equal. `left`/`right` describe the two
+    /// conflicting shapes; `left_span`/`right_span` are where each was born.
+    Mismatch {
+        /// Human-readable description of the left shape (never a variable name).
+        left: String,
+        /// Birth span of the left type.
+        left_span: Span,
+        /// Human-readable description of the right shape (never a variable name).
+        right: String,
+        /// Birth span of the right type.
+        right_span: Span,
+    },
+    /// A type/row variable was about to be bound to a term that contains it: a
+    /// cyclic (infinite) type. Rejected cleanly per §4 / §13 invariant 4.
+    Cyclic {
+        /// A description of the offending term's shape (never a variable name).
+        detail: String,
+        /// The span of the node that closed the cycle.
+        span: Span,
+    },
+}
+
+impl std::fmt::Display for UnifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnifyError::Mismatch {
+                left,
+                left_span,
+                right,
+                right_span,
+            } => write!(
+                f,
+                "type mismatch: `{left}` (from byte {}) cannot unify with `{right}` (from byte {})",
+                left_span.start, right_span.start
+            ),
+            UnifyError::Cyclic { detail, span } => write!(
+                f,
+                "cyclic type: a type would contain itself (`{detail}` at byte {})",
+                span.start
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UnifyError {}
+
+/// The recursion guard for unification and the occurs check (§4 / §13 invariant
+/// 4). With occurs-before-every-bind the substitution graph stays acyclic, so
+/// honest terms terminate well within this bound; the cap exists so a malicious
+/// or accidental cyclic program degrades to a *typed cyclic-type error* instead
+/// of a compiler stack overflow.
+const UNIFY_MAX_DEPTH: usize = 10_000;
+
+/// Render a type's shape for a diagnostic, without leaking internal variable
+/// names (§7: never surface `'t7`). A variable renders as the neutral word
+/// `a value`; concrete shapes render structurally.
+fn describe_ty(ty: &Ty) -> String {
+    match &ty.kind {
+        TyKind::Var(_) => "a value".to_string(),
+        TyKind::Con(name) => name.clone(),
+        TyKind::App(name, args) => {
+            if args.is_empty() {
+                name.clone()
+            } else {
+                let inner: Vec<String> = args.iter().map(describe_ty).collect();
+                format!("{name} {}", inner.join(" "))
+            }
+        }
+        TyKind::Quote(_) => "a quotation".to_string(),
+    }
+}
+
+impl InferCtx {
+    /// Chase top-level type-variable bindings to a representative: the result is
+    /// either a non-`Var` shape or an unbound `Var`. Interiors are **not**
+    /// rewritten — callers that need deep canonicalization recurse themselves
+    /// (occurs and `describe`). This is the "canonicalize, then check" step §4
+    /// mandates before the occurs check.
+    pub fn resolve_ty(&self, ty: &Ty) -> Ty {
+        let mut cur = ty.clone();
+        let mut guard = 0usize;
+        while let TyKind::Var(v) = cur.kind {
+            match self.subst.get_ty(v) {
+                Some(bound) => {
+                    cur = bound.clone();
+                    guard += 1;
+                    if guard > UNIFY_MAX_DEPTH {
+                        // An acyclic substitution can never loop here; bail to a
+                        // representative rather than spin.
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        cur
+    }
+
+    /// Fully resolve a stack type: chase every row binding so all observed
+    /// elements are exposed and the resulting `row` is an *unbound* row variable.
+    ///
+    /// A row stands for "whatever is underneath, untouched"; if `s.row` is bound
+    /// to `StackTy { elems2, row2 }`, those `elems2` sit **below** `s.elems`
+    /// (top-of-stack is last), so the flattened element list is
+    /// `elems2 ++ s.elems` and the tail chases on to `row2`.
+    pub fn resolve_stack(&self, s: &StackTy) -> StackTy {
+        let mut elems = s.elems.clone();
+        let mut row = s.row;
+        let span = s.span;
+        let mut guard = 0usize;
+        while let Some(bound) = self.subst.get_row(row) {
+            let mut prefix = bound.elems.clone();
+            prefix.extend(elems);
+            elems = prefix;
+            row = bound.row;
+            guard += 1;
+            if guard > UNIFY_MAX_DEPTH {
+                break;
+            }
+        }
+        StackTy { elems, row, span }
+    }
+
+    /// Occurs check for a **type** variable: does `v` appear anywhere in `term`,
+    /// after canonicalization? Recurses **uniformly into both stack types of every
+    /// `Quote` arrow** (§4: "do not skip arrow interiors"). Depth-bounded so a
+    /// pathological term cannot overflow the stack (§13 invariant 4).
+    fn occurs_ty(&self, v: TyVar, term: &Ty, depth: usize) -> bool {
+        if depth > UNIFY_MAX_DEPTH {
+            return true;
+        }
+        let term = self.resolve_ty(term);
+        match &term.kind {
+            TyKind::Var(u) => *u == v,
+            TyKind::Con(_) => false,
+            TyKind::App(_, args) => args.iter().any(|a| self.occurs_ty(v, a, depth + 1)),
+            TyKind::Quote(w) => {
+                self.occurs_ty_in_stack(v, &w.input, depth + 1)
+                    || self.occurs_ty_in_stack(v, &w.output, depth + 1)
+            }
+        }
+    }
+
+    /// Occurs check for a type variable, scanning a stack's element types (a row
+    /// variable lives in a different namespace, so only elements can hold `v`).
+    fn occurs_ty_in_stack(&self, v: TyVar, s: &StackTy, depth: usize) -> bool {
+        if depth > UNIFY_MAX_DEPTH {
+            return true;
+        }
+        let s = self.resolve_stack(s);
+        s.elems.iter().any(|e| self.occurs_ty(v, e, depth + 1))
+    }
+
+    /// Occurs check for a **row** variable over a stack type: does `v` appear as
+    /// the tail of this stack, or inside any `Quote` interior reachable from its
+    /// elements? Canonicalizes first and recurses uniformly through arrows.
+    fn occurs_row(&self, v: RowVar, s: &StackTy, depth: usize) -> bool {
+        if depth > UNIFY_MAX_DEPTH {
+            return true;
+        }
+        let s = self.resolve_stack(s);
+        if s.row == v {
+            return true;
+        }
+        s.elems
+            .iter()
+            .any(|e| self.occurs_row_in_ty(v, e, depth + 1))
+    }
+
+    /// Occurs check for a row variable, descending into a type's `Quote` interiors.
+    fn occurs_row_in_ty(&self, v: RowVar, term: &Ty, depth: usize) -> bool {
+        if depth > UNIFY_MAX_DEPTH {
+            return true;
+        }
+        let term = self.resolve_ty(term);
+        match &term.kind {
+            TyKind::Var(_) | TyKind::Con(_) => false,
+            TyKind::App(_, args) => args.iter().any(|a| self.occurs_row_in_ty(v, a, depth + 1)),
+            TyKind::Quote(w) => {
+                self.occurs_row(v, &w.input, depth + 1) || self.occurs_row(v, &w.output, depth + 1)
+            }
+        }
+    }
+
+    /// Bind a type variable to a term, doing the full §4 sequence:
+    /// (1) canonicalize the term, (2) run the occurs check, (3) on a positive
+    /// occurrence emit a typed cyclic-type error, (4) otherwise write the binding.
+    fn bind_ty_checked(&mut self, v: TyVar, term: &Ty) -> Result<(), UnifyError> {
+        let term = self.resolve_ty(term);
+        if let TyKind::Var(u) = term.kind
+            && u == v
+        {
+            return Ok(());
+        }
+        if self.occurs_ty(v, &term, 0) {
+            return Err(UnifyError::Cyclic {
+                detail: describe_ty(&term),
+                span: term.span,
+            });
+        }
+        self.subst.bind_ty(v, term);
+        Ok(())
+    }
+
+    /// Bind a row variable to a stack, with the same canonicalize-then-occurs
+    /// discipline as [`InferCtx::bind_ty_checked`].
+    fn bind_row_checked(&mut self, v: RowVar, stack: &StackTy) -> Result<(), UnifyError> {
+        let stack = self.resolve_stack(stack);
+        if stack.elems.is_empty() && stack.row == v {
+            return Ok(());
+        }
+        if self.occurs_row(v, &stack, 0) {
+            return Err(UnifyError::Cyclic {
+                detail: "a stack that contains itself".to_string(),
+                span: stack.span,
+            });
+        }
+        self.subst.bind_row(v, stack);
+        Ok(())
+    }
+
+    /// Unify two row variables: equal ⇒ done; else bind one to the other (as an
+    /// empty stack carrying the other row), via the checked bind path.
+    fn unify_row(&mut self, a: RowVar, b: RowVar, span: Span) -> Result<(), UnifyError> {
+        if a == b {
+            return Ok(());
+        }
+        self.bind_row_checked(a, &StackTy::empty(b, span))
+    }
+
+    /// Unify two element types (§4 `unify_ty`).
+    ///
+    /// `Var` binds (via the checked bind path); `Con(n)`/`Con(m)` agree iff
+    /// `n == m`; `App` agrees iff same head + arity, then unifies args pairwise;
+    /// `Quote(p)`/`Quote(q)` unifies `p.input ~ q.input` **and**
+    /// `p.output ~ q.output` component-wise (it does **not** generalize here); any
+    /// other pairing is a typed mismatch carrying both origin spans (§7). No
+    /// label/record/field machinery exists (§13 invariant 3).
+    pub fn unify_ty(&mut self, a: &Ty, b: &Ty) -> Result<(), UnifyError> {
+        self.unify_ty_d(a, b, 0)
+    }
+
+    fn unify_ty_d(&mut self, a: &Ty, b: &Ty, depth: usize) -> Result<(), UnifyError> {
+        if depth > UNIFY_MAX_DEPTH {
+            return Err(UnifyError::Cyclic {
+                detail: describe_ty(a),
+                span: a.span,
+            });
+        }
+        let a = self.resolve_ty(a);
+        let b = self.resolve_ty(b);
+        match (&a.kind, &b.kind) {
+            (TyKind::Var(va), TyKind::Var(vb)) if va == vb => Ok(()),
+            (TyKind::Var(va), _) => self.bind_ty_checked(*va, &b),
+            (_, TyKind::Var(vb)) => self.bind_ty_checked(*vb, &a),
+            (TyKind::Con(n), TyKind::Con(m)) => {
+                if n == m {
+                    Ok(())
+                } else {
+                    Err(UnifyError::Mismatch {
+                        left: describe_ty(&a),
+                        left_span: a.span,
+                        right: describe_ty(&b),
+                        right_span: b.span,
+                    })
+                }
+            }
+            (TyKind::App(n, xs), TyKind::App(m, ys)) => {
+                if n != m || xs.len() != ys.len() {
+                    return Err(UnifyError::Mismatch {
+                        left: describe_ty(&a),
+                        left_span: a.span,
+                        right: describe_ty(&b),
+                        right_span: b.span,
+                    });
+                }
+                for (x, y) in xs.iter().zip(ys.iter()) {
+                    self.unify_ty_d(x, y, depth + 1)?;
+                    // Re-resolve happens lazily inside unify_ty_d via resolve_ty.
+                }
+                Ok(())
+            }
+            (TyKind::Quote(p), TyKind::Quote(q)) => {
+                // Component-wise; no generalization here (§4).
+                self.unify_stack_d(&p.input, &q.input, depth + 1)?;
+                self.unify_stack_d(&p.output, &q.output, depth + 1)
+            }
+            _ => Err(UnifyError::Mismatch {
+                left: describe_ty(&a),
+                left_span: a.span,
+                right: describe_ty(&b),
+                right_span: b.span,
+            }),
+        }
+    }
+
+    /// Unify two stack types head-directed (§4 `unify_stack`).
+    ///
+    /// Peel matching elements from the **top** (last element first), re-applying
+    /// the substitution after each step; then if both sides are exhausted unify
+    /// the tail rows, and if exactly one side is exhausted let its row **absorb**
+    /// the other side's remaining elements + row.
+    pub fn unify_stack(&mut self, a: &StackTy, b: &StackTy) -> Result<(), UnifyError> {
+        self.unify_stack_d(a, b, 0)
+    }
+
+    fn unify_stack_d(&mut self, a: &StackTy, b: &StackTy, depth: usize) -> Result<(), UnifyError> {
+        if depth > UNIFY_MAX_DEPTH {
+            return Err(UnifyError::Cyclic {
+                detail: "a stack that contains itself".to_string(),
+                span: a.span,
+            });
+        }
+        // Canonicalize both sides so any row already bound to a concrete stack
+        // exposes its elements before we peel (transitive canonicalization, §4).
+        let mut ra = self.resolve_stack(a);
+        let mut rb = self.resolve_stack(b);
+        while !ra.elems.is_empty() && !rb.elems.is_empty() {
+            // pop_last from each (top of stack) and unify.
+            let ta = ra.elems.pop().expect("nonempty checked by loop guard");
+            let tb = rb.elems.pop().expect("nonempty checked by loop guard");
+            self.unify_ty_d(&ta, &tb, depth + 1)?;
+            // Re-apply the substitution: a binding made above may turn a row into
+            // a longer stack, so re-resolve before the next peel.
+            ra = self.resolve_stack(&ra);
+            rb = self.resolve_stack(&rb);
+        }
+        if ra.elems.is_empty() && rb.elems.is_empty() {
+            self.unify_row(ra.row, rb.row, ra.span)
+        } else if ra.elems.is_empty() {
+            // ra is just a row; absorb rb's remaining elems + row.
+            self.bind_row_checked(ra.row, &rb)
+        } else {
+            self.bind_row_checked(rb.row, &ra)
+        }
+    }
+}
+
+fn map_ty(v: TyVar, ty_map: &[(TyVar, TyVar)]) -> TyVar {
+    ty_map
+        .iter()
+        .find(|(old, _)| *old == v)
+        .map(|(_, new)| *new)
+        .unwrap_or(v)
+}
+
+fn map_row(v: RowVar, row_map: &[(RowVar, RowVar)]) -> RowVar {
+    row_map
+        .iter()
+        .find(|(old, _)| *old == v)
+        .map(|(_, new)| *new)
+        .unwrap_or(v)
+}
+
+fn rename_ty(ty: &Ty, ty_map: &[(TyVar, TyVar)], row_map: &[(RowVar, RowVar)]) -> Ty {
+    let kind = match &ty.kind {
+        TyKind::Var(v) => TyKind::Var(map_ty(*v, ty_map)),
+        TyKind::Con(name) => TyKind::Con(name.clone()),
+        TyKind::App(name, args) => TyKind::App(
+            name.clone(),
+            args.iter().map(|a| rename_ty(a, ty_map, row_map)).collect(),
+        ),
+        TyKind::Quote(arrow) => TyKind::Quote(Box::new(rename_word(arrow, ty_map, row_map))),
+    };
+    Ty {
+        kind,
+        span: ty.span,
+    }
+}
+
+fn rename_stack(
+    stack: &StackTy,
+    ty_map: &[(TyVar, TyVar)],
+    row_map: &[(RowVar, RowVar)],
+) -> StackTy {
+    StackTy {
+        elems: stack
+            .elems
+            .iter()
+            .map(|e| rename_ty(e, ty_map, row_map))
+            .collect(),
+        row: map_row(stack.row, row_map),
+        span: stack.span,
+    }
+}
+
+fn rename_word(word: &WordTy, ty_map: &[(TyVar, TyVar)], row_map: &[(RowVar, RowVar)]) -> WordTy {
+    WordTy {
+        input: rename_stack(&word.input, ty_map, row_map),
+        output: rename_stack(&word.output, ty_map, row_map),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sp() -> Span {
+        Span { start: 0, end: 1 }
+    }
+
+    #[test]
+    fn every_node_carries_a_span_from_parser() {
+        // The span type is parser::Span re-exported; no invented span type.
+        let s = sp();
+        let t = Ty::num(s);
+        assert_eq!(t.span, s);
+        let st = StackTy::new(vec![Ty::num(s), Ty::var(0, s)], 0, s);
+        assert_eq!(st.span, s);
+        for e in &st.elems {
+            assert_eq!(e.span, s);
+        }
+    }
+
+    #[test]
+    fn stack_top_is_last() {
+        let s = sp();
+        // ( 'S a b ) with top-of-stack b last.
+        let st = StackTy::new(vec![Ty::var(0, s), Ty::con("a", s), Ty::con("b", s)], 9, s);
+        assert_eq!(st.elems.last().unwrap().kind, TyKind::Con("b".into()));
+    }
+
+    #[test]
+    fn subst_bind_and_read() {
+        let mut subst = Subst::new();
+        assert!(subst.get_ty(0).is_none());
+        subst.bind_ty(0, Ty::num(sp()));
+        assert_eq!(subst.get_ty(0).unwrap().kind, TyKind::Con(NUM.into()));
+        subst.bind_row(3, StackTy::empty(7, sp()));
+        assert_eq!(subst.get_row(3).unwrap().row, 7);
+    }
+
+    #[test]
+    fn trail_rewinds_to_checkpoint() {
+        let mut subst = Subst::new();
+        subst.bind_ty(0, Ty::num(sp()));
+        let cp = subst.checkpoint();
+        subst.bind_ty(1, Ty::bool(sp()));
+        subst.bind_row(2, StackTy::empty(5, sp()));
+        // rebind an already-bound slot; rewind must restore the OLD value.
+        subst.bind_ty(0, Ty::bool(sp()));
+        assert_eq!(subst.get_ty(0).unwrap().kind, TyKind::Con(BOOL.into()));
+
+        subst.rewind(cp);
+        // Everything since the checkpoint is undone.
+        assert_eq!(subst.get_ty(0).unwrap().kind, TyKind::Con(NUM.into()));
+        assert!(subst.get_ty(1).is_none());
+        assert!(subst.get_row(2).is_none());
+    }
+
+    #[test]
+    fn frames_push_pop_and_breadcrumb_persists() {
+        let s = sp();
+        let mut frames = FrameStack::new();
+        let effect = WordTy::new(StackTy::empty(0, s), StackTy::empty(0, s));
+        frames.push(TypingFrame {
+            span: s,
+            expected: effect.clone(),
+        });
+        assert_eq!(frames.depth(), 1);
+        // Capture a breadcrumb while the frame is live...
+        let crumb = frames.breadcrumb();
+        // ...then pop the frame off the live stack.
+        frames.pop();
+        assert_eq!(frames.depth(), 0);
+        // The captured breadcrumb still carries the frame (durable spine).
+        assert_eq!(crumb.len(), 1);
+        assert_eq!(crumb[0].span, s);
+    }
+
+    #[test]
+    fn instantiate_renames_to_fresh_vars() {
+        let s = sp();
+        // Scheme: ( 'R a -- 'R a a ) generalized over row 0 and ty 0 (DUP-like).
+        let input = StackTy::new(vec![Ty::var(0, s)], 0, s);
+        let output = StackTy::new(vec![Ty::var(0, s), Ty::var(0, s)], 0, s);
+        let scheme = Scheme::new(vec![0], vec![0], WordTy::new(input, output));
+
+        let mut ctx = InferCtx::new();
+        let a = ctx.instantiate(&scheme);
+        let b = ctx.instantiate(&scheme);
+
+        // Two instantiations must not share variables.
+        let row_a = a.input.row;
+        let row_b = b.input.row;
+        assert_ne!(row_a, row_b);
+        // Within one instantiation the shared variable stays shared.
+        assert_eq!(a.output.elems[0].kind, a.output.elems[1].kind);
+    }
+
+    #[test]
+    fn empty_program_effect_is_identity_over_one_row() {
+        let mut ctx = InferCtx::new();
+        let eff = ctx.empty_program_effect(sp());
+        assert!(eff.input.elems.is_empty());
+        assert!(eff.output.elems.is_empty());
+        assert_eq!(eff.input.row, eff.output.row);
+    }
+
+    // ----- §12 M1 acceptance: the unifier -----
+
+    /// Helper: a row-only stack `( 'row -- )` shape born at `sp()`.
+    fn row_stack(row: RowVar, elems: Vec<Ty>) -> StackTy {
+        StackTy::new(elems, row, sp())
+    }
+
+    #[test]
+    fn m1_top_peel_unifies_distinct_rows() {
+        // ( 'a Num ) vs ( 'b Num ): peel the Num pair, then 'a ~ 'b.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let a = row_stack(0, vec![Ty::num(s)]);
+        let b = row_stack(1, vec![Ty::num(s)]);
+        ctx.unify_stack(&a, &b).expect("top-peel must unify");
+        // 'a and 'b are now the same row: resolving 'a's tail reaches 'b (or
+        // vice-versa). Unifying the two bare rows again is a no-op.
+        let ra = ctx.resolve_stack(&row_stack(0, vec![]));
+        let rb = ctx.resolve_stack(&row_stack(1, vec![]));
+        assert_eq!(ra.row, rb.row, "'a and 'b must canonicalize to one row");
+    }
+
+    #[test]
+    fn m1_mismatched_head_is_a_typed_mismatch() {
+        // ( 'a Num ) vs ( 'b Bool ): the heads conflict; provenance pair reported.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let a = row_stack(0, vec![Ty::num(s)]);
+        let b = row_stack(1, vec![Ty::bool(s)]);
+        let err = ctx.unify_stack(&a, &b).unwrap_err();
+        match err {
+            UnifyError::Mismatch { left, right, .. } => {
+                assert!(left == NUM || right == NUM);
+                assert!(left == BOOL || right == BOOL);
+            }
+            other => panic!("expected a typed mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn m1_row_absorption_binds_the_short_row() {
+        // ( 'a -- ) unifies with ( 'b Num Bool -- ) by 'a := 'b Num Bool.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let a = row_stack(0, vec![]);
+        let b = row_stack(1, vec![Ty::num(s), Ty::bool(s)]);
+        ctx.unify_stack(&a, &b).expect("row absorption must unify");
+        // Resolving 'a now exposes [Num, Bool] over row 'b.
+        let ra = ctx.resolve_stack(&row_stack(0, vec![]));
+        assert_eq!(ra.row, 1, "'a's tail must be 'b after absorption");
+        assert_eq!(ra.elems.len(), 2);
+        assert_eq!(ra.elems[0].kind, TyKind::Con(NUM.into()));
+        assert_eq!(ra.elems[1].kind, TyKind::Con(BOOL.into()));
+    }
+
+    #[test]
+    fn m1_transitive_canonicalization_no_false_cyclic() {
+        // 'r1 -> 'r2 -> concrete: a further unification canonicalizes correctly
+        // before the occurs check, with no false cyclic rejection.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        // Bind 'r1 := ( 'r2 ), then 'r2 := ( 'r3 Num ).
+        ctx.subst.bind_row(1, StackTy::empty(2, s));
+        ctx.subst.bind_row(2, StackTy::new(vec![Ty::num(s)], 3, s));
+        // Resolving 'r1 should expose [Num] over 'r3 (transitive chase).
+        let r1 = ctx.resolve_stack(&row_stack(1, vec![]));
+        assert_eq!(r1.elems.len(), 1);
+        assert_eq!(r1.row, 3);
+        // Now unify ( 'r1 ) with ( 'b Num ): the Num peels, leaving 'r3 ~ 'b.
+        let lhs = row_stack(1, vec![]);
+        let rhs = row_stack(4, vec![Ty::num(s)]);
+        ctx.unify_stack(&lhs, &rhs)
+            .expect("transitive canonicalization must unify without false cyclic");
+    }
+
+    #[test]
+    fn m1_occurs_rejects_a_eq_a_num() {
+        // 'a := App("Num", ['a]) — 'a occurs inside the term it is bound to.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let a = Ty::var(0, s);
+        let a_num = Ty {
+            kind: TyKind::App(NUM.into(), vec![Ty::var(0, s)]),
+            span: s,
+        };
+        let err = ctx.unify_ty(&a, &a_num).unwrap_err();
+        assert!(
+            matches!(err, UnifyError::Cyclic { .. }),
+            "occurs must reject 'a := 'a Num as cyclic, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn m1_cyclic_via_arrows_is_clean_rejection_no_overflow() {
+        // `[ DUP CALL ] DUP CALL` forces a ~ ( 'X a -- 'Y ): a type variable that
+        // must equal an arrow whose INPUT contains that very variable. Occurs
+        // recurses into the Quote interior and rejects cleanly — no overflow.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let a = Ty::var(0, s); // the quote value on the stack
+        // arrow ( 'X a -- 'Y ) with 'a (var 0) appearing in the input stack.
+        let arrow = WordTy::new(
+            StackTy::new(vec![Ty::var(0, s)], 10, s), // input: 'X a   (a == var 0)
+            StackTy::empty(11, s),                    // output: 'Y
+        );
+        let quote = Ty::quote(arrow, s);
+        let err = ctx.unify_ty(&a, &quote).unwrap_err();
+        assert!(
+            matches!(err, UnifyError::Cyclic { .. }),
+            "cyclic-via-arrows must be a typed cyclic-type error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn m1_quote_arrows_unify_component_wise() {
+        // Two quotation arrows unify by input AND output, component-wise.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        // ( 'a Num -- 'a Bool ) and ( 'c X -- 'c Y ): peeling forces X~Num, Y~Bool
+        // and the rows to agree.
+        let left = WordTy::new(
+            StackTy::new(vec![Ty::num(s)], 0, s),
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+        );
+        let right = WordTy::new(
+            StackTy::new(vec![Ty::var(0, s)], 1, s),
+            StackTy::new(vec![Ty::var(1, s)], 1, s),
+        );
+        ctx.unify_ty(&Ty::quote(left, s), &Ty::quote(right, s))
+            .expect("quote arrows must unify component-wise");
+        // var 0 ~ Num, var 1 ~ Bool.
+        assert_eq!(ctx.resolve_ty(&Ty::var(0, s)).kind, TyKind::Con(NUM.into()));
+        assert_eq!(
+            ctx.resolve_ty(&Ty::var(1, s)).kind,
+            TyKind::Con(BOOL.into())
+        );
+    }
+
+    #[test]
+    fn m1_quote_arrows_with_conflicting_components_mismatch() {
+        // ( -- Num ) vs ( -- Bool ) inside a quote: a typed mismatch, not silent.
+        let s = sp();
+        let mut ctx = InferCtx::new();
+        let left = WordTy::new(StackTy::empty(0, s), StackTy::new(vec![Ty::num(s)], 0, s));
+        let right = WordTy::new(StackTy::empty(1, s), StackTy::new(vec![Ty::bool(s)], 1, s));
+        let err = ctx
+            .unify_ty(&Ty::quote(left, s), &Ty::quote(right, s))
+            .unwrap_err();
+        assert!(matches!(err, UnifyError::Mismatch { .. }));
+    }
+
+    #[test]
+    fn m1_error_display_leaks_no_internal_variable_names() {
+        // §7: diagnostics must never surface internal variable names like 't7.
+        let s = Span { start: 5, end: 8 };
+        let err = UnifyError::Mismatch {
+            left: NUM.into(),
+            left_span: s,
+            right: BOOL.into(),
+            right_span: Span { start: 12, end: 16 },
+        };
+        let text = err.to_string();
+        assert!(
+            !text.contains('\''),
+            "no leading-quote variable names: {text}"
+        );
+        assert!(text.contains("byte 5") && text.contains("byte 12"));
+    }
+
+    #[test]
+    fn numeric_literal_decision_is_recorded() {
+        assert!(is_numeric_literal("1"));
+        assert!(is_numeric_literal("42"));
+        assert!(is_numeric_literal("-3.5"));
+        assert!(!is_numeric_literal("DUP"));
+        assert!(!is_numeric_literal(""));
+        // There is no core `+`: it is not a numeric literal and must arrive via
+        // registration.
+        assert!(!is_numeric_literal("+"));
+    }
+}


### PR DESCRIPTION
Implement the §4 head-directed unifier and occurs check on the existing
Tier-0 substrate (types.rs), and commit the previously-untracked M0
foundation (types.rs, check.rs) so it cannot be lost to a git clean.

- unify_stack/unify_ty (InferCtx): peel from the top, absorb the
  remainder via a row variable; Quote arrows unify by input AND output
  component-wise; no label/record machinery (§13 inv 3).
- occurs/occurs_stack: canonicalize-then-check, uniform through Quote
  interiors, depth-bounded so a cyclic program (e.g. [ DUP CALL ] DUP
  CALL) is rejected with a typed cyclic-type error, never a stack
  overflow (§13 inv 4).
- UnifyError carries provenance-pair / cyclic spans and leaks no internal
  variable names (§7).
- §12 M1 acceptance tests: top-peel, row absorption, transitive
  canonicalization, occurs rejects 'a := 'a Num, cyclic-via-arrows clean
  rejection.
- Thread REAL source spans into the checker: Evaluator::load_with_spans
  retains spanned definition bodies; check.rs walks SpannedToken and
  reports UnresolvedWord / typing-frame spans at true byte offsets, not
  Span{0,0} (§3 inv 2 / §13 inv 6).
- Clear the two pre-existing collapsible-if clippy warnings in load.

Co-authored-by: AI
