### PR TITLE
caternary: M14 — whole-program ledger + attestation hash + CI-gate/free-runtime (§10.10/§12 M14)

### DIFF
--- a/caternary/Cargo.toml
+++ b/caternary/Cargo.toml
@@ -30,3 +30,8 @@ required-features = ["binaries"]
 name = "m13_emission_parity"
 path = "examples/m13_emission_parity.rs"
 required-features = ["binaries"]
+
+[[example]]
+name = "m14_attestation"
+path = "examples/m14_attestation.rs"
+required-features = ["binaries"]

--- a/caternary/examples/m14_attestation.rs
+++ b/caternary/examples/m14_attestation.rs
@@ -1,0 +1,166 @@
+//! M14 — whole-program ledger + attestation hash + CI gate / free runtime
+//! (architecture section / §10.10 / §12 M14).
+//!
+//! This makes the final trust story inspectable end to end. It:
+//!   1. registers an embedder operator and loads a whole program of definitions,
+//!   2. prints the **one artifact attestation hash** of the contract set and
+//!      shows it is stable across a rebuild of the same source,
+//!   3. enumerates the **operator-table modulo** (language core + embedder),
+//!   4. enumerates the **one global ledger** of `assume`s and shows it equals
+//!      `grep assume` over the source, and
+//!   5. demonstrates a **warm-compile cache hit** on an unchanged obligation
+//!      (only the changed obligation re-solves).
+
+use caternary::*;
+
+/// A minimal stack value type so the program can both type-check and run.
+#[derive(Debug, Clone, PartialEq)]
+enum Value {
+    Word(String),
+    Bracket(Vec<Token>),
+    Num(f64),
+}
+
+impl From<Token> for Value {
+    fn from(token: Token) -> Self {
+        match token {
+            Token::Word(w) => match w.parse::<f64>() {
+                Ok(n) => Value::Num(n),
+                Err(_) => Value::Word(w),
+            },
+            Token::Bracket(b) => Value::Bracket(b),
+        }
+    }
+}
+
+impl Quotable for Value {
+    fn as_quotation(&self) -> Option<&[Token]> {
+        match self {
+            Value::Bracket(b) => Some(b),
+            _ => None,
+        }
+    }
+    fn to_tokens(&self) -> Vec<Token> {
+        match self {
+            Value::Word(w) => vec![Token::Word(w.clone())],
+            Value::Bracket(b) => vec![Token::Bracket(b.clone())],
+            Value::Num(n) => vec![Token::Word(n.to_string())],
+        }
+    }
+    fn as_sequence(&self) -> Option<Vec<Self>> {
+        match self {
+            Value::Bracket(b) => Some(b.iter().map(|t| Value::from(t.clone())).collect()),
+            _ => None,
+        }
+    }
+    fn from_sequence(elements: Vec<Self>) -> Self {
+        Value::Bracket(elements.iter().flat_map(|v| v.to_tokens()).collect())
+    }
+}
+
+fn plus_scheme() -> Scheme {
+    let s = Span { start: 0, end: 1 };
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::num(s), Ty::num(s)], 0, s),
+            StackTy::new(vec![Ty::num(s)], 0, s),
+        ),
+    )
+}
+
+fn build(src: &str) -> Evaluator<Value> {
+    let mut eval: Evaluator<Value> = Evaluator::new();
+    eval.register_operator_with_contract("+", plus_scheme());
+    let toks = parse_with_spans(src).unwrap();
+    eval.load_with_spans(&toks).unwrap();
+    eval
+}
+
+fn ge(a: &str, k: &str) -> Pred {
+    Pred::Bin(
+        BinOp::Ge,
+        Box::new(Pred::Var(a.into())),
+        Box::new(Pred::Num(k.into())),
+    )
+}
+
+fn main() {
+    // A small whole program: `inc` adds one, `main` calls it.
+    let src = "[ 1 + ] :inc [ 2 inc ] :main";
+    let eval = build(src);
+
+    // (1) The CI gate: full Tier-0 verification pays at build time.
+    check(&eval).expect("the program is checked");
+    println!("== caternary check: PASS (build-time gate) ==\n");
+
+    // (2) The one artifact attestation hash, stable across rebuilds.
+    let h1 = attestation_hash(&eval).unwrap();
+    let h2 = attestation_hash(&build(src)).unwrap();
+    println!("whole-program attestation hash: {h1:#018x}");
+    println!("rebuild of unchanged source:   {h2:#018x}");
+    println!("stable across rebuilds:        {}\n", h1 == h2);
+
+    // (3) The operator-table modulo of every proof.
+    let table = OperatorTable::of(&eval);
+    println!("operator table (the modulo of every proof):");
+    for entry in table.entries() {
+        println!("  [{:>8}] {}", entry.origin.tag(), entry.name);
+    }
+    println!();
+
+    // (4) The one global ledger of assumes = grep assume over the source.
+    let foo_body = parse("opaque \"assume(result >= 0)\" sqrt").unwrap();
+    let defs = vec![Definition {
+        name: "foo".into(),
+        body: foo_body.clone(),
+        sig: None,
+    }];
+    let lookup = |w: &str| match w {
+        "sqrt" => parse_signature("sqrt : ( n: Num where n >= 0  --  r: Num )").ok(),
+        _ => None,
+    };
+    let ledger = check_program(&defs, &lookup, SmtLibSolver::new).unwrap();
+    println!("one global ledger — complete user trusted base:");
+    for surface in ledger.grep_assume() {
+        println!("  {surface}");
+    }
+    println!(
+        "grep assume over source:       {:?}",
+        grep_assume_tokens(&foo_body)
+    );
+    println!("foo's honest status:           {}\n", ledger.status("foo"));
+
+    // (5) Warm-compile reuse: only the changed obligation re-solves.
+    let mut cache = ExploratoryCache::new();
+    let obligations = [ge("x", "0"), ge("y", "0")];
+    {
+        let mut solver = SmtLibSolver::new();
+        for g in &obligations {
+            cache.discharge_obligation(&mut solver, g);
+        }
+    }
+    println!(
+        "cold compile: solves={} hits={}",
+        cache.solves(),
+        cache.hits()
+    );
+    {
+        // Re-run with one unchanged + one changed obligation.
+        let mut solver = SmtLibSolver::new();
+        let _ = cache.discharge_obligation(&mut solver, &obligations[0]); // unchanged ⇒ hit
+        let changed = ge("z", "0");
+        let _ = cache.discharge_obligation(&mut solver, &changed); // new ⇒ solve
+    }
+    println!(
+        "warm compile: solves={} hits={}",
+        cache.solves(),
+        cache.hits()
+    );
+    println!("(only the changed obligation re-solved; the unchanged one was reused)");
+
+    // Per-obligation sub-hashes are stable fingerprints of the exact cache keys.
+    let sub = obligation_sub_hash(&obligations[0], &[]);
+    println!("\nper-obligation sub-hash of `x >= 0`: {sub:#018x}");
+}

--- a/caternary/src/attestation.rs
+++ b/caternary/src/attestation.rs
@@ -1,0 +1,329 @@
+//! M14 — whole-program ledger + attestation hash + CI-gate / free-runtime model
+//! (architecture section / §10.10 / §12 M14 / invariants 14–17, 20).
+//!
+//! This is the final milestone. It does not introduce a new verification
+//! mechanism; it makes the *trust story* of the whole-program / embeddable /
+//! operator-contracted design **enumerable and content-addressable**:
+//!
+//! 1. **One global ledger** ([`crate::Ledger`], M12): every `assume` in the
+//!    program lands in one structure, so `grep assume` over the source
+//!    enumerates the *complete* user trusted base — there are no modules to
+//!    reconcile (invariant 15). [`grep_assume_tokens`] is the source-side
+//!    `grep`; a test asserts it equals the ledger's accepted entries for a clean
+//!    program.
+//! 2. **The operator table is the modulo of every proof** (invariants 16/17):
+//!    the language-core primitives ([`crate::core_scheme`]) plus the embedder's
+//!    [`crate::Evaluator::register_operator_with_contract`] entries. [`OperatorTable`]
+//!    enumerates exactly that set — the enumerable statement of *"proven sound
+//!    modulo these attested contracts."*
+//! 3. **One artifact attestation hash** ([`ContractSet::attestation_hash`]):
+//!    a content-hash of the whole-program contract set — every generalized
+//!    definition signature (M3 schemes) plus the operator table — **stable across
+//!    rebuilds of unchanged source**. The discharge cache uses exact
+//!    per-obligation content keys; [`crate::obligation_sub_hash`] exposes the
+//!    corresponding M14 fingerprint, so changing one obligation invalidates only
+//!    its own cache entry (warm-compile reuse).
+//! 4. **CI gate; free runtime** (invariants 14/20): a *checked* program links no
+//!    solver (there is no `z3` crate in the dependency graph) and carries no
+//!    shadow-stack/solver machinery at runtime (the shadow stack is compile-time
+//!    only; it is never a field of [`crate::Evaluator`]). [`caternary check`] —
+//!    the public [`crate::check`] / [`crate::Evaluator::check_refinements`] path
+//!    — pays the entire verification cost at build time; these properties are
+//!    asserted structurally in the M14 tests below.
+
+use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use crate::Token;
+use crate::check::TypeError;
+use crate::combinators::Quotable;
+use crate::evaluator::Evaluator;
+use crate::refinement::ASSUME_PREFIX;
+use crate::types::Scheme;
+use crate::types::StackTy;
+use crate::types::Ty;
+use crate::types::TyKind;
+use crate::types::WordTy;
+use crate::types::core_scheme;
+
+const CORE_PRIMITIVES: &[&str] = &["DUP", "DROP", "SWAP", "OVER", "CALL", "DIP", "IF"];
+
+// ===========================================================================
+// The operator table — the modulo of every proof (invariants 16/17)
+// ===========================================================================
+
+/// Which of the **two registrants** attested an operator contract (architecture
+/// section / invariant 16). The user is neither — there is no third variant,
+/// because the user has no registration surface (the capability wall is the
+/// embedding API, structural).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OperatorOrigin {
+    /// The **language core** registered this irreducible primitive
+    /// (`DUP`/`DROP`/`SWAP`/`OVER`/`CALL`/`DIP`/`IF`), baked into
+    /// [`crate::core_scheme`] with its Tier-0 scheme (and Tier-1 axiom, §10.6).
+    LanguageCore,
+    /// The **embedder** registered this host operator at embed time via
+    /// [`crate::Evaluator::register_operator_with_contract`] — an explicit
+    /// attestation that the host's Rust satisfies the contract (the FFI floor).
+    Embedder,
+}
+
+impl OperatorOrigin {
+    /// A stable tag for hashing/display (`"core"` / `"embedder"`).
+    pub fn tag(self) -> &'static str {
+        match self {
+            OperatorOrigin::LanguageCore => "core",
+            OperatorOrigin::Embedder => "embedder",
+        }
+    }
+}
+
+/// One attested operator contract — a row of the operator table (invariant 17).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorContract {
+    /// The operator name as written in Caternary source (UPPER_SNAKE_CASE for
+    /// core primitives, the registered name for embedder ops).
+    pub name: String,
+    /// Who attested it (language core vs. embedder).
+    pub origin: OperatorOrigin,
+    /// The attested Tier-0 [`Scheme`] — the type Caternary takes on faith.
+    pub scheme: Scheme,
+}
+
+/// The **operator table**: the complete, enumerable **modulo** of every
+/// Caternary proof (architecture section / invariants 16/17). It is the exact
+/// statement of *"this program is proven sound **modulo** these attested
+/// contracts"*: language-core primitives plus embedder registrations, and
+/// nothing else (the user cannot add to it).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OperatorTable {
+    entries: Vec<OperatorContract>,
+}
+
+impl OperatorTable {
+    /// Build the operator table of an [`Evaluator`]: the language-core primitives
+    /// ([`crate::core_scheme`], in fixed UPPER_SNAKE_CASE order) followed by the
+    /// embedder's registered contracts (sorted by name). The result is deterministic
+    /// for a fixed embedding — the input to the stable attestation hash.
+    pub fn of<T>(evaluator: &Evaluator<T>) -> Self {
+        let mut entries = Vec::new();
+        // Language core: every primitive that has a core scheme, in the fixed
+        // UPPER_SNAKE_CASE order (deterministic).
+        for runtime in CORE_PRIMITIVES {
+            if let Some(scheme) = core_scheme(runtime) {
+                entries.push(OperatorContract {
+                    name: (*runtime).to_string(),
+                    origin: OperatorOrigin::LanguageCore,
+                    scheme,
+                });
+            }
+        }
+        // Embedder: registered contracts, sorted by name for determinism.
+        let mut names: Vec<String> = evaluator.contract_names().map(String::from).collect();
+        names.sort();
+        for name in names {
+            if let Some(scheme) = evaluator.contract(&name) {
+                entries.push(OperatorContract {
+                    name,
+                    origin: OperatorOrigin::Embedder,
+                    scheme: scheme.clone(),
+                });
+            }
+        }
+        OperatorTable { entries }
+    }
+
+    /// Every attested contract, in deterministic order (core first, then embedder
+    /// by name). This enumeration *is* the modulo of every proof.
+    pub fn entries(&self) -> &[OperatorContract] {
+        &self.entries
+    }
+
+    /// The names of every attested operator, in table order.
+    pub fn names(&self) -> Vec<String> {
+        self.entries.iter().map(|e| e.name.clone()).collect()
+    }
+
+    /// The language-core half of the table (the irreducible primitives).
+    pub fn core(&self) -> impl Iterator<Item = &OperatorContract> {
+        self.entries
+            .iter()
+            .filter(|e| e.origin == OperatorOrigin::LanguageCore)
+    }
+
+    /// The embedder half of the table (host operators attested at embed time).
+    pub fn embedder(&self) -> impl Iterator<Item = &OperatorContract> {
+        self.entries
+            .iter()
+            .filter(|e| e.origin == OperatorOrigin::Embedder)
+    }
+
+    /// The number of attested contracts in the table.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the table is empty (no core primitives and no embedder ops).
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+// ===========================================================================
+// The whole-program contract set + its one artifact attestation hash
+// ===========================================================================
+
+/// The **whole-program contract set** (§12 M14): every generalized definition
+/// signature (M3 [`Scheme`]) plus the [`OperatorTable`]. This is exactly the set
+/// the architecture section says to content-hash into *one artifact attestation
+/// hash* for build reproducibility and the CI gate — there is no per-module
+/// `Cid` machinery, one program-level attestation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContractSet {
+    /// Generalized definition signatures, keyed by name (sorted iteration).
+    pub definitions: BTreeMap<String, Scheme>,
+    /// The operator table (the modulo).
+    pub operators: OperatorTable,
+}
+
+impl ContractSet {
+    /// Derive the whole-program contract set from a loaded [`Evaluator`]. This
+    /// runs the same SCC generalization pass [`crate::type_check`] runs, so a
+    /// program that does not type-check returns the same [`TypeError`]; a checked
+    /// program returns the full set. Reads the evaluator read-only (§3 barrier).
+    pub fn of<T>(evaluator: &Evaluator<T>) -> Result<Self, TypeError>
+    where
+        T: Quotable,
+    {
+        let schemes = crate::check::definition_schemes(evaluator)?;
+        Ok(ContractSet {
+            definitions: schemes.into_iter().collect(),
+            operators: OperatorTable::of(evaluator),
+        })
+    }
+
+    /// The **one artifact attestation hash** (§12 M14): a content-hash of the
+    /// whole contract set — every definition signature (canonicalized so a
+    /// variable-id renaming cannot perturb it) plus every operator-table entry.
+    /// **Stable across rebuilds of unchanged source**: the canonical rendering
+    /// drops origin spans and renumbers type/row variables in first-appearance
+    /// order, so the hash is a property of the *contracts*, not of inference's
+    /// internal counters.
+    pub fn attestation_hash(&self) -> u64 {
+        let mut h = DefaultHasher::new();
+        // Definitions, in sorted name order (BTreeMap iterates sorted).
+        h.write_usize(self.definitions.len());
+        for (name, scheme) in &self.definitions {
+            name.hash(&mut h);
+            canonical_scheme(scheme).hash(&mut h);
+        }
+        // Operator table, in table order (deterministic).
+        h.write_usize(self.operators.len());
+        for entry in self.operators.entries() {
+            entry.name.hash(&mut h);
+            entry.origin.tag().hash(&mut h);
+            canonical_scheme(&entry.scheme).hash(&mut h);
+        }
+        h.finish()
+    }
+}
+
+/// The whole-program artifact attestation hash for a loaded [`Evaluator`]
+/// (§12 M14): builds the [`ContractSet`] and hashes it. Convenience over
+/// [`ContractSet::of`] + [`ContractSet::attestation_hash`].
+pub fn attestation_hash<T>(evaluator: &Evaluator<T>) -> Result<u64, TypeError>
+where
+    T: Quotable,
+{
+    Ok(ContractSet::of(evaluator)?.attestation_hash())
+}
+
+// ---- canonical scheme rendering (stable across var-id renaming) ------------
+
+/// Canonicalize a [`Scheme`] to a stable string: type/row variables are
+/// renumbered in first-appearance order (input before output) and origin spans
+/// are dropped, so two structurally identical schemes with different internal
+/// variable ids — e.g. the same definition re-inferred on a rebuild — render
+/// identically. This is what makes [`ContractSet::attestation_hash`] reproducible.
+fn canonical_scheme(scheme: &Scheme) -> String {
+    let mut tymap: BTreeMap<u32, usize> = BTreeMap::new();
+    let mut rowmap: BTreeMap<u32, usize> = BTreeMap::new();
+    render_word(&scheme.ty, &mut tymap, &mut rowmap)
+}
+
+fn canon_id(map: &mut BTreeMap<u32, usize>, v: u32) -> usize {
+    let next = map.len();
+    *map.entry(v).or_insert(next)
+}
+
+fn render_word(
+    w: &WordTy,
+    tymap: &mut BTreeMap<u32, usize>,
+    rowmap: &mut BTreeMap<u32, usize>,
+) -> String {
+    format!(
+        "({} -- {})",
+        render_stack(&w.input, tymap, rowmap),
+        render_stack(&w.output, tymap, rowmap)
+    )
+}
+
+fn render_stack(
+    s: &StackTy,
+    tymap: &mut BTreeMap<u32, usize>,
+    rowmap: &mut BTreeMap<u32, usize>,
+) -> String {
+    let elems: Vec<String> = s
+        .elems
+        .iter()
+        .map(|e| render_ty(e, tymap, rowmap))
+        .collect();
+    format!("[{}|r{}]", elems.join(","), canon_id(rowmap, s.row))
+}
+
+fn render_ty(
+    t: &Ty,
+    tymap: &mut BTreeMap<u32, usize>,
+    rowmap: &mut BTreeMap<u32, usize>,
+) -> String {
+    match &t.kind {
+        TyKind::Var(v) => format!("t{}", canon_id(tymap, *v)),
+        TyKind::Con(n) => n.clone(),
+        TyKind::App(n, args) => {
+            let inner: Vec<String> = args.iter().map(|a| render_ty(a, tymap, rowmap)).collect();
+            format!("{n}({})", inner.join(","))
+        }
+        TyKind::Quote(w) => render_word(w, tymap, rowmap),
+    }
+}
+
+// ===========================================================================
+// grep assume — the source-side enumeration of the user trusted base
+// ===========================================================================
+
+/// Enumerate the `assume( … )` surfaces in a token body, recursing into
+/// quotations — the source-side `grep assume` (architecture section / invariant
+/// 15). Returns each surface verbatim (e.g. `assume(result>0)`), in source
+/// order. For a clean (checked) program this equals the global [`crate::Ledger`]'s
+/// accepted entries — there are no modules to reconcile, so one `grep` over the
+/// whole program *is* the complete user trusted base.
+pub fn grep_assume_tokens(tokens: &[Token]) -> Vec<String> {
+    let mut out = Vec::new();
+    walk_assume(tokens, &mut out);
+    out
+}
+
+fn walk_assume(tokens: &[Token], out: &mut Vec<String>) {
+    for t in tokens {
+        match t {
+            Token::Bracket(body) => walk_assume(body, out),
+            Token::Word(w) if w.starts_with(ASSUME_PREFIX) => out.push(w.clone()),
+            Token::Word(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/caternary/src/attestation/tests.rs
+++ b/caternary/src/attestation/tests.rs
@@ -1,0 +1,449 @@
+//! M14 acceptance tests (§12 M14): one global ledger / grep-assume parity, the
+//! operator table as the enumerable modulo, the whole-program attestation hash
+//! (stable across rebuilds; selective per-obligation content-key invalidation with
+//! warm-compile reuse), and the CI-gate / free-runtime structural guarantees.
+
+use super::*;
+
+use crate::BinOp;
+use crate::Definition;
+use crate::Evaluator;
+use crate::ExploratoryCache;
+use crate::Pred;
+use crate::SmtLibSolver;
+use crate::Solver;
+use crate::Span;
+use crate::Token;
+use crate::Verdict;
+use crate::check_program;
+use crate::obligation_sub_hash;
+use crate::parse;
+use crate::parse_with_spans;
+use crate::types::Scheme;
+use crate::types::StackTy;
+use crate::types::Ty;
+use crate::types::WordTy;
+
+// ----- test scaffolding -----------------------------------------------------
+
+/// A minimal stack value type for driver tests (mirrors the check.rs harness).
+#[derive(Debug, Clone, PartialEq)]
+enum Value {
+    Word(String),
+    Bracket(Vec<Token>),
+}
+
+impl From<Token> for Value {
+    fn from(token: Token) -> Self {
+        match token {
+            Token::Word(w) => Value::Word(w),
+            Token::Bracket(b) => Value::Bracket(b),
+        }
+    }
+}
+
+impl Quotable for Value {
+    fn as_quotation(&self) -> Option<&[Token]> {
+        match self {
+            Value::Bracket(b) => Some(b),
+            Value::Word(_) => None,
+        }
+    }
+    fn to_tokens(&self) -> Vec<Token> {
+        match self {
+            Value::Word(w) => vec![Token::Word(w.clone())],
+            Value::Bracket(b) => vec![Token::Bracket(b.clone())],
+        }
+    }
+    fn as_sequence(&self) -> Option<Vec<Self>> {
+        match self {
+            Value::Bracket(b) => Some(b.iter().map(|t| Value::from(t.clone())).collect()),
+            Value::Word(_) => None,
+        }
+    }
+    fn from_sequence(elements: Vec<Self>) -> Self {
+        Value::Bracket(elements.iter().flat_map(|v| v.to_tokens()).collect())
+    }
+}
+
+fn sp() -> Span {
+    Span { start: 0, end: 1 }
+}
+
+/// `+ : ( 'S Num Num -- 'S Num )` — an embedder-registered contract.
+fn plus_scheme() -> Scheme {
+    let s = sp();
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::num(s), Ty::num(s)], 0, s),
+            StackTy::new(vec![Ty::num(s)], 0, s),
+        ),
+    )
+}
+
+/// Build an evaluator from program source, registering `+` as the only embedder
+/// operator. The same source always produces an equivalent evaluator (a rebuild).
+fn build(src: &str) -> Evaluator<Value> {
+    let mut eval: Evaluator<Value> = Evaluator::new();
+    eval.register_operator_with_contract("+", plus_scheme());
+    let toks = parse_with_spans(src).unwrap();
+    eval.load_with_spans(&toks).unwrap();
+    eval
+}
+
+fn var(n: &str) -> Pred {
+    Pred::Var(n.to_string())
+}
+fn num(n: &str) -> Pred {
+    Pred::Num(n.to_string())
+}
+fn ge(a: &str, k: &str) -> Pred {
+    Pred::Bin(BinOp::Ge, Box::new(var(a)), Box::new(num(k)))
+}
+
+// ===========================================================================
+// (1) One global ledger — grep assume = the complete user trusted base
+// ===========================================================================
+
+#[test]
+fn grep_assume_over_the_program_equals_the_one_global_ledger() {
+    // (§12 M14 / invariant 15) `grep assume` over the whole program enumerates the
+    // complete user trusted base, and it equals the one global ledger's accepted
+    // entries — there is no per-module reconciliation, one `grep` covers it all.
+    let foo_body = parse("opaque \"assume(result >= 0)\" sqrt").unwrap();
+    let bar_body = parse("foo").unwrap();
+    let baz_body = parse("opaque \"assume(other >= 0)\" sqrt").unwrap();
+    let defs = vec![
+        Definition {
+            name: "foo".into(),
+            body: foo_body.clone(),
+            sig: None,
+        },
+        Definition {
+            name: "bar".into(),
+            body: bar_body.clone(),
+            sig: None,
+        },
+        Definition {
+            name: "baz".into(),
+            body: baz_body.clone(),
+            sig: None,
+        },
+    ];
+    let lookup = |w: &str| match w {
+        "sqrt" => crate::parse_signature("sqrt : ( n: Num where n >= 0  --  r: Num )").ok(),
+        _ => None,
+    };
+    let ledger = check_program(&defs, &lookup, SmtLibSolver::new).unwrap();
+    assert!(ledger.is_clean(), "rejections: {:?}", ledger.rejections());
+
+    // Source-side grep over EVERY definition body (the whole program).
+    let mut source_grep: Vec<String> = Vec::new();
+    for d in &defs {
+        source_grep.extend(grep_assume_tokens(&d.body));
+    }
+    source_grep.sort();
+
+    // Ledger-side enumeration of the complete user trusted base.
+    let mut ledger_grep = ledger.grep_assume();
+    ledger_grep.sort();
+
+    assert_eq!(
+        source_grep, ledger_grep,
+        "grep assume over the program must equal the one global ledger"
+    );
+    assert_eq!(
+        ledger_grep,
+        vec![
+            "assume(other >= 0)".to_string(),
+            "assume(result >= 0)".to_string()
+        ]
+    );
+    assert_eq!(ledger.assumptions().len(), 2);
+}
+
+#[test]
+fn grep_assume_recurses_into_quotations() {
+    // The source-side grep finds assumes nested inside quotations, so a program's
+    // complete trusted base is enumerable regardless of bracket nesting.
+    let toks = parse("[ a \"assume(p > 0)\" [ b \"assume(q > 0)\" ] ]").unwrap();
+    let mut found = grep_assume_tokens(&toks);
+    found.sort();
+    assert_eq!(
+        found,
+        vec!["assume(p > 0)".to_string(), "assume(q > 0)".to_string()]
+    );
+}
+
+// ===========================================================================
+// (2) The operator table is the enumerable modulo of every proof
+// ===========================================================================
+
+#[test]
+fn operator_table_enumerates_the_modulo() {
+    // (§12 M14 / invariants 16/17) The operator table = language-core primitives
+    // PLUS embedder registrations, and nothing else.
+    let eval = build("[ 1 + ] :main");
+    let table = OperatorTable::of(&eval);
+
+    let core_names: Vec<String> = table.core().map(|c| c.name.clone()).collect();
+    for p in ["DUP", "DROP", "SWAP", "OVER", "CALL", "DIP", "IF"] {
+        assert!(
+            core_names.contains(&p.to_string()),
+            "missing core primitive {p}"
+        );
+        let entry = table.entries().iter().find(|e| e.name == p).unwrap();
+        assert_eq!(entry.origin, OperatorOrigin::LanguageCore);
+    }
+
+    let embedder_names: Vec<String> = table.embedder().map(|c| c.name.clone()).collect();
+    assert_eq!(embedder_names, vec!["+".to_string()]);
+    let plus = table.entries().iter().find(|e| e.name == "+").unwrap();
+    assert_eq!(plus.origin, OperatorOrigin::Embedder);
+    assert_eq!(plus.scheme, plus_scheme());
+
+    assert_eq!(table.core().count(), 7);
+    assert_eq!(table.embedder().count(), 1);
+    assert_eq!(table.len(), 8);
+}
+
+#[test]
+fn different_embeddings_have_different_trusted_bases() {
+    // (architecture / invariant 17) The trusted base is the API the host chose to
+    // expose, attested; a sandbox and a systems embedding differ in their modulo.
+    let sandbox: Evaluator<Value> = Evaluator::new();
+    let sandbox_table = OperatorTable::of(&sandbox);
+    assert_eq!(
+        sandbox_table.embedder().count(),
+        0,
+        "sandbox exposes no host ops"
+    );
+
+    let mut systems: Evaluator<Value> = Evaluator::new();
+    systems.register_operator_with_contract("syscall_read", plus_scheme());
+    let systems_table = OperatorTable::of(&systems);
+    assert_eq!(systems_table.embedder().count(), 1);
+    assert_eq!(
+        systems_table.embedder().next().unwrap().name,
+        "syscall_read"
+    );
+
+    let sc: Vec<_> = sandbox_table.core().map(|c| c.name.clone()).collect();
+    let yc: Vec<_> = systems_table.core().map(|c| c.name.clone()).collect();
+    assert_eq!(sc, yc, "the core half is identical");
+    assert_ne!(sandbox_table.names(), systems_table.names());
+}
+
+// ===========================================================================
+// (3) Whole-program attestation hash — stable + content-addressed
+// ===========================================================================
+
+#[test]
+fn attestation_hash_is_stable_across_rebuilds_of_unchanged_source() {
+    // (§12 M14) The whole-program attestation hash is stable across rebuilds of
+    // unchanged source (fresh inference, fresh internal variable ids).
+    let src = "[ bar 1 + ] :foo [ 2 ] :bar [ foo ] :main";
+    let h1 = attestation_hash(&build(src)).unwrap();
+    let h2 = attestation_hash(&build(src)).unwrap();
+    assert_eq!(h1, h2, "attestation hash must be stable across rebuilds");
+
+    let cs = ContractSet::of(&build(src)).unwrap();
+    assert_eq!(cs.attestation_hash(), h1);
+}
+
+#[test]
+fn attestation_hash_changes_when_the_contract_set_changes() {
+    // The attestation hash is content-addressed over the contract set, not a
+    // constant: a changed signature or a changed operator table changes it.
+    let base = attestation_hash(&build("[ 1 + ] :foo [ foo ] :main")).unwrap();
+
+    let changed = attestation_hash(&build("[ 1 + + ] :foo [ 3 foo ] :main")).unwrap();
+    assert_ne!(base, changed, "a changed contract set must change the hash");
+
+    let mut eval = build("[ 1 + ] :foo [ foo ] :main");
+    eval.register_operator_with_contract("neg", plus_scheme());
+    let with_op = attestation_hash(&eval).unwrap();
+    assert_ne!(
+        base, with_op,
+        "a changed operator table must change the hash"
+    );
+}
+
+#[test]
+fn attestation_hash_ignores_internal_variable_ids() {
+    // The canonical rendering renumbers variables in first-appearance order, so a
+    // scheme's hash does not depend on the ids inference happened to assign — this
+    // is *why* the hash is reproducible across rebuilds.
+    let a = ContractSet::of(&build("[ DUP ] :twice [ twice ] :main")).unwrap();
+    let b = ContractSet::of(&build("[ 7 DROP ] :noise [ DUP ] :twice [ twice ] :main")).unwrap();
+    let ta = super::canonical_scheme(&a.definitions["twice"]);
+    let tb = super::canonical_scheme(&b.definitions["twice"]);
+    assert_eq!(
+        ta, tb,
+        "canonical signature must not depend on var-id allocation"
+    );
+}
+
+// ===========================================================================
+// (3b) Per-obligation keys — selective invalidation + warm-compile reuse
+// ===========================================================================
+
+#[test]
+fn changing_one_obligation_invalidates_only_its_sub_hash() {
+    // (§12 M14) Changing one obligation changes only its sub-hash; every other
+    // obligation's sub-hash is unchanged (selective invalidation).
+    let facts: Vec<Pred> = vec![ge("a", "0")];
+    let g1 = ge("x", "0");
+    let g2 = ge("y", "0");
+    let g3 = ge("z", "0");
+
+    let h1 = obligation_sub_hash(&g1, &facts);
+    let h2 = obligation_sub_hash(&g2, &facts);
+    let h3 = obligation_sub_hash(&g3, &facts);
+
+    assert_eq!(h1, obligation_sub_hash(&g1, &facts), "sub-hash is stable");
+
+    let g3b = Pred::Bin(BinOp::Ge, Box::new(var("z")), Box::new(num("1")));
+    let h3b = obligation_sub_hash(&g3b, &facts);
+    assert_ne!(h3, h3b, "the changed obligation's sub-hash must change");
+    assert_eq!(h1, obligation_sub_hash(&g1, &facts), "g1 unchanged");
+    assert_eq!(h2, obligation_sub_hash(&g2, &facts), "g2 unchanged");
+
+    let facts2: Vec<Pred> = vec![ge("a", "1")];
+    assert_ne!(
+        h1,
+        obligation_sub_hash(&g1, &facts2),
+        "facts are part of the key"
+    );
+}
+
+#[test]
+fn warm_compile_reuses_unchanged_obligations_and_resolves_only_the_changed_one() {
+    // (§12 M14) The discharge cache keyed on exact per-obligation content gives
+    // warm-compile reuse: a recompile re-solves only the changed obligation.
+    let g1 = ge("x", "0");
+    let g2 = ge("y", "0");
+    let g3 = ge("z", "0");
+
+    let mut cache = ExploratoryCache::new();
+
+    {
+        let mut solver = SmtLibSolver::new();
+        for g in [&g1, &g2, &g3] {
+            let (_v, from_cache) = cache.discharge_obligation(&mut solver, g);
+            assert!(!from_cache, "cold compile is all misses");
+        }
+    }
+    assert_eq!(cache.solves(), 3);
+    assert_eq!(cache.hits(), 0);
+
+    let g3b = Pred::Bin(BinOp::Ge, Box::new(var("z")), Box::new(num("1")));
+    {
+        let mut solver = SmtLibSolver::new();
+        let (_v1, c1) = cache.discharge_obligation(&mut solver, &g1);
+        let (_v2, c2) = cache.discharge_obligation(&mut solver, &g2);
+        let (_v3, c3) = cache.discharge_obligation(&mut solver, &g3b);
+        assert!(c1, "g1 unchanged ⇒ warm cache hit");
+        assert!(c2, "g2 unchanged ⇒ warm cache hit");
+        assert!(!c3, "g3 changed ⇒ a fresh solve");
+    }
+    assert_eq!(cache.solves(), 4, "only the changed obligation re-solves");
+    assert_eq!(cache.hits(), 2, "the two unchanged obligations are reused");
+}
+
+// ===========================================================================
+// (4) CI gate; free runtime — no Z3, no shadow stack at runtime
+// ===========================================================================
+
+#[test]
+fn checked_program_links_no_z3_symbols() {
+    // (§12 M14 / invariant 20) A checked program links no solver: no z3 crate in
+    // the dependency graph, and caternary's own dependencies name no solver crate.
+    let manifest = include_str!("../../Cargo.toml");
+    let deps = manifest
+        .split_once("[dependencies]")
+        .expect("a [dependencies] section")
+        .1;
+    let lower = deps.to_lowercase();
+    assert!(
+        !lower.contains("z3"),
+        "caternary must not depend on a z3 crate"
+    );
+    assert!(
+        !lower.contains("cvc5") && !lower.contains("z3-sys"),
+        "no native solver crate in caternary's dependencies"
+    );
+
+    let lock_path = format!("{}/../Cargo.lock", env!("CARGO_MANIFEST_DIR"));
+    let lock = std::fs::read_to_string(&lock_path).expect("workspace Cargo.lock");
+    for line in lock.lines() {
+        let l = line.trim();
+        assert!(
+            l != "name = \"z3\"" && l != "name = \"z3-sys\"" && l != "name = \"cvc5\"",
+            "a solver crate is in the dependency graph: {l}"
+        );
+    }
+}
+
+#[test]
+fn evaluator_carries_no_shadow_stack_or_solver_at_runtime() {
+    // (§12 M14 / invariants 14/20) The shadow stack and solver are compile-time
+    // only: the shadow stack is NEVER a field of the runtime Evaluator. Lock it
+    // structurally by reading the Evaluator struct definition.
+    let src = include_str!("../evaluator.rs");
+    let start = src
+        .find("pub struct Evaluator<T> {")
+        .expect("Evaluator struct");
+    let body = &src[start..];
+    let end = body.find("\n}").expect("struct body ends") + start;
+    let struct_def = &src[start..end];
+    for forbidden in [
+        "ShadowStack",
+        "SmtLibSolver",
+        "ExploratoryCache",
+        "Obligation",
+    ] {
+        assert!(
+            !struct_def.contains(forbidden),
+            "Evaluator must not carry `{forbidden}` at runtime:\n{struct_def}"
+        );
+    }
+    assert!(
+        !struct_def.contains("dyn Solver") && !struct_def.contains(": Solver"),
+        "Evaluator must not carry a solver:\n{struct_def}"
+    );
+}
+
+#[test]
+fn check_is_the_build_time_gate_and_eval_runs_lean() {
+    // (§10.10 / invariant 20) `caternary check` (the public type_check/check path)
+    // is the build-time gate; a checked program runs with no verification
+    // machinery and evaluation touches no solver.
+    let mut eval = build("[ 1 1 + ] :main");
+    crate::check(&eval).expect("the program is checked");
+    eval.define("+", |stack: &mut Vec<Value>, _ev: &Evaluator<Value>| {
+        stack.pop();
+        Ok(())
+    });
+    let out = eval.eval(&parse("1 1 +").unwrap()).expect("runs lean");
+    assert_eq!(out.len(), 1);
+}
+
+#[test]
+fn attestation_hash_requires_a_checked_program() {
+    // The attestation hash runs the same SCC generalization the gate runs, so an
+    // ill-typed definition yields a TypeError rather than a hash (CI-gate
+    // consistency): `+` demands `Num Num`, but `true` is `Bool`.
+    let eval = build("[ true 1 + ] :main");
+    assert!(attestation_hash(&eval).is_err());
+}
+
+#[allow(dead_code)]
+fn _verdict_referenced(v: Verdict) -> bool {
+    matches!(v, Verdict::Unsat | Verdict::Sat | Verdict::Unknown)
+}
+
+#[allow(dead_code)]
+fn _solver_referenced<S: Solver>(_s: &S) {}

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -1078,6 +1078,23 @@ fn parse_elem(
 ///
 /// Returns the map `name → Scheme`. A definition word later resolves by
 /// instantiating its scheme; recursion no longer inlines bodies.
+/// The **generalized signature** ([`Scheme`]) of every loaded definition (M3 /
+/// §6), keyed by name — the definition half of the whole-program contract set
+/// the M14 attestation hash content-addresses (architecture section / §12 M14).
+///
+/// This runs the same SCC generalization pass [`type_check`] runs, so a program
+/// that does not type-check returns the same [`TypeError`] here; a checked
+/// program returns one `Scheme` per definition. It reads the evaluator
+/// read-only (the §3 immutability barrier). Use [`crate::ContractSet`] to fold
+/// these together with the operator table into the artifact attestation hash.
+pub fn definition_schemes<T>(evaluator: &Evaluator<T>) -> Result<HashMap<String, Scheme>, TypeError>
+where
+    T: Quotable,
+{
+    let mut ctx = InferCtx::new();
+    infer_definition_schemes(evaluator, &mut ctx)
+}
+
 fn infer_definition_schemes<T>(
     evaluator: &Evaluator<T>,
     ctx: &mut InferCtx,

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -279,6 +279,17 @@ impl<T> Evaluator<T> {
         self.contracts.len()
     }
 
+    /// The names of every **embedder-registered** operator contract (the
+    /// `register_operator_with_contract` entries). This is the read path the M14
+    /// whole-program attestation uses to enumerate the embedder half of the
+    /// operator table — the **modulo** of every proof (architecture / invariants
+    /// 16/17). Order is unspecified; callers that need determinism sort. The
+    /// language-core primitives (`call`/`dip`/`if` …) are *not* here — they live
+    /// in [`crate::core_scheme`], baked in rather than attested at embed time.
+    pub fn contract_names(&self) -> impl Iterator<Item = &str> {
+        self.contracts.keys().map(String::as_str)
+    }
+
     /// True if `name` is a loaded `[ body ] :name` definition (flat global
     /// namespace populated by [`Evaluator::load`]). The type checker rides on the
     /// same table the runtime resolves against.

--- a/caternary/src/lib.rs
+++ b/caternary/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+mod attestation;
 mod builtins;
 mod check;
 mod combinators;
@@ -13,9 +14,16 @@ mod shadow;
 mod solver;
 mod types;
 
+pub use attestation::ContractSet;
+pub use attestation::OperatorContract;
+pub use attestation::OperatorOrigin;
+pub use attestation::OperatorTable;
+pub use attestation::attestation_hash;
+pub use attestation::grep_assume_tokens;
 pub use builtins::register_stack_builtins;
 pub use check::TypeError;
 pub use check::check;
+pub use check::definition_schemes;
 pub use check::type_check;
 pub use check::type_check_entry;
 pub use combinators::Quotable;
@@ -90,6 +98,7 @@ pub use solver::check_subsumption;
 pub use solver::discharge;
 pub use solver::discharge_with_model;
 pub use solver::negate;
+pub use solver::obligation_sub_hash;
 pub use solver::refinement_verify_word;
 pub use solver::relay_quote_post;
 pub use solver::render_smtlib;

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -647,8 +647,7 @@ where
     }
 }
 
-/// Is this word the `if` combinator (either the spec's `if` or the runtime
-/// `IF` — see [`crate::BUILTIN_NAME_MAP`])?
+/// Is this word the `IF` combinator?
 fn is_if(word: &str) -> bool {
     word.eq_ignore_ascii_case("if")
 }
@@ -1083,6 +1082,25 @@ impl ExploratoryCache {
         self.verdicts.is_empty()
     }
 
+    /// Discharge an **obligation** `goal` through the per-obligation discharge
+    /// cache (§12 M14 / §10.7), keyed on its exact canonical content (predicate +
+    /// in-scope facts). On a cache **hit** the memoized verdict is returned with
+    /// `from_cache = true` and **no solver call is made** (warm-compile reuse);
+    /// on a miss the goal is discharged once, memoized, and `solves` is bumped.
+    ///
+    /// This is the same machinery the strict-`assume` exploratory check uses
+    /// (the M12 cache), surfaced as a general per-obligation cache so a
+    /// whole-program warm recompile re-solves only the obligations whose content
+    /// changed. Changing one obligation changes only its key; every other
+    /// obligation hits the cache.
+    pub fn discharge_obligation<S: Solver + FactSnapshot>(
+        &mut self,
+        solver: &mut S,
+        goal: &Pred,
+    ) -> (Verdict, bool) {
+        self.discharge_cached(solver, goal)
+    }
+
     /// Run the exploratory drop-and-re-run for `goal` under the solver's live
     /// facts, reusing a cached verdict when the obligation's canonical content
     /// (predicate + in-scope facts) is unchanged. Returns the verdict and whether
@@ -1131,6 +1149,23 @@ fn obligation_key(goal: &Pred, facts: &[Pred]) -> String {
         push_part(&mut key, f);
     }
     key
+}
+
+/// The **per-obligation sub-hash** (§12 M14): the content-hash of an obligation
+/// — its goal predicate plus the order-independent set of in-scope facts. The
+/// discharge cache itself uses the full canonical content key (see
+/// [`ExploratoryCache`]) so a hash collision cannot alias two obligations; this
+/// helper is only the exported M14 fingerprint for selective-invalidation
+/// reporting. The whole-program attestation hash ([`crate::ContractSet`]) is the
+/// contract-set counterpart; this is its per-obligation granularity.
+pub fn obligation_sub_hash(goal: &Pred, facts: &[Pred]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hash;
+    use std::hash::Hasher;
+
+    let mut h = DefaultHasher::new();
+    obligation_key(goal, facts).hash(&mut h);
+    h.finish()
 }
 
 /// The free variables of `pred` in **left-to-right first-appearance order** — the


### PR DESCRIPTION
Final milestone. Makes the whole-program/embeddable/operator-contracted trust
story enumerable and content-addressable:

1. One global ledger (invariant 15): `grep_assume_tokens` is the source-side
   `grep assume`; a test asserts it equals the global Ledger's accepted entries
   for a clean program — no per-module reconciliation.
2. Operator table as the enumerable modulo (invariants 16/17): `OperatorTable`
   enumerates language-core `core_scheme` primitives plus embedder
   `register_operator_with_contract` entries, the exact statement of "sound
   modulo the attested contracts." Different embeddings differ only in the
   embedder half.
3. One artifact attestation hash (§12 M14): `ContractSet::attestation_hash`
   content-hashes the whole-program contract set (M3 definition signatures +
   operator table), canonicalizing variable ids so it is stable across rebuilds
   of unchanged source. The per-obligation sub-hash (`obligation_sub_hash`,
   reusing the M12 obligation_hash) keys the discharge cache, so changing one
   obligation invalidates only its entry (warm-compile reuse via
   `ExploratoryCache::discharge_obligation`).
4. CI gate / free runtime (invariants 14/20): structural tests assert no z3
   crate in the dependency graph and that the runtime Evaluator carries no
   shadow-stack/solver machinery; `check` is the build-time gate, `eval` runs
   lean.

Adds `definition_schemes` (public SCC-generalization entry) and an
`m14_attestation` example. cargo test green (291), clippy/fmt clean,
typing.md unmodified.

Co-authored-by: AI
