### PR TITLE
fix: use uppercase keyword tokens in caternary examples

### DIFF
--- a/caternary/examples/m13_emission_parity.rs
+++ b/caternary/examples/m13_emission_parity.rs
@@ -41,7 +41,7 @@ fn main() {
 
     // ---- Scenario 1: path condition + an `assume` boundary -----------------
     //
-    // `x 0 > [ x sqrt ] [ 0 ] if` exercises the M8 path-condition `if` (the
+    // `x 0 > [ x sqrt ] [ 0 ] IF` exercises the M8 path-condition `IF` (the
     // sqrt demand discharges under x > 0), and `opaque assume(x>=0) sqrt`
     // exercises the M12 strict drop-and-re-run plus the dependent obligation.
     let span = || Span { start: 0, end: 0 };
@@ -73,12 +73,12 @@ fn main() {
         }
     };
 
-    let toks = parse("x 0 > [ x sqrt ] [ 0 ] if").unwrap();
+    let toks = parse("x 0 > [ x sqrt ] [ 0 ] IF").unwrap();
     let mut solver = SmtLibSolver::new();
     let mut stack = ShadowStack::new();
     let mut obligations = Vec::new();
     verify(&toks, &mut stack, &mut solver, &sqrt, &mut obligations).unwrap();
-    print_script("path-condition `if` (M8)", solver.script());
+    print_script("path-condition `IF` (M8)", solver.script());
     for o in &obligations {
         println!("  obligation {:?} => {:?}", o.goal, o.verdict);
     }

--- a/caternary/examples/m14_attestation.rs
+++ b/caternary/examples/m14_attestation.rs
@@ -100,7 +100,7 @@ fn main() {
     //          `assume` the solver cannot otherwise discharge), and feeds it to
     //          the refined `sqrt` (which demands `n >= 0`);
     //   `main` runs `foo` and closes against the empty stack.
-    let src = "[ mk \"assume(result >= 0)\" sqrt drop ] :foo [ foo ] :main";
+    let src = "[ mk \"assume(result >= 0)\" sqrt DROP ] :foo [ foo ] :main";
     let eval = build(src);
 
     // (1) The CI gate — a SINGLE build-time act (§10.10, invariant 19/20): one

--- a/caternary/examples/m8_script.rs
+++ b/caternary/examples/m8_script.rs
@@ -8,7 +8,7 @@ fn span() -> Span {
 }
 
 fn main() {
-    let toks = parse("x 0 > [ x sqrt ] [ 0 ] if").unwrap();
+    let toks = parse("x 0 > [ x sqrt ] [ 0 ] IF").unwrap();
     let mut stack = ShadowStack::new();
     let mut solver = SmtLibSolver::new();
     let mut obligations = Vec::new();

--- a/caternary/examples/m9_vc_generation.rs
+++ b/caternary/examples/m9_vc_generation.rs
@@ -53,13 +53,13 @@ fn main() {
         report("nonneg sqrt  (guarantee supplies the fact)", &obs);
     }
 
-    // (3) `x 0 > [ x sqrt ] [ 0 ] if`: the M8 path condition composes with M9 VC
+    // (3) `x 0 > [ x sqrt ] [ 0 ] IF`: the M8 path condition composes with M9 VC
     // generation — inside the x > 0 branch, the demand discharges.
     {
-        let toks = parse("x 0 > [ x sqrt ] [ 0 ] if").unwrap();
+        let toks = parse("x 0 > [ x sqrt ] [ 0 ] IF").unwrap();
         let lookup = |w: &str| (w == "sqrt").then(|| sqrt.clone());
         let mut solver = SmtLibSolver::new();
         let obs = check_refinements(&toks, &lookup, &mut solver).unwrap();
-        report("x 0 > [ x sqrt ] [ 0 ] if  (path condition)", &obs);
+        report("x 0 > [ x sqrt ] [ 0 ] IF  (path condition)", &obs);
     }
 }

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -284,7 +284,7 @@ impl<T> Evaluator<T> {
     /// whole-program attestation uses to enumerate the embedder half of the
     /// operator table — the **modulo** of every proof (architecture / invariants
     /// 16/17). Order is unspecified; callers that need determinism sort. The
-    /// language-core primitives (`call`/`dip`/`if` …) are *not* here — they live
+    /// language-core primitives (`CALL`/`DIP`/`IF` …) are *not* here — they live
     /// in [`crate::core_scheme`], baked in rather than attested at embed time.
     pub fn contract_names(&self) -> impl Iterator<Item = &str> {
         self.contracts.keys().map(String::as_str)


### PR DESCRIPTION
The parser and core primitives recognize stack-language keywords in
uppercase (IF, DROP, CALL, DIP), but several examples and one doc
comment still used the obsolete lowercase forms. The lowercase tokens
no longer parse, so the affected examples were broken.

Rename the keyword tokens to their uppercase forms:
- m8_script, m9_vc_generation, m13_emission_parity: `if` -> `IF`
- m14_attestation: `drop` -> `DROP`
- evaluator doc comment: `call`/`dip`/`if` -> `CALL`/`DIP`/`IF`

Co-authored-by: AI
