### PR TITLE
feat(caternary): extend core with stack shuffles and combinators

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -129,12 +129,14 @@ a host predicate with that name is also registered.
 | `SWAP` | `1 2 SWAP` | `2 1` |
 | `OVER` | `1 2 OVER` | `1 2 1` |
 | `ROT` | `1 2 3 ROT` | `2 3 1` |
+| `-ROT` | `1 2 3 -ROT` | `3 1 2` |
 | `NIP` | `1 2 NIP` | `2` |
 | `TUCK` | `1 2 TUCK` | `2 1 2` |
 | `2DUP` | `1 2 2DUP` | `1 2 1 2` |
 | `2DROP` | `1 2 3 4 2DROP` | `1 2` |
 | `2SWAP` | `1 2 3 4 2SWAP` | `3 4 1 2` |
 | `2OVER` | `1 2 3 4 2OVER` | `1 2 3 4 1 2` |
+| `2ROT` | `1 2 3 4 5 6 2ROT` | `3 4 5 6 1 2` |
 
 ### Core Combinators
 
@@ -146,6 +148,9 @@ a host predicate with that name is also registered.
 | `BI` | `5 [DUP +] [DUP *] BI` | `10 25` |
 | `BI*` | `3 4 [DUP *] [DUP +] BI*` | `9 8` |
 | `BI@` | `3 4 [DUP *] BI@` | `9 16` |
+| `TRI` | `5 [DUP +] [DUP *] [1 +] TRI` | `10 25 6` |
+| `TRI*` | `3 4 5 [DUP *] [DUP +] [1 +] TRI*` | `9 8 6` |
+| `TRI@` | `3 4 5 [DUP *] TRI@` | `9 16 25` |
 | `CLEAVE` | `5 [[DUP +] [DUP *] [1 +]] CLEAVE` | `10 25 6` |
 | `SPREAD` | `1 2 3 [[DUP +] [DUP *] [1 +]] SPREAD` | `2 4 4` |
 | `COMPOSE` | `[1 +] [2 *] COMPOSE` | `[1 + 2 *]` |

--- a/caternary/src/attestation.rs
+++ b/caternary/src/attestation.rs
@@ -49,7 +49,10 @@ use crate::types::TyKind;
 use crate::types::WordTy;
 use crate::types::core_scheme;
 
-const CORE_PRIMITIVES: &[&str] = &["DUP", "DROP", "SWAP", "OVER", "CALL", "DIP", "IF"];
+const CORE_PRIMITIVES: &[&str] = &[
+    "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER",
+    "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
+];
 
 // ===========================================================================
 // The operator table — the modulo of every proof (invariants 16/17)
@@ -62,7 +65,7 @@ const CORE_PRIMITIVES: &[&str] = &["DUP", "DROP", "SWAP", "OVER", "CALL", "DIP",
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum OperatorOrigin {
     /// The **language core** registered this irreducible primitive
-    /// (`DUP`/`DROP`/`SWAP`/`OVER`/`CALL`/`DIP`/`IF`), baked into
+    /// (fixed stack shuffles plus fixed-arity quotation combinators), baked into
     /// [`crate::core_scheme`] with its Tier-0 scheme (and Tier-1 axiom, §10.6).
     LanguageCore,
     /// The **embedder** registered this host operator at embed time via

--- a/caternary/src/attestation/tests.rs
+++ b/caternary/src/attestation/tests.rs
@@ -189,7 +189,12 @@ fn operator_table_enumerates_the_modulo() {
     let table = OperatorTable::of(&eval);
 
     let core_names: Vec<String> = table.core().map(|c| c.name.clone()).collect();
-    for p in ["DUP", "DROP", "SWAP", "OVER", "CALL", "DIP", "IF"] {
+    let expected_core = [
+        "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP",
+        "2OVER", "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@",
+        "COMPOSE",
+    ];
+    for p in expected_core.iter().copied() {
         assert!(
             core_names.contains(&p.to_string()),
             "missing core primitive {p}"
@@ -204,9 +209,9 @@ fn operator_table_enumerates_the_modulo() {
     assert_eq!(plus.origin, OperatorOrigin::Embedder);
     assert_eq!(plus.scheme, plus_scheme());
 
-    assert_eq!(table.core().count(), 7);
+    assert_eq!(table.core().count(), expected_core.len());
     assert_eq!(table.embedder().count(), 1);
-    assert_eq!(table.len(), 8);
+    assert_eq!(table.len(), expected_core.len() + 1);
 }
 
 #[test]

--- a/caternary/src/builtins.rs
+++ b/caternary/src/builtins.rs
@@ -62,6 +62,13 @@ fn rot<T>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
     Ok(())
 }
 
+fn minus_rot<T>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 3)?;
+    let len = stack.len();
+    stack[len - 3..].rotate_right(1);
+    Ok(())
+}
+
 fn nip<T>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
     require_len(stack, 2)?;
     let len = stack.len();
@@ -108,6 +115,13 @@ fn two_over<T: Clone>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), Ev
     let b = stack[len - 3].clone();
     stack.push(a);
     stack.push(b);
+    Ok(())
+}
+
+fn two_rot<T>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 6)?;
+    let len = stack.len();
+    stack[len - 6..].rotate_left(2);
     Ok(())
 }
 
@@ -399,12 +413,14 @@ where
     evaluator.define("SWAP", swap::<T>);
     evaluator.define("OVER", over::<T>);
     evaluator.define("ROT", rot::<T>);
+    evaluator.define("-ROT", minus_rot::<T>);
     evaluator.define("NIP", nip::<T>);
     evaluator.define("TUCK", tuck::<T>);
     evaluator.define("2DUP", two_dup::<T>);
     evaluator.define("2DROP", two_drop::<T>);
     evaluator.define("2SWAP", two_swap::<T>);
     evaluator.define("2OVER", two_over::<T>);
+    evaluator.define("2ROT", two_rot::<T>);
 }
 
 /// Register scalar arithmetic, comparison, boolean, and integer bitwise builtins.
@@ -589,6 +605,27 @@ mod tests {
         let stack = eval.eval(&tokens).unwrap();
 
         assert_eq!(stack, vec![Number(1), Number(2), Number(2), Number(2)]);
+    }
+
+    #[test]
+    fn forth_rotations_run() {
+        let mut eval: Evaluator<Number> = Evaluator::new();
+        register_stack_builtins(&mut eval);
+
+        let tokens = parse("1 2 3 -ROT 4 5 6 2ROT").unwrap();
+        let stack = eval.eval(&tokens).unwrap();
+
+        assert_eq!(
+            stack,
+            vec![
+                Number(2),
+                Number(4),
+                Number(5),
+                Number(6),
+                Number(3),
+                Number(1)
+            ]
+        );
     }
 
     #[test]

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2309,6 +2309,50 @@ mod tests {
     }
 
     #[test]
+    fn m4_core_schemes_cover_fixed_stack_combinators() {
+        for word in [
+            "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER", "2ROT",
+        ] {
+            assert!(
+                core_scheme(word).is_some(),
+                "missing core scheme for {word}"
+            );
+        }
+
+        let arrow = infer_snippet(
+            "1 2 3 -ROT DROP DROP DROP \
+             1 2 3 4 5 6 2ROT 2DROP 2DROP 2DROP",
+        )
+        .unwrap();
+        assert!(arrow.input.elems.is_empty());
+        assert!(arrow.output.elems.is_empty());
+    }
+
+    #[test]
+    fn m4_core_schemes_cover_fixed_quotation_combinators() {
+        for word in ["KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE"] {
+            assert!(
+                core_scheme(word).is_some(),
+                "missing core scheme for {word}"
+            );
+        }
+
+        let arrow = infer_snippet(
+            "5 [ 1 + ] KEEP DROP DROP \
+             5 [ 1 + ] [ 2 + ] BI DROP DROP \
+             5 6 [ 1 + ] [ 2 + ] BI* DROP DROP \
+             5 6 [ 1 + ] BI@ DROP DROP \
+             5 [ 1 + ] [ 2 + ] [ 3 + ] TRI DROP DROP DROP \
+             5 6 7 [ 1 + ] [ 2 + ] [ 3 + ] TRI* DROP DROP DROP \
+             5 6 7 [ 1 + ] TRI@ DROP DROP DROP \
+             [ 1 + ] [ 2 + ] COMPOSE 5 SWAP CALL DROP",
+        )
+        .unwrap();
+        assert!(arrow.input.elems.is_empty());
+        assert!(arrow.output.elems.is_empty());
+    }
+
+    #[test]
     fn m4_dip_relays_quotation_and_carries_the_set_aside_value() {
         // §12 M4: `xs total [ 99 push ] DIP` type-checks; result shape `… List
         // Num`; DIP contributes ONLY that `total` is carried through. `DIP` is

--- a/caternary/src/combinators.rs
+++ b/caternary/src/combinators.rs
@@ -180,6 +180,80 @@ fn bi_at<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eva
     Ok(())
 }
 
+/// `TRI`: Apply three quotations to a single value.
+///
+/// Stack effect: `( x [P] [Q] [R] -- P(x) Q(x) R(x) )`
+///
+/// Pops three quotations and a value, applies each quotation to a copy of the value.
+fn tri<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 4)?;
+    let r = pop_quotation(stack)?;
+    let q = pop_quotation(stack)?;
+    let p = pop_quotation(stack)?;
+    let x = stack.pop().unwrap();
+
+    stack.push(x.clone());
+    eval.eval_with_stack(&p, stack)?;
+
+    stack.push(x.clone());
+    eval.eval_with_stack(&q, stack)?;
+
+    stack.push(x);
+    eval.eval_with_stack(&r, stack)?;
+
+    Ok(())
+}
+
+/// `TRI*`: Apply three quotations to three values respectively.
+///
+/// Stack effect: `( x y z [P] [Q] [R] -- P(x) Q(y) R(z) )`
+///
+/// Pops three quotations and three values, applies P to x, Q to y, and R to z.
+fn tri_star<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 6)?;
+    let r = pop_quotation(stack)?;
+    let q = pop_quotation(stack)?;
+    let p = pop_quotation(stack)?;
+    let z = stack.pop().unwrap();
+    let y = stack.pop().unwrap();
+    let x = stack.pop().unwrap();
+
+    stack.push(x);
+    eval.eval_with_stack(&p, stack)?;
+
+    stack.push(y);
+    eval.eval_with_stack(&q, stack)?;
+
+    stack.push(z);
+    eval.eval_with_stack(&r, stack)?;
+
+    Ok(())
+}
+
+/// `TRI@`: Apply one quotation to three values.
+///
+/// Stack effect: `( x y z [Q] -- Q(x) Q(y) Q(z) )`
+///
+/// Pops a quotation and three values, applies the quotation to each.
+fn tri_at<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 4)?;
+    let q = pop_quotation(stack)?;
+    let z = stack.pop().unwrap();
+    let y = stack.pop().unwrap();
+    let x = stack.pop().unwrap();
+
+    stack.push(x);
+    eval.eval_with_stack(&q, stack)?;
+
+    stack.push(y);
+    eval.eval_with_stack(&q, stack)?;
+
+    stack.push(z);
+    eval.eval_with_stack(&q, stack)?;
+
+    Ok(())
+}
+
 /// `CLEAVE`: Apply multiple quotations to a single value.
 ///
 /// Stack effect: `( x [[P] [Q] ...] -- P(x) Q(x) ... )`
@@ -459,7 +533,7 @@ fn each<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
 /// Register quotation combinators on an evaluator.
 ///
 /// This registers the core combinators: `CALL`, `DIP`, `KEEP`, `BI`, `BI*`, `BI@`,
-/// `CLEAVE`, `SPREAD`, `COMPOSE`, `CURRY`.
+/// `TRI`, `TRI*`, `TRI@`, `CLEAVE`, `SPREAD`, `COMPOSE`, `CURRY`.
 pub fn register_combinators<T>(evaluator: &mut Evaluator<T>)
 where
     T: Quotable,
@@ -470,6 +544,9 @@ where
     evaluator.define("BI", bi::<T>);
     evaluator.define("BI*", bi_star::<T>);
     evaluator.define("BI@", bi_at::<T>);
+    evaluator.define("TRI", tri::<T>);
+    evaluator.define("TRI*", tri_star::<T>);
+    evaluator.define("TRI@", tri_at::<T>);
     evaluator.define("CLEAVE", cleave::<T>);
     evaluator.define("SPREAD", spread::<T>);
     evaluator.define("COMPOSE", compose::<T>);
@@ -753,6 +830,45 @@ mod tests {
         let tokens = parse("3 4 [DUP MUL] BI@").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(9), Value::Int(16)]);
+        println!("Stack: {result:?}");
+    }
+
+    // ========================================================================
+    // TRI tests
+    // ========================================================================
+
+    #[test]
+    fn tri_applies_three_quotations() {
+        let eval = make_eval();
+        let tokens = parse("5 [DUP ADD] [DUP MUL] [1 ADD] TRI").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(10), Value::Int(25), Value::Int(6)]);
+        println!("Stack: {result:?}");
+    }
+
+    // ========================================================================
+    // TRI* tests
+    // ========================================================================
+
+    #[test]
+    fn tri_star_applies_to_three_values() {
+        let eval = make_eval();
+        let tokens = parse("3 4 5 [DUP MUL] [DUP ADD] [1 ADD] TRI*").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(9), Value::Int(8), Value::Int(6)]);
+        println!("Stack: {result:?}");
+    }
+
+    // ========================================================================
+    // TRI@ tests
+    // ========================================================================
+
+    #[test]
+    fn tri_at_applies_same_quotation() {
+        let eval = make_eval();
+        let tokens = parse("3 4 5 [DUP MUL] TRI@").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(9), Value::Int(16), Value::Int(25)]);
         println!("Stack: {result:?}");
     }
 

--- a/caternary/src/shadow.rs
+++ b/caternary/src/shadow.rs
@@ -155,15 +155,43 @@ pub enum ShadowWord {
     Over,
     /// `ROT` — rotate the top three terms left.
     Rot,
+    /// `-ROT` — rotate the top three terms right.
+    MinusRot,
     /// `NIP` — discard the second term.
     Nip,
     /// `TUCK` — copy the top term below the second.
     Tuck,
+    /// `2DUP` — duplicate the top pair.
+    TwoDup,
+    /// `2DROP` — discard the top pair.
+    TwoDrop,
+    /// `2SWAP` — exchange the top two pairs.
+    TwoSwap,
+    /// `2OVER` — copy the second pair over the top pair.
+    TwoOver,
+    /// `2ROT` — rotate the top three pairs left.
+    TwoRot,
     /// `DIP` — pop the quotation, set aside the next term, run the quotation on
     /// the rest, restore the set-aside term (the real shuffle, §10.3).
     Dip,
     /// `CALL` — pop the quotation and run it on the whole stack.
     Call,
+    /// `KEEP` — run a quotation and restore a copy of its input value.
+    Keep,
+    /// `BI` — run two quotations against one copied value.
+    Bi,
+    /// `BI*` — run two quotations against two corresponding values.
+    BiStar,
+    /// `BI@` — run one quotation against two corresponding values.
+    BiAt,
+    /// `TRI` — run three quotations against one copied value.
+    Tri,
+    /// `TRI*` — run three quotations against three corresponding values.
+    TriStar,
+    /// `TRI@` — run one quotation against three corresponding values.
+    TriAt,
+    /// `COMPOSE` — concatenate two quotation bodies into one quotation value.
+    Compose,
     /// An interpreted binary operator (arithmetic/comparison/connective): pops
     /// two terms `a b` and pushes the proposition/term `Bin(op, a, b)`.
     Bin(BinOp),
@@ -194,10 +222,24 @@ pub fn core_shadow_word(name: &str) -> Option<ShadowWord> {
         "SWAP" => ShadowWord::Swap,
         "OVER" => ShadowWord::Over,
         "ROT" => ShadowWord::Rot,
+        "-ROT" => ShadowWord::MinusRot,
         "NIP" => ShadowWord::Nip,
         "TUCK" => ShadowWord::Tuck,
+        "2DUP" => ShadowWord::TwoDup,
+        "2DROP" => ShadowWord::TwoDrop,
+        "2SWAP" => ShadowWord::TwoSwap,
+        "2OVER" => ShadowWord::TwoOver,
+        "2ROT" => ShadowWord::TwoRot,
         "DIP" => ShadowWord::Dip,
         "CALL" => ShadowWord::Call,
+        "KEEP" => ShadowWord::Keep,
+        "BI" => ShadowWord::Bi,
+        "BI*" => ShadowWord::BiStar,
+        "BI@" => ShadowWord::BiAt,
+        "TRI" => ShadowWord::Tri,
+        "TRI*" => ShadowWord::TriStar,
+        "TRI@" => ShadowWord::TriAt,
+        "COMPOSE" => ShadowWord::Compose,
         _ => return None,
     };
     Some(word)
@@ -326,7 +368,7 @@ impl ShadowStack {
         p
     }
 
-    fn require(&self, need: usize) -> Result<(), ShadowError> {
+    pub(crate) fn require(&self, need: usize) -> Result<(), ShadowError> {
         if self.slots.len() < need {
             return Err(underflow(need, self.slots.len()));
         }
@@ -378,6 +420,14 @@ impl ShadowStack {
         Ok(())
     }
 
+    /// `-ROT`: rotate the top three terms right. Mirrors `builtins.rs::minus_rot`.
+    pub fn minus_rot(&mut self) -> Result<(), ShadowError> {
+        self.require(3)?;
+        let len = self.slots.len();
+        self.slots[len - 3..].rotate_right(1);
+        Ok(())
+    }
+
     /// `NIP`: discard the second term. Mirrors `builtins.rs::nip`.
     pub fn nip(&mut self) -> Result<(), ShadowError> {
         self.require(2)?;
@@ -392,6 +442,52 @@ impl ShadowStack {
         let len = self.slots.len();
         let top = self.slots[len - 1].clone();
         self.slots.insert(len - 2, top);
+        Ok(())
+    }
+
+    /// `2DUP`: duplicate the top pair. Mirrors `builtins.rs::two_dup`.
+    pub fn two_dup(&mut self) -> Result<(), ShadowError> {
+        self.require(2)?;
+        let len = self.slots.len();
+        let a = self.slots[len - 2].clone();
+        let b = self.slots[len - 1].clone();
+        self.slots.push(a);
+        self.slots.push(b);
+        Ok(())
+    }
+
+    /// `2DROP`: discard the top pair. Mirrors `builtins.rs::two_drop`.
+    pub fn two_drop(&mut self) -> Result<(), ShadowError> {
+        self.require(2)?;
+        self.slots.pop();
+        self.slots.pop();
+        Ok(())
+    }
+
+    /// `2SWAP`: exchange the top two pairs. Mirrors `builtins.rs::two_swap`.
+    pub fn two_swap(&mut self) -> Result<(), ShadowError> {
+        self.require(4)?;
+        let len = self.slots.len();
+        self.slots[len - 4..].rotate_left(2);
+        Ok(())
+    }
+
+    /// `2OVER`: copy the second pair over the top pair. Mirrors `builtins.rs::two_over`.
+    pub fn two_over(&mut self) -> Result<(), ShadowError> {
+        self.require(4)?;
+        let len = self.slots.len();
+        let a = self.slots[len - 4].clone();
+        let b = self.slots[len - 3].clone();
+        self.slots.push(a);
+        self.slots.push(b);
+        Ok(())
+    }
+
+    /// `2ROT`: rotate the top three pairs left. Mirrors `builtins.rs::two_rot`.
+    pub fn two_rot(&mut self) -> Result<(), ShadowError> {
+        self.require(6)?;
+        let len = self.slots.len();
+        self.slots[len - 6..].rotate_left(2);
         Ok(())
     }
 
@@ -465,8 +561,14 @@ impl ShadowStack {
                     ShadowWord::Swap => self.swap()?,
                     ShadowWord::Over => self.over()?,
                     ShadowWord::Rot => self.rot()?,
+                    ShadowWord::MinusRot => self.minus_rot()?,
                     ShadowWord::Nip => self.nip()?,
                     ShadowWord::Tuck => self.tuck()?,
+                    ShadowWord::TwoDup => self.two_dup()?,
+                    ShadowWord::TwoDrop => self.two_drop()?,
+                    ShadowWord::TwoSwap => self.two_swap()?,
+                    ShadowWord::TwoOver => self.two_over()?,
+                    ShadowWord::TwoRot => self.two_rot()?,
                     ShadowWord::Dip => {
                         // Mirror combinators.rs::dip EXACTLY: pop the quotation
                         // (top), set aside the next term, run the quotation on
@@ -482,6 +584,92 @@ impl ShadowStack {
                         // it on the whole stack.
                         let body = self.pop_quote()?;
                         self.exec(&body, resolve)?;
+                    }
+                    ShadowWord::Keep => {
+                        self.require(2)?;
+                        let body = self.pop_quote()?;
+                        let kept = self.slots.last().unwrap().clone();
+                        self.exec(&body, resolve)?;
+                        self.push_slot(kept);
+                    }
+                    ShadowWord::Bi => {
+                        self.require(3)?;
+                        let q = self.pop_quote()?;
+                        let p = self.pop_quote()?;
+                        let x = self.pop()?;
+                        self.push_slot(x.clone());
+                        self.exec(&p, resolve)?;
+                        self.push_slot(x);
+                        self.exec(&q, resolve)?;
+                    }
+                    ShadowWord::BiStar => {
+                        self.require(4)?;
+                        let q = self.pop_quote()?;
+                        let p = self.pop_quote()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.push_slot(x);
+                        self.exec(&p, resolve)?;
+                        self.push_slot(y);
+                        self.exec(&q, resolve)?;
+                    }
+                    ShadowWord::BiAt => {
+                        self.require(3)?;
+                        let q = self.pop_quote()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.push_slot(x);
+                        self.exec(&q, resolve)?;
+                        self.push_slot(y);
+                        self.exec(&q, resolve)?;
+                    }
+                    ShadowWord::Tri => {
+                        self.require(4)?;
+                        let r = self.pop_quote()?;
+                        let q = self.pop_quote()?;
+                        let p = self.pop_quote()?;
+                        let x = self.pop()?;
+                        self.push_slot(x.clone());
+                        self.exec(&p, resolve)?;
+                        self.push_slot(x.clone());
+                        self.exec(&q, resolve)?;
+                        self.push_slot(x);
+                        self.exec(&r, resolve)?;
+                    }
+                    ShadowWord::TriStar => {
+                        self.require(6)?;
+                        let r = self.pop_quote()?;
+                        let q = self.pop_quote()?;
+                        let p = self.pop_quote()?;
+                        let z = self.pop()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.push_slot(x);
+                        self.exec(&p, resolve)?;
+                        self.push_slot(y);
+                        self.exec(&q, resolve)?;
+                        self.push_slot(z);
+                        self.exec(&r, resolve)?;
+                    }
+                    ShadowWord::TriAt => {
+                        self.require(4)?;
+                        let q = self.pop_quote()?;
+                        let z = self.pop()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.push_slot(x);
+                        self.exec(&q, resolve)?;
+                        self.push_slot(y);
+                        self.exec(&q, resolve)?;
+                        self.push_slot(z);
+                        self.exec(&q, resolve)?;
+                    }
+                    ShadowWord::Compose => {
+                        self.require(2)?;
+                        let q = self.pop_quote()?;
+                        let mut p = self.pop_quote()?;
+                        p.extend(q);
+                        self.push_quote(p);
                     }
                     ShadowWord::Bin(op) => self.bin(op)?,
                     ShadowWord::Un(op) => self.un(op)?,
@@ -611,6 +799,8 @@ mod tests {
     fn core_shadow_word_requires_runtime_spelling() {
         assert_eq!(core_shadow_word("DUP"), Some(ShadowWord::Dup));
         assert_eq!(core_shadow_word("DIP"), Some(ShadowWord::Dip));
+        assert_eq!(core_shadow_word("2ROT"), Some(ShadowWord::TwoRot));
+        assert_eq!(core_shadow_word("TRI"), Some(ShadowWord::Tri));
         assert_eq!(core_shadow_word("dup"), None);
         assert_eq!(core_shadow_word("dip"), None);
     }
@@ -923,8 +1113,14 @@ mod tests {
         assert_conformance("SWAP", 2);
         assert_conformance("OVER", 2);
         assert_conformance("ROT", 3);
+        assert_conformance("-ROT", 3);
         assert_conformance("NIP", 2);
         assert_conformance("TUCK", 2);
+        assert_conformance("2DUP", 2);
+        assert_conformance("2DROP", 2);
+        assert_conformance("2SWAP", 4);
+        assert_conformance("2OVER", 4);
+        assert_conformance("2ROT", 6);
         assert_conformance("DUP SWAP DROP", 3);
         assert_conformance("OVER OVER ROT", 3);
         assert_conformance("[ SWAP ] DIP", 3);
@@ -934,6 +1130,14 @@ mod tests {
         assert_conformance("[ ROT ] DIP", 4);
         assert_conformance("[ [ SWAP ] DIP ] DIP", 4);
         assert_conformance("[ SWAP ] CALL", 2);
+        assert_conformance("[ DUP ] KEEP", 1);
+        assert_conformance("[ DUP ] [ DROP ] BI", 1);
+        assert_conformance("[ DUP ] [ DROP ] BI*", 2);
+        assert_conformance("[ DUP ] BI@", 2);
+        assert_conformance("[ DUP ] [ DROP ] [ SWAP ] TRI", 2);
+        assert_conformance("[ DUP ] [ DROP ] [ SWAP ] TRI*", 3);
+        assert_conformance("[ DUP ] TRI@", 3);
+        assert_conformance("[ SWAP ] [ DUP ] COMPOSE CALL", 2);
     }
 
     #[test]
@@ -955,7 +1159,7 @@ mod tests {
         // Words requiring at least N values present (excluding the quotation for
         // DIP/CALL). Track an abstract height so generated programs are valid.
         for _ in 0..2000 {
-            let depth = 2 + (next() % 4); // 2..=5 seeded values
+            let depth = 2 + (next() % 5); // 2..=6 seeded values
             let mut height = depth as i64;
             let mut program = String::new();
             let steps = 1 + next() % 8;
@@ -969,8 +1173,14 @@ mod tests {
                     ("SWAP", 2, 0),
                     ("OVER", 2, 1),
                     ("ROT", 3, 0),
+                    ("-ROT", 3, 0),
                     ("NIP", 2, -1),
                     ("TUCK", 2, 1),
+                    ("2DUP", 2, 2),
+                    ("2DROP", 2, -2),
+                    ("2SWAP", 4, 0),
+                    ("2OVER", 4, 2),
+                    ("2ROT", 6, 0),
                 ];
                 let pick = &choices[(next() as usize) % choices.len()];
                 if height < pick.1 {

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -1049,8 +1049,14 @@ fn apply_core<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
         ShadowWord::Swap => stack.swap(),
         ShadowWord::Over => stack.over(),
         ShadowWord::Rot => stack.rot(),
+        ShadowWord::MinusRot => stack.minus_rot(),
         ShadowWord::Nip => stack.nip(),
         ShadowWord::Tuck => stack.tuck(),
+        ShadowWord::TwoDup => stack.two_dup(),
+        ShadowWord::TwoDrop => stack.two_drop(),
+        ShadowWord::TwoSwap => stack.two_swap(),
+        ShadowWord::TwoOver => stack.two_over(),
+        ShadowWord::TwoRot => stack.two_rot(),
         ShadowWord::Bin(op) => stack.bin(op),
         ShadowWord::Un(op) => stack.un(op),
         ShadowWord::Num(lexeme) => {
@@ -1074,6 +1080,94 @@ fn apply_core<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
         ShadowWord::Call => {
             let body = stack.pop_quote()?;
             verify_ctx(&body, stack, solver, resolve, ctx)
+        }
+        ShadowWord::Keep => {
+            stack.require(2)?;
+            let body = stack.pop_quote()?;
+            let kept = stack.slots().last().unwrap().clone();
+            verify_ctx(&body, stack, solver, resolve, ctx)?;
+            stack.push_slot(kept);
+            Ok(())
+        }
+        ShadowWord::Bi => {
+            stack.require(3)?;
+            let q = stack.pop_quote()?;
+            let p = stack.pop_quote()?;
+            let x = stack.pop()?;
+            stack.push_slot(x.clone());
+            verify_ctx(&p, stack, solver, resolve, ctx)?;
+            stack.push_slot(x);
+            verify_ctx(&q, stack, solver, resolve, ctx)
+        }
+        ShadowWord::BiStar => {
+            stack.require(4)?;
+            let q = stack.pop_quote()?;
+            let p = stack.pop_quote()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            stack.push_slot(x);
+            verify_ctx(&p, stack, solver, resolve, ctx)?;
+            stack.push_slot(y);
+            verify_ctx(&q, stack, solver, resolve, ctx)
+        }
+        ShadowWord::BiAt => {
+            stack.require(3)?;
+            let q = stack.pop_quote()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            stack.push_slot(x);
+            verify_ctx(&q, stack, solver, resolve, ctx)?;
+            stack.push_slot(y);
+            verify_ctx(&q, stack, solver, resolve, ctx)
+        }
+        ShadowWord::Tri => {
+            stack.require(4)?;
+            let r = stack.pop_quote()?;
+            let q = stack.pop_quote()?;
+            let p = stack.pop_quote()?;
+            let x = stack.pop()?;
+            stack.push_slot(x.clone());
+            verify_ctx(&p, stack, solver, resolve, ctx)?;
+            stack.push_slot(x.clone());
+            verify_ctx(&q, stack, solver, resolve, ctx)?;
+            stack.push_slot(x);
+            verify_ctx(&r, stack, solver, resolve, ctx)
+        }
+        ShadowWord::TriStar => {
+            stack.require(6)?;
+            let r = stack.pop_quote()?;
+            let q = stack.pop_quote()?;
+            let p = stack.pop_quote()?;
+            let z = stack.pop()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            stack.push_slot(x);
+            verify_ctx(&p, stack, solver, resolve, ctx)?;
+            stack.push_slot(y);
+            verify_ctx(&q, stack, solver, resolve, ctx)?;
+            stack.push_slot(z);
+            verify_ctx(&r, stack, solver, resolve, ctx)
+        }
+        ShadowWord::TriAt => {
+            stack.require(4)?;
+            let q = stack.pop_quote()?;
+            let z = stack.pop()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            stack.push_slot(x);
+            verify_ctx(&q, stack, solver, resolve, ctx)?;
+            stack.push_slot(y);
+            verify_ctx(&q, stack, solver, resolve, ctx)?;
+            stack.push_slot(z);
+            verify_ctx(&q, stack, solver, resolve, ctx)
+        }
+        ShadowWord::Compose => {
+            stack.require(2)?;
+            let q = stack.pop_quote()?;
+            let mut p = stack.pop_quote()?;
+            p.extend(q);
+            stack.push_quote(p);
+            Ok(())
         }
     }
 }

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -74,7 +74,8 @@ pub fn is_bool_literal(word: &str) -> bool {
 }
 
 /// The synthetic span carried by a language-core scheme's nodes. Core schemes
-/// (`DUP`/`DROP`/`SWAP`/`OVER`/`CALL`/`IF`) have no *source* location — they
+/// (`DUP`/`DROP`/`SWAP`/`OVER`/`CALL`/`IF` and the other fixed builtins here)
+/// have no *source* location — they
 /// are authored contracts, not parsed text — so their nodes are born at this
 /// neutral span and [`respan_word`] re-anchors them at the call-site token
 /// whenever a use is instantiated, so diagnostics point at the user's word
@@ -89,15 +90,25 @@ const CORE_SPAN: Span = Span { start: 0, end: 0 };
 /// This is the language-core counterpart to the embedder's
 /// [`crate::Evaluator::register_operator_with_contract`]: both contribute schemes
 /// to inference (§5 `lookup`), but core schemes are baked in rather than attested
-/// at embed time. The schemes are exactly §2:
+/// at embed time. The schemes include the §2 primitives and the fixed-arity
+/// stack/combinator words that the runtime implements directly:
 ///
 /// ```text
-/// DUP   : ( 'S a        -- 'S a a )
-/// DROP  : ( 'S a        -- 'S )
-/// SWAP  : ( 'S a b       -- 'S b a )
-/// OVER  : ( 'S a b       -- 'S a b a )
-/// CALL  : ( 'S ('S -- 'T) -- 'T )
-/// IF    : ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
+/// DUP    : ( 'S a        -- 'S a a )
+/// DROP   : ( 'S a        -- 'S )
+/// SWAP   : ( 'S a b      -- 'S b a )
+/// OVER   : ( 'S a b      -- 'S a b a )
+/// ROT    : ( 'S a b c    -- 'S b c a )
+/// -ROT   : ( 'S a b c    -- 'S c a b )
+/// NIP    : ( 'S a b      -- 'S b )
+/// TUCK   : ( 'S a b      -- 'S b a b )
+/// 2DUP   : ( 'S a b      -- 'S a b a b )
+/// 2DROP  : ( 'S a b      -- 'S )
+/// 2SWAP  : ( 'S a b c d  -- 'S c d a b )
+/// 2OVER  : ( 'S a b c d  -- 'S a b c d a b )
+/// 2ROT   : ( 'S a b c d e f -- 'S c d e f a b )
+/// CALL   : ( 'S ('S -- 'T) -- 'T )
+/// IF     : ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
 /// ```
 ///
 /// `DIP` is the M4 §8 **relay** combinator: its scheme alone states the only
@@ -107,48 +118,100 @@ const CORE_SPAN: Span = Span { start: 0, end: 0 };
 /// (§13 invariant 8).
 pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
     let s = CORE_SPAN;
+    let v = |idx| Ty::var(idx, s);
+    let stack = |row, elems| StackTy::new(elems, row, s);
+    let empty = |row| StackTy::empty(row, s);
+    let quote = |input, output| Ty::quote(WordTy::new(input, output), s);
     // The quotation argument's arrow ( 'S -- 'T ): rowvar 0 = 'S, rowvar 1 = 'T.
-    let arrow_st = || WordTy::new(StackTy::empty(0, s), StackTy::empty(1, s));
+    let arrow_st = || WordTy::new(empty(0), empty(1));
     let scheme = match runtime_name {
         "DUP" => Scheme::new(
             vec![0],
             vec![0],
-            WordTy::new(
-                StackTy::new(vec![Ty::var(0, s)], 0, s),
-                StackTy::new(vec![Ty::var(0, s), Ty::var(0, s)], 0, s),
-            ),
+            WordTy::new(stack(0, vec![v(0)]), stack(0, vec![v(0), v(0)])),
         ),
         "DROP" => Scheme::new(
             vec![0],
             vec![0],
-            WordTy::new(
-                StackTy::new(vec![Ty::var(0, s)], 0, s),
-                StackTy::empty(0, s),
-            ),
+            WordTy::new(stack(0, vec![v(0)]), empty(0)),
         ),
         "SWAP" => Scheme::new(
             vec![0, 1],
             vec![0],
-            WordTy::new(
-                StackTy::new(vec![Ty::var(0, s), Ty::var(1, s)], 0, s),
-                StackTy::new(vec![Ty::var(1, s), Ty::var(0, s)], 0, s),
-            ),
+            WordTy::new(stack(0, vec![v(0), v(1)]), stack(0, vec![v(1), v(0)])),
         ),
         "OVER" => Scheme::new(
             vec![0, 1],
             vec![0],
+            WordTy::new(stack(0, vec![v(0), v(1)]), stack(0, vec![v(0), v(1), v(0)])),
+        ),
+        "ROT" => Scheme::new(
+            vec![0, 1, 2],
+            vec![0],
             WordTy::new(
-                StackTy::new(vec![Ty::var(0, s), Ty::var(1, s)], 0, s),
-                StackTy::new(vec![Ty::var(0, s), Ty::var(1, s), Ty::var(0, s)], 0, s),
+                stack(0, vec![v(0), v(1), v(2)]),
+                stack(0, vec![v(1), v(2), v(0)]),
+            ),
+        ),
+        "-ROT" => Scheme::new(
+            vec![0, 1, 2],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), v(2)]),
+                stack(0, vec![v(2), v(0), v(1)]),
+            ),
+        ),
+        "NIP" => Scheme::new(
+            vec![0, 1],
+            vec![0],
+            WordTy::new(stack(0, vec![v(0), v(1)]), stack(0, vec![v(1)])),
+        ),
+        "TUCK" => Scheme::new(
+            vec![0, 1],
+            vec![0],
+            WordTy::new(stack(0, vec![v(0), v(1)]), stack(0, vec![v(1), v(0), v(1)])),
+        ),
+        "2DUP" => Scheme::new(
+            vec![0, 1],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![v(0), v(1)]),
+                stack(0, vec![v(0), v(1), v(0), v(1)]),
+            ),
+        ),
+        "2DROP" => Scheme::new(
+            vec![0, 1],
+            vec![0],
+            WordTy::new(stack(0, vec![v(0), v(1)]), empty(0)),
+        ),
+        "2SWAP" => Scheme::new(
+            vec![0, 1, 2, 3],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), v(2), v(3)]),
+                stack(0, vec![v(2), v(3), v(0), v(1)]),
+            ),
+        ),
+        "2OVER" => Scheme::new(
+            vec![0, 1, 2, 3],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), v(2), v(3)]),
+                stack(0, vec![v(0), v(1), v(2), v(3), v(0), v(1)]),
+            ),
+        ),
+        "2ROT" => Scheme::new(
+            vec![0, 1, 2, 3, 4, 5],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), v(2), v(3), v(4), v(5)]),
+                stack(0, vec![v(2), v(3), v(4), v(5), v(0), v(1)]),
             ),
         ),
         "CALL" => Scheme::new(
             vec![],
             vec![0, 1],
-            WordTy::new(
-                StackTy::new(vec![Ty::quote(arrow_st(), s)], 0, s),
-                StackTy::empty(1, s),
-            ),
+            WordTy::new(stack(0, vec![Ty::quote(arrow_st(), s)]), empty(1)),
         ),
         // DIP : ( 'S a ( 'S -- 'T ) -- 'T a ) (§2, §8 relay). Input has the
         // set-aside value `a` (tyvar 0) below the quotation ( 'S -- 'T ) on top
@@ -159,26 +222,100 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
             vec![0],
             vec![0, 1],
             WordTy::new(
-                StackTy::new(vec![Ty::var(0, s), Ty::quote(arrow_st(), s)], 0, s),
-                StackTy::new(vec![Ty::var(0, s)], 1, s),
+                stack(0, vec![v(0), Ty::quote(arrow_st(), s)]),
+                stack(1, vec![v(0)]),
             ),
         ),
         "IF" => Scheme::new(
             vec![],
             vec![0, 1],
             WordTy::new(
-                StackTy::new(
+                stack(
+                    0,
                     vec![
                         Ty::bool(s),
                         Ty::quote(arrow_st(), s),
                         Ty::quote(arrow_st(), s),
                     ],
-                    0,
-                    s,
                 ),
-                StackTy::empty(1, s),
+                empty(1),
             ),
         ),
+        "KEEP" => {
+            let q = quote(stack(0, vec![v(0)]), empty(1));
+            Scheme::new(
+                vec![0],
+                vec![0, 1],
+                WordTy::new(stack(0, vec![v(0), q]), stack(1, vec![v(0)])),
+            )
+        }
+        "BI" => {
+            let p = quote(stack(0, vec![v(0)]), empty(1));
+            let q = quote(stack(1, vec![v(0)]), empty(2));
+            Scheme::new(
+                vec![0],
+                vec![0, 1, 2],
+                WordTy::new(stack(0, vec![v(0), p, q]), empty(2)),
+            )
+        }
+        "BI*" => {
+            let p = quote(stack(0, vec![v(0)]), empty(1));
+            let q = quote(stack(1, vec![v(1)]), empty(2));
+            Scheme::new(
+                vec![0, 1],
+                vec![0, 1, 2],
+                WordTy::new(stack(0, vec![v(0), v(1), p, q]), empty(2)),
+            )
+        }
+        "BI@" => {
+            let q = quote(stack(1, vec![v(0)]), stack(1, vec![v(1)]));
+            Scheme::new(
+                vec![0, 1],
+                vec![0, 1],
+                WordTy::new(stack(0, vec![v(0), v(0), q]), stack(0, vec![v(1), v(1)])),
+            )
+        }
+        "TRI" => {
+            let p = quote(stack(0, vec![v(0)]), empty(1));
+            let q = quote(stack(1, vec![v(0)]), empty(2));
+            let r = quote(stack(2, vec![v(0)]), empty(3));
+            Scheme::new(
+                vec![0],
+                vec![0, 1, 2, 3],
+                WordTy::new(stack(0, vec![v(0), p, q, r]), empty(3)),
+            )
+        }
+        "TRI*" => {
+            let p = quote(stack(0, vec![v(0)]), empty(1));
+            let q = quote(stack(1, vec![v(1)]), empty(2));
+            let r = quote(stack(2, vec![v(2)]), empty(3));
+            Scheme::new(
+                vec![0, 1, 2],
+                vec![0, 1, 2, 3],
+                WordTy::new(stack(0, vec![v(0), v(1), v(2), p, q, r]), empty(3)),
+            )
+        }
+        "TRI@" => {
+            let q = quote(stack(1, vec![v(0)]), stack(1, vec![v(1)]));
+            Scheme::new(
+                vec![0, 1],
+                vec![0, 1],
+                WordTy::new(
+                    stack(0, vec![v(0), v(0), v(0), q]),
+                    stack(0, vec![v(1), v(1), v(1)]),
+                ),
+            )
+        }
+        "COMPOSE" => {
+            let p = quote(empty(1), empty(2));
+            let q = quote(empty(2), empty(3));
+            let composed = quote(empty(1), empty(3));
+            Scheme::new(
+                vec![],
+                vec![0, 1, 2, 3],
+                WordTy::new(stack(0, vec![p, q]), stack(0, vec![composed])),
+            )
+        }
         _ => return None,
     };
     Some(scheme)


### PR DESCRIPTION
Add fixed-arity stack shufflers and quotation combinators to the
language core, wiring each through every layer that the existing
primitives touch: runtime builtins, baked-in type schemes, shadow
execution, solver verification, and attestation.

New stack words: -ROT, 2DUP, 2DROP, 2SWAP, 2OVER, 2ROT.
New quotation combinators: TRI, TRI*, TRI@.

core_scheme now bakes Tier-0 schemes for the previously
runtime-only fixed words (ROT, NIP, TUCK, 2*) plus KEEP, BI, BI*,
BI@, TRI, TRI*, TRI@, and COMPOSE, so inference covers them
directly. A local helper set (v/stack/empty/quote) collapses the
repetitive StackTy/Ty construction.

CORE_PRIMITIVES and the operator-table test grow to enumerate the
full modulo; the shadow interpreter, solver verifier, and the
conformance/proptest harnesses gain the matching cases so the
shadow stays in lockstep with builtins.

README documents the new words with examples.

Co-authored-by: AI
