### PR TITLE
feat(caternary): add scalar arithmetic, comparison, and bitwise builtins

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -117,7 +117,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Language Features By Example
 
-Assume the evaluator has all builtins registered and helper operators like `ADD`, `MUL`, `GT`, `EVEN`.
+Assume the evaluator has all builtins registered. Examples that use `EVEN` assume
+a host predicate with that name is also registered.
 
 ### Stack Builtins
 
@@ -139,16 +140,16 @@ Assume the evaluator has all builtins registered and helper operators like `ADD`
 
 | Operator | Example | Resulting stack |
 |---|---|---|
-| `CALL` | `1 2 [ADD] CALL` | `3` |
-| `DIP` | `1 2 3 [ADD] DIP` | `3 3` |
-| `KEEP` | `5 [DUP MUL] KEEP` | `25 5` |
-| `BI` | `5 [DUP ADD] [DUP MUL] BI` | `10 25` |
-| `BI*` | `3 4 [DUP MUL] [DUP ADD] BI*` | `9 8` |
-| `BI@` | `3 4 [DUP MUL] BI@` | `9 16` |
-| `CLEAVE` | `5 [[DUP ADD] [DUP MUL] [1 ADD]] CLEAVE` | `10 25 6` |
-| `SPREAD` | `1 2 3 [[DUP ADD] [DUP MUL] [1 ADD]] SPREAD` | `2 4 4` |
-| `COMPOSE` | `[1 ADD] [2 MUL] COMPOSE` | `[1 ADD 2 MUL]` |
-| `CURRY` | `10 [ADD] CURRY` | `[10 ADD]` |
+| `CALL` | `1 2 [+] CALL` | `3` |
+| `DIP` | `1 2 3 [+] DIP` | `3 3` |
+| `KEEP` | `5 [DUP *] KEEP` | `25 5` |
+| `BI` | `5 [DUP +] [DUP *] BI` | `10 25` |
+| `BI*` | `3 4 [DUP *] [DUP +] BI*` | `9 8` |
+| `BI@` | `3 4 [DUP *] BI@` | `9 16` |
+| `CLEAVE` | `5 [[DUP +] [DUP *] [1 +]] CLEAVE` | `10 25 6` |
+| `SPREAD` | `1 2 3 [[DUP +] [DUP *] [1 +]] SPREAD` | `2 4 4` |
+| `COMPOSE` | `[1 +] [2 *] COMPOSE` | `[1 + 2 *]` |
+| `CURRY` | `10 [+] CURRY` | `[10 +]` |
 
 ### Conditionals
 
@@ -165,9 +166,9 @@ Assume the evaluator has all builtins registered and helper operators like `ADD`
 
 | Operator | Example | Resulting stack |
 |---|---|---|
-| `MAP` | `[1 2 3] [DUP MUL] MAP` | `[1 4 9]` |
+| `MAP` | `[1 2 3] [DUP *] MAP` | `[1 4 9]` |
 | `FILTER` | `[1 2 3 4] [EVEN] FILTER` | `[2 4]` |
-| `FOLD` | `[1 2 3] 0 [ADD] FOLD` | `6` |
+| `FOLD` | `[1 2 3] 0 [+] FOLD` | `6` |
 | `EACH` | `[1 2 3] [DROP] EACH` | *(unchanged)* |
 
 Notes:
@@ -207,9 +208,9 @@ Scoping rules:
   stream, so programs without locals are unaffected.
 
 ```text
-Program: 10 >x [x ADD] CALL
+Program: 10 >x [x +] CALL
 Meaning: bind 10 to x, push a quotation that captures x by value, then call it
-Stack (with 5 on the stack before, ADD registered): 15
+Stack (with 5 on the stack before): 15
 ```
 
 ### User Function Definitions
@@ -226,7 +227,7 @@ let mut eval: Evaluator<Value> = Evaluator::new();
 register_all_builtins(&mut eval);
 
 // Load definitions once, then evaluate many programs against them.
-eval.load(&parse("[1 ADD] :inc [inc inc] :twice")?)?;
+eval.load(&parse("[1 +] :inc [inc inc] :twice")?)?;
 
 let stack = eval.eval(&parse("5 twice")?)?; // 7
 ```
@@ -234,7 +235,7 @@ let stack = eval.eval(&parse("5 twice")?)?; // 7
 Because `load` sees the whole token stream before execution:
 
 - **Order does not matter.** Forward references resolve: `[inc inc] :twice` may
-  appear before `[1 ADD] :inc`.
+  appear before `[1 +] :inc`.
 - **Recursion works.** A body resolves its own name at call time against the
   fully populated table.
 - **Load is additive.** Call `load` repeatedly to assemble a library

--- a/caternary/src/builtins.rs
+++ b/caternary/src/builtins.rs
@@ -5,7 +5,13 @@
 
 use crate::EvalError;
 use crate::Evaluator;
+use crate::Quotable;
+use crate::Scheme;
+use crate::Span;
+use crate::StackTy;
 use crate::Token;
+use crate::Ty;
+use crate::WordTy;
 use crate::evaluator::operator_error;
 
 fn stack_underflow(expected: usize, found: usize) -> EvalError {
@@ -105,6 +111,284 @@ fn two_over<T: Clone>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), Ev
     Ok(())
 }
 
+fn scalar_word<T: Quotable>(value: &T) -> Result<String, EvalError> {
+    match value.to_tokens().as_slice() {
+        [Token::Word(w)] => Ok(w.clone()),
+        [Token::Bracket(_)] => Err(operator_error("expected a scalar word, found quotation")),
+        _ => Err(operator_error(
+            "expected a scalar value that renders as one word",
+        )),
+    }
+}
+
+fn pop_num<T: Quotable>(stack: &mut Vec<T>) -> Result<f64, EvalError> {
+    let value = stack.pop().ok_or_else(|| stack_underflow(1, stack.len()))?;
+    let word = scalar_word(&value)?;
+    word.parse::<f64>()
+        .map_err(|_| operator_error(format!("expected numeric value, found `{word}`")))
+}
+
+fn pop_int<T: Quotable>(stack: &mut Vec<T>) -> Result<i128, EvalError> {
+    let value = stack.pop().ok_or_else(|| stack_underflow(1, stack.len()))?;
+    let word = scalar_word(&value)?;
+    word.parse::<i128>()
+        .map_err(|_| operator_error(format!("expected integer value, found `{word}`")))
+}
+
+fn push_word<T: From<Token>>(stack: &mut Vec<T>, word: impl Into<String>) {
+    stack.push(T::from(Token::Word(word.into())));
+}
+
+fn push_num<T: From<Token>>(stack: &mut Vec<T>, n: f64) {
+    push_word(stack, n.to_string());
+}
+
+fn push_int<T: From<Token>>(stack: &mut Vec<T>, n: i128) {
+    push_word(stack, n.to_string());
+}
+
+fn numeric_bin<T, F>(stack: &mut Vec<T>, f: F) -> Result<(), EvalError>
+where
+    T: Quotable,
+    F: FnOnce(f64, f64) -> Result<f64, EvalError>,
+{
+    require_len(stack, 2)?;
+    let b = pop_num(stack)?;
+    let a = pop_num(stack)?;
+    let c = f(a, b)?;
+    push_num(stack, c);
+    Ok(())
+}
+
+fn integer_bin<T, F>(stack: &mut Vec<T>, f: F) -> Result<(), EvalError>
+where
+    T: Quotable,
+    F: FnOnce(i128, i128) -> Result<i128, EvalError>,
+{
+    require_len(stack, 2)?;
+    let b = pop_int(stack)?;
+    let a = pop_int(stack)?;
+    let c = f(a, b)?;
+    push_int(stack, c);
+    Ok(())
+}
+
+fn bool_bin<T, F>(stack: &mut Vec<T>, f: F) -> Result<(), EvalError>
+where
+    T: Quotable,
+    F: FnOnce(bool, bool) -> bool,
+{
+    require_len(stack, 2)?;
+    let b = stack.pop().unwrap().is_truthy();
+    let a = stack.pop().unwrap().is_truthy();
+    push_word(stack, f(a, b).to_string());
+    Ok(())
+}
+
+fn plus<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_bin(stack, |a, b| Ok(a + b))
+}
+
+fn minus<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_bin(stack, |a, b| Ok(a - b))
+}
+
+fn multiply<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_bin(stack, |a, b| Ok(a * b))
+}
+
+fn divide<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_bin(stack, |a, b| {
+        if b == 0.0 {
+            Err(operator_error("division by zero"))
+        } else {
+            Ok(a / b)
+        }
+    })
+}
+
+fn modulo<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_bin(stack, |a, b| {
+        if b == 0.0 {
+            Err(operator_error("modulo by zero"))
+        } else {
+            Ok(a % b)
+        }
+    })
+}
+
+fn bit_or<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    integer_bin(stack, |a, b| Ok(a | b))
+}
+
+fn bit_and<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    integer_bin(stack, |a, b| Ok(a & b))
+}
+
+fn bit_xor<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    integer_bin(stack, |a, b| Ok(a ^ b))
+}
+
+fn bit_not<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 1)?;
+    let a = pop_int(stack)?;
+    push_int(stack, !a);
+    Ok(())
+}
+
+fn shift_amount(n: i128) -> Result<u32, EvalError> {
+    u32::try_from(n).map_err(|_| operator_error(format!("invalid shift amount `{n}`")))
+}
+
+fn shift_left<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    integer_bin(stack, |a, b| {
+        a.checked_shl(shift_amount(b)?)
+            .ok_or_else(|| operator_error(format!("invalid shift amount `{b}`")))
+    })
+}
+
+fn shift_right<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    integer_bin(stack, |a, b| {
+        a.checked_shr(shift_amount(b)?)
+            .ok_or_else(|| operator_error(format!("invalid shift amount `{b}`")))
+    })
+}
+
+fn bool_or<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    bool_bin(stack, |a, b| a || b)
+}
+
+fn bool_and<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    bool_bin(stack, |a, b| a && b)
+}
+
+fn bool_not<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 1)?;
+    let a = stack.pop().unwrap().is_truthy();
+    push_word(stack, (!a).to_string());
+    Ok(())
+}
+
+fn eq<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 2)?;
+    let b = stack.pop().unwrap();
+    let a = stack.pop().unwrap();
+    push_word(stack, (a.to_tokens() == b.to_tokens()).to_string());
+    Ok(())
+}
+
+fn ne<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 2)?;
+    let b = stack.pop().unwrap();
+    let a = stack.pop().unwrap();
+    push_word(stack, (a.to_tokens() != b.to_tokens()).to_string());
+    Ok(())
+}
+
+fn numeric_cmp<T, F>(stack: &mut Vec<T>, f: F) -> Result<(), EvalError>
+where
+    T: Quotable,
+    F: FnOnce(f64, f64) -> bool,
+{
+    require_len(stack, 2)?;
+    let b = pop_num(stack)?;
+    let a = pop_num(stack)?;
+    push_word(stack, f(a, b).to_string());
+    Ok(())
+}
+
+fn lt<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_cmp(stack, |a, b| a < b)
+}
+
+fn le<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_cmp(stack, |a, b| a <= b)
+}
+
+fn gt<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_cmp(stack, |a, b| a > b)
+}
+
+fn ge<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    numeric_cmp(stack, |a, b| a >= b)
+}
+
+fn span() -> Span {
+    Span { start: 0, end: 0 }
+}
+
+fn num_num_num_scheme() -> Scheme {
+    let s = span();
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::num(s), Ty::num(s)], 0, s),
+            StackTy::new(vec![Ty::num(s)], 0, s),
+        ),
+    )
+}
+
+fn num_num_bool_scheme() -> Scheme {
+    let s = span();
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::num(s), Ty::num(s)], 0, s),
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+        ),
+    )
+}
+
+fn bool_bool_bool_scheme() -> Scheme {
+    let s = span();
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::bool(s), Ty::bool(s)], 0, s),
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+        ),
+    )
+}
+
+fn bool_bool_scheme() -> Scheme {
+    let s = span();
+    Scheme::new(
+        vec![],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+        ),
+    )
+}
+
+fn same_same_bool_scheme() -> Scheme {
+    let s = span();
+    Scheme::new(
+        vec![0],
+        vec![0],
+        WordTy::new(
+            StackTy::new(vec![Ty::var(0, s), Ty::var(0, s)], 0, s),
+            StackTy::new(vec![Ty::bool(s)], 0, s),
+        ),
+    )
+}
+
+fn num_num_num_refinements() -> [(&'static str, &'static str); 4] {
+    [
+        ("+", "+ : ( a: Num b: Num -- c: Num where c = a + b )"),
+        ("-", "- : ( a: Num b: Num -- c: Num where c = a - b )"),
+        ("*", "* : ( a: Num b: Num -- c: Num where c = a * b )"),
+        (
+            "/",
+            "/ : ( a: Num b: Num where b * b > 0 -- c: Num where c = a / b )",
+        ),
+    ]
+}
+
 /// Register standard stack combinators/manipulators on an evaluator.
 pub fn register_stack_builtins<T>(evaluator: &mut Evaluator<T>)
 where
@@ -123,11 +407,80 @@ where
     evaluator.define("2OVER", two_over::<T>);
 }
 
+/// Register scalar arithmetic, comparison, boolean, and integer bitwise builtins.
+///
+/// Arithmetic operators use the language's single `Num` type. Bitwise operators
+/// accept integer-valued `Num` lexemes at runtime and reject fractional values.
+pub fn register_scalar_builtins<T>(evaluator: &mut Evaluator<T>)
+where
+    T: Quotable,
+{
+    evaluator.define("+", plus::<T>);
+    evaluator.define("-", minus::<T>);
+    evaluator.define("*", multiply::<T>);
+    evaluator.define("/", divide::<T>);
+    evaluator.define("%", modulo::<T>);
+    evaluator.define("|", bit_or::<T>);
+    evaluator.define("&", bit_and::<T>);
+    evaluator.define("^", bit_xor::<T>);
+    evaluator.define("~", bit_not::<T>);
+    evaluator.define("<<", shift_left::<T>);
+    evaluator.define(">>", shift_right::<T>);
+    evaluator.define("||", bool_or::<T>);
+    evaluator.define("or", bool_or::<T>);
+    evaluator.define("&&", bool_and::<T>);
+    evaluator.define("and", bool_and::<T>);
+    evaluator.define("!", bool_not::<T>);
+    evaluator.define("not", bool_not::<T>);
+    evaluator.define("=", eq::<T>);
+    evaluator.define("==", eq::<T>);
+    evaluator.define("!=", ne::<T>);
+    evaluator.define("<", lt::<T>);
+    evaluator.define("<=", le::<T>);
+    evaluator.define(">", gt::<T>);
+    evaluator.define(">=", ge::<T>);
+
+    for op in ["+", "-", "*", "/", "%", "|", "&", "^", "<<", ">>"] {
+        evaluator.register_operator_with_contract(op, num_num_num_scheme());
+    }
+    evaluator.register_operator_with_contract("~", {
+        let s = span();
+        Scheme::new(
+            vec![],
+            vec![0],
+            WordTy::new(
+                StackTy::new(vec![Ty::num(s)], 0, s),
+                StackTy::new(vec![Ty::num(s)], 0, s),
+            ),
+        )
+    });
+    for op in ["||", "or", "&&", "and"] {
+        evaluator.register_operator_with_contract(op, bool_bool_bool_scheme());
+    }
+    for op in ["!", "not"] {
+        evaluator.register_operator_with_contract(op, bool_bool_scheme());
+    }
+    for op in ["=", "==", "!="] {
+        evaluator.register_operator_with_contract(op, same_same_bool_scheme());
+    }
+    for op in ["<", "<=", ">", ">="] {
+        evaluator.register_operator_with_contract(op, num_num_bool_scheme());
+    }
+    for (_, refinement) in num_num_num_refinements() {
+        evaluator
+            .attach_refinement(refinement)
+            .expect("builtin arithmetic refinement must parse");
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{Evaluator, Quotable, Token, parse};
+    use crate::{
+        Evaluator, Quotable, Scheme, Span, StackTy, Token, Ty, WordTy, check_whole_program, parse,
+        parse_with_spans,
+    };
 
-    use super::register_stack_builtins;
+    use super::{register_scalar_builtins, register_stack_builtins};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct Number(i32);
@@ -163,6 +516,70 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, PartialEq)]
+    enum Value {
+        Word(String),
+        Number(f64),
+        Bool(bool),
+        Quotation(Vec<Token>),
+    }
+
+    impl From<Token> for Value {
+        fn from(token: Token) -> Self {
+            match token {
+                Token::Word(w) => {
+                    if let Ok(n) = w.parse::<f64>() {
+                        Value::Number(n)
+                    } else if w == "true" {
+                        Value::Bool(true)
+                    } else if w == "false" {
+                        Value::Bool(false)
+                    } else {
+                        Value::Word(w)
+                    }
+                }
+                Token::Bracket(tokens) => Value::Quotation(tokens),
+            }
+        }
+    }
+
+    impl Quotable for Value {
+        fn as_quotation(&self) -> Option<&[Token]> {
+            match self {
+                Value::Quotation(tokens) => Some(tokens),
+                _ => None,
+            }
+        }
+
+        fn to_tokens(&self) -> Vec<Token> {
+            match self {
+                Value::Word(w) => vec![Token::Word(w.clone())],
+                Value::Number(n) => vec![Token::Word(n.to_string())],
+                Value::Bool(b) => vec![Token::Word(b.to_string())],
+                Value::Quotation(tokens) => vec![Token::Bracket(tokens.clone())],
+            }
+        }
+
+        fn is_truthy(&self) -> bool {
+            match self {
+                Value::Bool(b) => *b,
+                Value::Number(n) => *n != 0.0,
+                _ => true,
+            }
+        }
+
+        fn as_sequence(&self) -> Option<Vec<Self>> {
+            match self {
+                Value::Quotation(tokens) => Some(tokens.iter().cloned().map(Value::from).collect()),
+                _ => None,
+            }
+        }
+
+        fn from_sequence(elements: Vec<Self>) -> Self {
+            Value::Quotation(elements.iter().flat_map(|v| v.to_tokens()).collect())
+        }
+    }
+
     #[test]
     fn registers_and_runs_builtins() {
         let mut eval: Evaluator<Number> = Evaluator::new();
@@ -186,5 +603,66 @@ mod tests {
             err.to_string()
                 .contains("stack underflow: need at least 1 values, found 0")
         );
+    }
+
+    #[test]
+    fn scalar_builtins_run_common_operations() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        register_scalar_builtins(&mut eval);
+
+        let tokens = parse(
+            "false true || false true && 0 2 | 1 3 & 1 3 ^ \
+             2 3 + 2 3 * 2 3 - 2 4 /",
+        )
+        .unwrap();
+        let stack = eval.eval(&tokens).unwrap();
+
+        assert_eq!(
+            stack,
+            vec![
+                Value::Bool(true),
+                Value::Bool(false),
+                Value::Number(2.0),
+                Value::Number(1.0),
+                Value::Number(2.0),
+                Value::Number(5.0),
+                Value::Number(6.0),
+                Value::Number(-1.0),
+                Value::Number(0.5),
+            ]
+        );
+    }
+
+    #[test]
+    fn scalar_builtins_register_type_contracts() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        register_scalar_builtins(&mut eval);
+        let tokens =
+            parse_with_spans("[ 2 3 + DROP 2 4 / DROP false true || DROP 1 3 ^ DROP ] :main")
+                .unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+
+        check_whole_program(&eval, crate::SmtLibSolver::new).unwrap();
+    }
+
+    #[test]
+    fn arithmetic_refinement_publishes_exact_sum() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        register_scalar_builtins(&mut eval);
+        let s = Span { start: 0, end: 0 };
+        eval.register_operator_with_contract(
+            "need5",
+            Scheme::new(
+                vec![],
+                vec![0],
+                WordTy::new(StackTy::new(vec![Ty::num(s)], 0, s), StackTy::empty(0, s)),
+            ),
+        );
+        eval.attach_refinement("need5 : ( n: Num where n >= 5 -- )")
+            .unwrap();
+        let tokens = parse_with_spans("[ 2 3 + need5 ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+
+        check_whole_program(&eval, crate::SmtLibSolver::new).unwrap();
     }
 }

--- a/caternary/src/lib.rs
+++ b/caternary/src/lib.rs
@@ -20,6 +20,7 @@ pub use attestation::OperatorOrigin;
 pub use attestation::OperatorTable;
 pub use attestation::attestation_hash;
 pub use attestation::grep_assume_tokens;
+pub use builtins::register_scalar_builtins;
 pub use builtins::register_stack_builtins;
 pub use check::GateError;
 pub use check::TypeError;
@@ -134,6 +135,7 @@ where
     T: Quotable,
 {
     register_stack_builtins(evaluator);
+    register_scalar_builtins(evaluator);
     register_combinators(evaluator);
     register_conditionals(evaluator);
     register_sequence_combinators(evaluator);

--- a/caternary/src/refinement.rs
+++ b/caternary/src/refinement.rs
@@ -724,29 +724,14 @@ impl<'a> Parser<'a> {
 
     // ---- signature grammar ----
     //
-    //   sig   := IDENT ':' '(' side '--' side ')'
+    //   sig   := head ':' '(' side '--' side ')'
+    //   head  := IDENT | operator-token
     //   side  := binder* ('where' pred)?
     //   binder:= IDENT ':' IDENT
 
     fn parse_signature(&mut self) -> Result<RefinementSig, RefineParseError> {
-        // Head identifier: the definition name.
-        let name = match self.peek() {
-            Some(Tok::Ident(_)) => {
-                let Some(Spanned {
-                    tok: Tok::Ident(n), ..
-                }) = self.bump()
-                else {
-                    unreachable!("peeked Ident")
-                };
-                n.clone()
-            }
-            _ => {
-                return Err(RefineParseError::new(
-                    "expected the definition name a refinement signature attaches to",
-                    self.peek_span(),
-                ));
-            }
-        };
+        // Head: the definition/operator name this signature attaches to.
+        let name = self.parse_signature_head()?;
         self.expect(&Tok::Colon, "`:` after the definition name")?;
         self.expect(&Tok::LParen, "`(` to open the refinement signature")?;
         let demands = self.parse_side(SideEnd::Arrow)?;
@@ -764,6 +749,34 @@ impl<'a> Parser<'a> {
             demands,
             guarantees,
         })
+    }
+
+    fn parse_signature_head(&mut self) -> Result<String, RefineParseError> {
+        let Some(spanned) = self.bump() else {
+            return Err(RefineParseError::new(
+                "expected the definition or operator name a refinement signature attaches to",
+                self.peek_span(),
+            ));
+        };
+        let name = match &spanned.tok {
+            Tok::Ident(n) => n.clone(),
+            Tok::Plus => "+".to_string(),
+            Tok::Minus => "-".to_string(),
+            Tok::Star => "*".to_string(),
+            Tok::Slash => "/".to_string(),
+            Tok::Ge => ">=".to_string(),
+            Tok::Le => "<=".to_string(),
+            Tok::Gt => ">".to_string(),
+            Tok::Lt => "<".to_string(),
+            Tok::Eq => "=".to_string(),
+            _ => {
+                return Err(RefineParseError::new(
+                    "expected the definition or operator name a refinement signature attaches to",
+                    spanned.span,
+                ));
+            }
+        };
+        Ok(name)
     }
 
     fn parse_side(&mut self, end: SideEnd) -> Result<RefinementSide, RefineParseError> {
@@ -981,6 +994,21 @@ mod tests {
             bin(BinOp::Eq, bin(BinOp::Mul, v("r"), v("r")), v("n")),
         );
         assert_eq!(sig.guarantees.predicate, Some(expected_guarantee));
+    }
+
+    #[test]
+    fn operator_symbol_parses_as_signature_head() {
+        let sig = parse_signature("+ : ( a: Num b: Num -- c: Num where c = a + b )")
+            .expect("operator-headed signature parses");
+
+        assert_eq!(sig.name, "+");
+        assert_eq!(sig.demands.binders[0].name, "a");
+        assert_eq!(sig.demands.binders[1].name, "b");
+        assert_eq!(sig.guarantees.binders[0].name, "c");
+        assert_eq!(
+            sig.guarantees.predicate,
+            Some(bin(BinOp::Eq, v("c"), bin(BinOp::Add, v("a"), v("b")))),
+        );
     }
 
     // --- §12 M6: push parses; uninterpreted `length`, no input `where` ---

--- a/caternary/src/shadow.rs
+++ b/caternary/src/shadow.rs
@@ -217,9 +217,13 @@ pub fn interpreted_op(name: &str) -> Option<ShadowWord> {
         ">" => ShadowWord::Bin(BinOp::Gt),
         "<" => ShadowWord::Bin(BinOp::Lt),
         "=" => ShadowWord::Bin(BinOp::Eq),
+        "==" => ShadowWord::Bin(BinOp::Eq),
         "and" => ShadowWord::Bin(BinOp::And),
+        "&&" => ShadowWord::Bin(BinOp::And),
         "or" => ShadowWord::Bin(BinOp::Or),
+        "||" => ShadowWord::Bin(BinOp::Or),
         "not" => ShadowWord::Un(UnOp::Not),
+        "!" => ShadowWord::Un(UnOp::Not),
         _ => return None,
     };
     Some(word)

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -859,13 +859,13 @@ fn apply_effect<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
             guarantee,
             arrow,
         } => {
+            let input_bindings = bind_positional(&binders, stack)?;
             // (1) Demand → VC at the call site: bind the demand's parameters to
             // the actual shadow terms (§10.2), substitute, discharge under the
             // live facts + path conditions via the negated-goal encoding, pulling
             // the counterexample model on a `Sat` (§10.4/§10.5).
             if let Some(demand) = demand {
-                let bindings = bind_positional(&binders, stack)?;
-                let goal = substitute(&demand, &bindings);
+                let goal = substitute(&demand, &input_bindings);
                 let (verdict, model) = discharge_with_model(solver, &goal);
                 ctx.obligations.push(Obligation {
                     word: word.to_string(),
@@ -888,11 +888,16 @@ fn apply_effect<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
             // literals).
             stack.apply_opaque(&arrow)?;
             // (3) Guarantee → publish as a live fact: bind the output binders to
-            // the freshly pushed output terms, substitute, and assert into the
-            // current scope so downstream demands (and the rest of this scope)
-            // can use it (§10.1 — output predicates are gifts to the next word).
+            // the freshly pushed output terms, combine those with the input
+            // bindings captured before the effect, substitute, and assert into
+            // the current scope so downstream demands (and the rest of this
+            // scope) can use it (§10.1 — output predicates are gifts to the next
+            // word). Output predicates may relate results back to inputs (`sqrt`
+            // documents `r * r = n`; arithmetic builtins use `c = a + b`), so
+            // both sides must be in scope for substitution.
             if let Some(guarantee) = guarantee {
-                let bindings = bind_positional(&out_binders, stack)?;
+                let mut bindings = input_bindings;
+                bindings.extend(bind_positional(&out_binders, stack)?);
                 let fact = substitute(&guarantee, &bindings);
                 solver.assert(&fact);
             }
@@ -2793,10 +2798,19 @@ fn fourier_motzkin_solve(mut constraints: Vec<Constraint>) -> (bool, Vec<(String
                 if name == var {
                     continue;
                 }
-                let val = model
-                    .get(name)
-                    .copied()
-                    .expect("back-substitution: referenced variable must be assigned");
+                let val = match model.get(name).copied() {
+                    Some(val) => val,
+                    None => {
+                        // A bound may mention a variable that was never
+                        // eliminated because it became unconstrained in the
+                        // forward pass. It is genuinely free at this point; pick
+                        // a neutral witness value so model construction remains
+                        // total.
+                        let val = Rat::int(0);
+                        model.insert(name.clone(), val);
+                        val
+                    }
+                };
                 rest = rest.add(&coeff.mul(&val));
             }
             // bound = -rest / c_v

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -18,12 +18,12 @@
 //! registers for builtins, so there is no spec-name/runtime-name compatibility
 //! table in this layer. The remaining Tier-0 reconciliation facts are:
 //!
-//! * **There is no core `+` / `Num` builtin.** The spec's `+ : ( 'S Num Num --
-//!   'S Num )` signature does not correspond to any operator in the core tables;
-//!   only `ADD`/`MUL`/`GT` exist, and those appear *only in test code*. Numeric
-//!   operators therefore enter the type environment via *registration*
-//!   ([`crate::Evaluator::register_operator_with_contract`]), never from a core
-//!   table. The numeric base type is spelled [`NUM`].
+//! * **Scalar operators are registered builtins, not core schemes.** Arithmetic,
+//!   comparison, boolean, and bitwise words such as `+`, `>=`, `&&`, and `|`
+//!   enter the type environment through
+//!   [`crate::register_scalar_builtins`] /
+//!   [`crate::Evaluator::register_operator_with_contract`], never from
+//!   [`core_scheme`]. The numeric base type is spelled [`NUM`].
 //! * **There is no numeric token.** The parser emits only `Token::Word` and
 //!   `Token::Bracket` (see `parser.rs`); there is no `Token::Num`. The Tier-0
 //!   decision, recorded as [`is_numeric_literal`], is that a numeric literal is a


### PR DESCRIPTION
Introduce register_scalar_builtins, which defines the symbolic
operator words (+, -, *, /, %, bitwise, shifts, boolean, comparison,
and equality) along with their type contracts and the arithmetic
refinement signatures. register_all_builtins now wires these in
alongside the existing stack builtins, so programs can use `+`/`*`
directly instead of the test-only ADD/MUL helpers.

Supporting changes:

- refinement: accept operator tokens (+, -, *, /, comparisons) as
  signature heads, not just identifiers, so builtin operators can carry
  refinement contracts like `+ : ( a: Num b: Num -- c: Num where
  c = a + b )`.
- solver: capture input bindings before applying an effect and merge
  them into the output-binder scope, so guarantee predicates may relate
  results back to inputs (e.g. `c = a + b`). Also make Fourier-Motzkin
  back-substitution total by witnessing genuinely-free variables with a
  neutral value instead of panicking.
- shadow: map the symbolic aliases ==, &&, ||, and ! onto their
  existing interpreted operators.
- types: revise the Tier-0 reconciliation note to reflect that scalar
  operators are registered builtins rather than absent from the core.
- README: update examples to use the registered operators (+, *, /)
  instead of the ADD/MUL/GT helpers.

Co-authored-by: AI
