### PR TITLE
feat(caternary): add caternary binary with check and shell

### DIFF
--- a/caternary/Cargo.toml
+++ b/caternary/Cargo.toml
@@ -7,17 +7,30 @@ description = "Caternary is a stack-based language and runtime."
 license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
-[features]
-default = ["binaries"]
-
-binaries = []
-# The native solver backend is build-time-only and opt-in.
-z3 = ["dep:z3"]
-
 [dependencies]
+arrrg = { workspace = true, optional = true }
+arrrg_derive = { workspace = true, optional = true }
+getopts = { workspace = true, optional = true }
 handled = { workspace = true }
+rustyline = { workspace = true, optional = true }
 shvar = { workspace = true }
 z3 = { version = "0.20.0", optional = true }
+
+[features]
+# `caternary check` discharges verification conditions through the solver seam
+# (`Solver`/`CounterModel`/`FactSnapshot`, src/solver.rs). The day-one backend is
+# the SMT-LIB2 text-emission + embedded reasoner (`SmtLibSolver`); enabling `z3`
+# drops a native `Z3Solver` in behind the same seam. It is OFF by default so the
+# default build (and a *checked program* at runtime) links no solver — z3 is a
+# build-time-only, opt-in check backend.
+default = ["binaries"]
+binaries = ["dep:arrrg", "dep:arrrg_derive", "dep:getopts", "dep:rustyline"]
+z3 = ["dep:z3"]
+
+[[bin]]
+name = "caternary"
+path = "src/bin/caternary.rs"
+required-features = ["binaries"]
 
 [[example]]
 name = "m8_script"

--- a/caternary/src/bin/caternary.rs
+++ b/caternary/src/bin/caternary.rs
@@ -1,0 +1,310 @@
+use std::error::Error;
+use std::fmt;
+use std::io::Read;
+
+use arrrg::CommandLine;
+use caternary::{
+    Evaluator, Quotable, SmtLibSolver, SpannedToken, SpannedTokenKind, Token, check_whole_program,
+    parse_with_spans, register_all_builtins,
+};
+use rustyline::error::ReadlineError;
+use rustyline::history::MemHistory;
+use rustyline::{Config, Editor};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct Options {}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct CheckOptions {}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
+struct ShellOptions {}
+
+enum Command {
+    Check(CheckOptions, Vec<String>),
+    Shell(ShellOptions, Vec<String>),
+}
+
+#[derive(Debug)]
+struct CliError(String);
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for CliError {}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Value {
+    Word(String),
+    Number(f64),
+    Bool(bool),
+    Quotation(Vec<Token>),
+}
+
+impl From<Token> for Value {
+    fn from(token: Token) -> Self {
+        match token {
+            Token::Word(w) => {
+                if let Ok(n) = w.parse::<f64>() {
+                    Value::Number(n)
+                } else if w == "true" {
+                    Value::Bool(true)
+                } else if w == "false" {
+                    Value::Bool(false)
+                } else {
+                    Value::Word(w)
+                }
+            }
+            Token::Bracket(tokens) => Value::Quotation(tokens),
+        }
+    }
+}
+
+impl Quotable for Value {
+    fn as_quotation(&self) -> Option<&[Token]> {
+        match self {
+            Value::Quotation(tokens) => Some(tokens),
+            _ => None,
+        }
+    }
+
+    fn to_tokens(&self) -> Vec<Token> {
+        match self {
+            Value::Word(w) => vec![Token::Word(w.clone())],
+            Value::Number(n) => vec![Token::Word(n.to_string())],
+            Value::Bool(b) => vec![Token::Word(b.to_string())],
+            Value::Quotation(tokens) => vec![Token::Bracket(tokens.clone())],
+        }
+    }
+
+    fn is_truthy(&self) -> bool {
+        match self {
+            Value::Bool(b) => *b,
+            Value::Number(n) => *n != 0.0,
+            _ => true,
+        }
+    }
+
+    fn as_sequence(&self) -> Option<Vec<Self>> {
+        match self {
+            Value::Quotation(tokens) => Some(tokens.iter().cloned().map(Value::from).collect()),
+            _ => None,
+        }
+    }
+
+    fn from_sequence(elements: Vec<Self>) -> Self {
+        Value::Quotation(elements.into_iter().flat_map(|v| v.to_tokens()).collect())
+    }
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("caternary: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let (_options, free) = Options::from_command_line_relaxed(
+        "Usage: caternary [OPTIONS] <check|shell> [COMMAND OPTIONS]",
+    );
+    let command = arrrg::dispatch_subcommands!(free, {
+        "check" => CheckOptions as check, check_free => {
+            Ok(Command::Check(check, check_free))
+        },
+        "shell" => ShellOptions as shell, shell_free => {
+            Ok(Command::Shell(shell, shell_free))
+        },
+    })?;
+    match command {
+        Command::Check(options, free) => check_command(options, free),
+        Command::Shell(options, free) => shell_command(options, free),
+    }
+}
+
+fn check_command(_options: CheckOptions, free: Vec<String>) -> Result<()> {
+    expect_no_positionals("check", &free)?;
+
+    let mut source = String::new();
+    std::io::stdin().read_to_string(&mut source)?;
+
+    let mut evaluator = new_evaluator();
+    let tokens = parse_with_spans(&source)?;
+    evaluator.load_with_spans(&tokens)?;
+    check_whole_program(&evaluator, SmtLibSolver::new)?;
+
+    Ok(())
+}
+
+fn shell_command(_options: ShellOptions, free: Vec<String>) -> Result<()> {
+    expect_no_positionals("shell", &free)?;
+
+    let config = Config::builder()
+        .max_history_size(1_000_000)?
+        .history_ignore_dups(true)?
+        .history_ignore_space(true)
+        .build();
+    let hist = MemHistory::new();
+    let mut rl: Editor<(), MemHistory> = Editor::with_history(config, hist)?;
+    let mut evaluator = new_evaluator();
+    let mut stack = Vec::new();
+
+    loop {
+        match rl.readline("caternary> ") {
+            Ok(line) => {
+                rl.add_history_entry(&line)?;
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                if line == "exit" || line == "quit" {
+                    return Ok(());
+                }
+                match shell_eval_line(&mut evaluator, &mut stack, line) {
+                    Ok(()) => println!("{}", format_stack(&stack)),
+                    Err(err) => eprintln!("error: {err}"),
+                }
+            }
+            Err(ReadlineError::Interrupted) => continue,
+            Err(ReadlineError::Eof) => return Ok(()),
+            Err(err) => return Err(Box::new(err)),
+        }
+    }
+}
+
+fn shell_eval_line(
+    evaluator: &mut Evaluator<Value>,
+    stack: &mut Vec<Value>,
+    line: &str,
+) -> Result<()> {
+    let spanned = parse_with_spans(line)?;
+    evaluator.load_with_spans(&spanned)?;
+    let tokens = shell_runtime_tokens(&spanned);
+    evaluator.eval_with_stack(&tokens, stack)?;
+    Ok(())
+}
+
+fn new_evaluator() -> Evaluator<Value> {
+    let mut evaluator = Evaluator::new();
+    register_all_builtins(&mut evaluator);
+    evaluator
+}
+
+fn expect_no_positionals(command: &str, free: &[String]) -> Result<()> {
+    if free.is_empty() {
+        Ok(())
+    } else {
+        Err(Box::new(CliError(format!(
+            "`caternary {command}` takes no positional arguments"
+        ))))
+    }
+}
+
+fn shell_runtime_tokens(tokens: &[SpannedToken]) -> Vec<Token> {
+    let mut skip = vec![false; tokens.len()];
+    for i in 1..tokens.len() {
+        let SpannedTokenKind::Word(word) = &tokens[i].kind else {
+            continue;
+        };
+        if (is_definition_binder(word) || is_annotation_binder(word))
+            && matches!(tokens[i - 1].kind, SpannedTokenKind::Bracket(_))
+        {
+            skip[i - 1] = true;
+            skip[i] = true;
+        }
+    }
+    tokens
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !skip[*i])
+        .map(|(_, token)| token.to_token())
+        .collect()
+}
+
+fn is_definition_binder(word: &str) -> bool {
+    word.strip_prefix(':').is_some_and(is_name)
+}
+
+fn is_annotation_binder(word: &str) -> bool {
+    word.strip_prefix('@').is_some_and(is_name)
+}
+
+fn is_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn format_stack(stack: &[Value]) -> String {
+    let values = stack.iter().map(format_value).collect::<Vec<_>>();
+    format!("[{}]", values.join(" "))
+}
+
+fn format_value(value: &Value) -> String {
+    match value {
+        Value::Word(w) => format_word(w),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Quotation(tokens) => format!("[{}]", format_tokens(tokens)),
+    }
+}
+
+fn format_word(word: &str) -> String {
+    if word.is_empty() {
+        "\"\"".to_string()
+    } else {
+        shvar::quote_string(word)
+    }
+}
+
+fn format_tokens(tokens: &[Token]) -> String {
+    tokens
+        .iter()
+        .map(|token| match token {
+            Token::Word(w) => format_word(w),
+            Token::Bracket(inner) => format!("[{}]", format_tokens(inner)),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_tokens_quotes_whitespace_words() {
+        let tokens = vec![
+            Token::Word("hello world".to_string()),
+            Token::Bracket(vec![Token::Word("two words".to_string())]),
+        ];
+
+        let formatted = format_tokens(&tokens);
+
+        assert_eq!(parse_with_spans(&formatted).unwrap().len(), 2);
+        assert_eq!(
+            caternary::parse(&formatted).unwrap(),
+            vec![
+                Token::Word("hello world".to_string()),
+                Token::Bracket(vec![Token::Word("two words".to_string())]),
+            ],
+        );
+    }
+
+    #[test]
+    fn format_word_quotes_empty_words() {
+        assert_eq!("\"\"", format_word(""));
+        assert_eq!(
+            caternary::parse(&format_word("")).unwrap(),
+            vec![Token::Word(String::new())],
+        );
+    }
+}


### PR DESCRIPTION
Add a command-line front end exposing two subcommands:
- check: parse stdin, load the program, and run the whole-program
  SMT check via SmtLibSolver.
- shell: an interactive rustyline REPL that evaluates lines against
  a persistent stack and prints the stack after each line.

Define a concrete Value type implementing Quotable so the
generic Evaluator can be instantiated, and gate the binary and its
dependencies (arrrg, arrrg_derive, getopts, rustyline) behind a new
default-on "binaries" feature so the library can still build without
them.

Co-authored-by: AI
