### PR TITLE
feat(caternary): build out the REPL with meta-commands and history

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -115,6 +115,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Command-Line Tools
+
+`caternary check` reads a whole program from standard input, loads its
+definitions, and runs the whole-program checker. A checked program must define
+`main`:
+
+```sh
+printf '[ 1 2 + ] :main\n' | caternary check
+```
+
+`caternary repl` starts the development REPL. Normal input is parsed, loaded,
+and evaluated against a persistent definition table and stack. Definition pairs
+such as `[ 1 + ] :inc` are loaded but not pushed onto the runtime stack.
+
+REPL meta-commands start with `:`:
+
+| Command | Behavior |
+|---|---|
+| `:help` | Show REPL commands. |
+| `:quit`, `:q` | Exit the REPL. |
+| `:stack` | Print the current stack. |
+| `:clear` | Clear the current stack. |
+| `:reset` | Clear stack and session definitions. |
+| `:defs` | List loaded user definitions as `name = [body]`. |
+| `:ops` | List typed core and registered operators. |
+| `:type <program>` | Infer and print the stack effect of a program snippet. |
+| `:check [program]` | Run the whole-program checker on the session, optionally plus a temporary program. |
+| `:load <path>` | Load and evaluate a source file transactionally. |
+
+REPL input is transactional: a parse, load, type, check, or evaluation error
+leaves the previous stack and definitions intact. If an input line has an
+unclosed `[` or shell quote, the REPL continues with a `... ` prompt until the
+program is complete. History is persisted in `~/.caternary_history` when
+available.
+
 ## Language Features By Example
 
 Assume the evaluator has all builtins registered. Examples that use `EVEN` assume

--- a/caternary/src/bin/caternary.rs
+++ b/caternary/src/bin/caternary.rs
@@ -1,16 +1,17 @@
 use std::error::Error;
 use std::fmt;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use arrrg::CommandLine;
 use caternary::{
-    CODE_OPERATOR_ERROR, EvalError, Evaluator, Quotable, Scheme, SmtLibSolver, Span, SpannedToken,
-    SpannedTokenKind, StackTy, Token, Ty, WordTy, check_whole_program, format_word_type,
-    infer_quote_type, parse_with_spans, register_all_builtins,
+    CODE_OPERATOR_ERROR, EvalError, Evaluator, ParseError, Quotable, Scheme, SmtLibSolver, Span,
+    SpannedToken, SpannedTokenKind, StackTy, Token, Ty, WordTy, check_whole_program, core_scheme,
+    format_word_type, infer_quote_type, parse_with_spans, register_all_builtins,
 };
 use handled::SError;
 use rustyline::error::ReadlineError;
-use rustyline::history::MemHistory;
+use rustyline::history::FileHistory;
 use rustyline::{Config, Editor};
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -22,11 +23,11 @@ struct Options {}
 struct CheckOptions {}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, arrrg_derive::CommandLine)]
-struct ShellOptions {}
+struct ReplOptions {}
 
 enum Command {
     Check(CheckOptions, Vec<String>),
-    Shell(ShellOptions, Vec<String>),
+    Repl(ReplOptions, Vec<String>),
 }
 
 #[derive(Debug)]
@@ -47,6 +48,11 @@ enum Value {
     Bool(bool),
     Quotation(Vec<Token>),
 }
+
+const CORE_OPERATOR_NAMES: &[&str] = &[
+    "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER",
+    "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
+];
 
 impl From<Token> for Value {
     fn from(token: Token) -> Self {
@@ -113,19 +119,19 @@ fn main() {
 
 fn run() -> Result<()> {
     let (_options, free) = Options::from_command_line_relaxed(
-        "Usage: caternary [OPTIONS] <check|shell> [COMMAND OPTIONS]",
+        "Usage: caternary [OPTIONS] <check|repl> [COMMAND OPTIONS]",
     );
     let command = arrrg::dispatch_subcommands!(free, {
         "check" => CheckOptions as check, check_free => {
             Ok(Command::Check(check, check_free))
         },
-        "shell" => ShellOptions as shell, shell_free => {
-            Ok(Command::Shell(shell, shell_free))
+        "repl" => ReplOptions as repl, repl_free => {
+            Ok(Command::Repl(repl, repl_free))
         },
     })?;
     match command {
         Command::Check(options, free) => check_command(options, free),
-        Command::Shell(options, free) => shell_command(options, free),
+        Command::Repl(options, free) => repl_command(options, free),
     }
 }
 
@@ -143,63 +149,343 @@ fn check_command(_options: CheckOptions, free: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn shell_command(_options: ShellOptions, free: Vec<String>) -> Result<()> {
-    expect_no_positionals("shell", &free)?;
+fn repl_command(_options: ReplOptions, free: Vec<String>) -> Result<()> {
+    expect_no_positionals("repl", &free)?;
 
     let config = Config::builder()
         .max_history_size(1_000_000)?
         .history_ignore_dups(true)?
         .history_ignore_space(true)
         .build();
-    let hist = MemHistory::new();
-    let mut rl: Editor<(), MemHistory> = Editor::with_history(config, hist)?;
-    let mut evaluator = new_evaluator();
-    let mut stack = Vec::new();
+    let hist = FileHistory::with_config(config);
+    let mut rl: Editor<(), FileHistory> = Editor::with_history(config, hist)?;
+    let history = history_path();
+    if let Some(history) = &history
+        && history.exists()
+        && let Err(err) = rl.load_history(history)
+    {
+        eprintln!("warning: could not load history: {err}");
+    }
+
+    let mut state = ReplState::new();
+    let mut pending = String::new();
 
     loop {
-        match rl.readline("caternary> ") {
+        let prompt = if pending.is_empty() {
+            "caternary> "
+        } else {
+            "... "
+        };
+        match rl.readline(prompt) {
             Ok(line) => {
                 rl.add_history_entry(&line)?;
-                let line = line.trim();
-                if line.is_empty() {
+                append_line(&mut pending, &line);
+                let source = pending.trim();
+                if source.is_empty() {
+                    pending.clear();
                     continue;
                 }
-                if line == "exit" || line == "quit" {
-                    return Ok(());
+                if source.starts_with(':') {
+                    let command = pending.clone();
+                    pending.clear();
+                    match state.handle_meta_command(command.trim()) {
+                        Ok(ReplAction::Quit) => {
+                            save_history(&mut rl, history.as_deref());
+                            return Ok(());
+                        }
+                        Ok(ReplAction::Continue) => {}
+                        Err(err) => eprintln!("error: {err}"),
+                    }
+                    continue;
                 }
-                match shell_eval_line(&mut evaluator, &mut stack, line) {
-                    Ok(()) => println!("{}", format_stack(&stack)),
+
+                if input_is_incomplete(&pending) {
+                    continue;
+                }
+
+                let source = pending.clone();
+                pending.clear();
+                match state.eval_source(&source) {
+                    Ok(()) => println!("{}", format_stack(&state.stack)),
                     Err(err) => eprintln!("error: {err}"),
                 }
             }
-            Err(ReadlineError::Interrupted) => continue,
-            Err(ReadlineError::Eof) => return Ok(()),
-            Err(err) => return Err(Box::new(err)),
+            Err(ReadlineError::Interrupted) => {
+                pending.clear();
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                save_history(&mut rl, history.as_deref());
+                return Ok(());
+            }
+            Err(err) => {
+                save_history(&mut rl, history.as_deref());
+                return Err(Box::new(err));
+            }
         }
     }
 }
 
-fn shell_eval_line(
-    evaluator: &mut Evaluator<Value>,
-    stack: &mut Vec<Value>,
-    line: &str,
-) -> Result<()> {
-    let spanned = parse_with_spans(line)?;
-    evaluator.load_with_spans(&spanned)?;
-    let tokens = shell_runtime_tokens(&spanned);
-    evaluator.eval_with_stack(&tokens, stack)?;
-    Ok(())
+#[derive(Clone)]
+struct ReplState {
+    evaluator: Evaluator<Value>,
+    stack: Vec<Value>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReplAction {
+    Continue,
+    Quit,
+}
+
+impl ReplState {
+    fn new() -> Self {
+        Self {
+            evaluator: new_evaluator(),
+            stack: Vec::new(),
+        }
+    }
+
+    fn eval_source(&mut self, source: &str) -> Result<()> {
+        let mut candidate = self.clone();
+        candidate.eval_source_in_place(source)?;
+        *self = candidate;
+        Ok(())
+    }
+
+    fn eval_source_in_place(&mut self, source: &str) -> Result<()> {
+        let spanned = parse_with_spans(source)?;
+        self.evaluator.load_with_spans(&spanned)?;
+        let tokens = repl_runtime_tokens(&spanned);
+        self.evaluator.eval_with_stack(&tokens, &mut self.stack)?;
+        Ok(())
+    }
+
+    fn type_source(&self, source: &str) -> Result<String> {
+        let mut candidate = self.evaluator.clone();
+        let spanned = parse_with_spans(source)?;
+        candidate.load_with_spans(&spanned)?;
+        let tokens = repl_runtime_tokens(&spanned);
+        let word = infer_quote_type(&candidate, &tokens)?;
+        Ok(format_word_type(&word))
+    }
+
+    fn check_source(&self, source: Option<&str>) -> Result<()> {
+        let mut candidate = self.evaluator.clone();
+        if let Some(source) = source {
+            let spanned = parse_with_spans(source)?;
+            candidate.load_with_spans(&spanned)?;
+        }
+        check_whole_program(&candidate, SmtLibSolver::new)?;
+        Ok(())
+    }
+
+    fn load_file(&mut self, path: &Path) -> Result<()> {
+        let source = std::fs::read_to_string(path)?;
+        self.eval_source(&source)
+    }
+
+    fn definition_lines(&self) -> Vec<String> {
+        let mut names: Vec<&str> = self.evaluator.definition_names().collect();
+        names.sort_unstable();
+        names
+            .into_iter()
+            .map(|name| {
+                let body = self.evaluator.definition_body(name).unwrap_or(&[]);
+                format!("{name} = [{}]", format_tokens(body))
+            })
+            .collect()
+    }
+
+    fn operator_lines(&self) -> Vec<String> {
+        let mut ops: Vec<(String, String)> = CORE_OPERATOR_NAMES
+            .iter()
+            .filter_map(|name| {
+                core_scheme(name).map(|scheme| (name.to_string(), format_word_type(&scheme.ty)))
+            })
+            .collect();
+        ops.extend(self.evaluator.contract_names().filter_map(|name| {
+            self.evaluator
+                .contract(name)
+                .map(|scheme| (name.to_string(), format_word_type(&scheme.ty)))
+        }));
+        ops.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        ops.dedup_by(|left, right| left.0 == right.0);
+        ops.into_iter()
+            .map(|(name, ty)| format!("{name} : {ty}"))
+            .collect()
+    }
+
+    fn handle_meta_command(&mut self, line: &str) -> Result<ReplAction> {
+        let (command, args) = split_meta_command(line)?;
+        match command {
+            "help" => {
+                print_help();
+                Ok(ReplAction::Continue)
+            }
+            "q" | "quit" => {
+                expect_empty_meta_args(command, args)?;
+                Ok(ReplAction::Quit)
+            }
+            "stack" => {
+                expect_empty_meta_args(command, args)?;
+                println!("{}", format_stack(&self.stack));
+                Ok(ReplAction::Continue)
+            }
+            "clear" => {
+                expect_empty_meta_args(command, args)?;
+                self.stack.clear();
+                println!("{}", format_stack(&self.stack));
+                Ok(ReplAction::Continue)
+            }
+            "reset" => {
+                expect_empty_meta_args(command, args)?;
+                *self = ReplState::new();
+                println!("reset");
+                Ok(ReplAction::Continue)
+            }
+            "defs" => {
+                expect_empty_meta_args(command, args)?;
+                print_lines_or_empty(self.definition_lines(), "no definitions");
+                Ok(ReplAction::Continue)
+            }
+            "ops" => {
+                expect_empty_meta_args(command, args)?;
+                print_lines_or_empty(self.operator_lines(), "no operators");
+                Ok(ReplAction::Continue)
+            }
+            "type" => {
+                if args.trim().is_empty() {
+                    return Err(cli_error("usage: :type <program>"));
+                }
+                println!("{}", self.type_source(args)?);
+                Ok(ReplAction::Continue)
+            }
+            "check" => {
+                let source = (!args.trim().is_empty()).then_some(args);
+                self.check_source(source)?;
+                println!("ok");
+                Ok(ReplAction::Continue)
+            }
+            "load" => {
+                let path = parse_load_path(args)?;
+                self.load_file(Path::new(&path))?;
+                println!("{}", format_stack(&self.stack));
+                Ok(ReplAction::Continue)
+            }
+            _ => Err(cli_error(format!("unknown REPL command `:{command}`"))),
+        }
+    }
+}
+
+fn append_line(buffer: &mut String, line: &str) {
+    if !buffer.is_empty() {
+        buffer.push('\n');
+    }
+    buffer.push_str(line);
+}
+
+fn input_is_incomplete(source: &str) -> bool {
+    match parse_with_spans(source) {
+        Ok(_) => false,
+        Err(err) => parse_error_is_incomplete(&err),
+    }
+}
+
+fn parse_error_is_incomplete(err: &ParseError) -> bool {
+    match err {
+        ParseError::UnmatchedOpenBracket { .. } => true,
+        ParseError::Tokenization { message } => {
+            message.contains("unclosed single quotes") || message.contains("unclosed double quotes")
+        }
+        ParseError::UnmatchedCloseBracket { .. } => false,
+    }
+}
+
+fn history_path() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(|home| PathBuf::from(home).join(".caternary_history"))
+}
+
+fn save_history(rl: &mut Editor<(), FileHistory>, history: Option<&Path>) {
+    if let Some(history) = history
+        && let Err(err) = rl.save_history(history)
+    {
+        eprintln!("warning: could not save history: {err}");
+    }
+}
+
+fn split_meta_command(line: &str) -> Result<(&str, &str)> {
+    let Some(rest) = line.trim().strip_prefix(':') else {
+        return Err(cli_error("REPL commands must start with `:`"));
+    };
+    let rest = rest.trim_start();
+    if rest.is_empty() {
+        return Err(cli_error("empty REPL command"));
+    }
+    let split_at = rest
+        .char_indices()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(idx, _)| idx)
+        .unwrap_or(rest.len());
+    let (command, args) = rest.split_at(split_at);
+    Ok((command, args.trim_start()))
+}
+
+fn expect_empty_meta_args(command: &str, args: &str) -> Result<()> {
+    if args.trim().is_empty() {
+        Ok(())
+    } else {
+        Err(cli_error(format!(":{command} takes no arguments")))
+    }
+}
+
+fn parse_load_path(args: &str) -> Result<String> {
+    let words = shvar::split(args)?;
+    match words.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => Err(cli_error("usage: :load <path>")),
+        _ => Err(cli_error(":load takes exactly one path")),
+    }
+}
+
+fn print_lines_or_empty(lines: Vec<String>, empty: &str) {
+    if lines.is_empty() {
+        println!("{empty}");
+    } else {
+        for line in lines {
+            println!("{line}");
+        }
+    }
+}
+
+fn print_help() {
+    println!(":help          show REPL commands");
+    println!(":quit, :q      exit");
+    println!(":stack         print the stack");
+    println!(":clear         clear the stack");
+    println!(":reset         clear stack and definitions");
+    println!(":defs          list loaded definitions");
+    println!(":ops           list typed operators");
+    println!(":type <prog>   infer a stack effect");
+    println!(":check [prog]  run the whole-program checker");
+    println!(":load <path>   load and evaluate a source file");
+}
+
+fn cli_error(message: impl Into<String>) -> Box<dyn Error> {
+    Box::new(CliError(message.into()))
 }
 
 fn new_evaluator() -> Evaluator<Value> {
     let mut evaluator = Evaluator::new();
     register_all_builtins(&mut evaluator);
-    register_shell_builtins(&mut evaluator);
+    register_repl_builtins(&mut evaluator);
     evaluator
 }
 
-fn register_shell_builtins(evaluator: &mut Evaluator<Value>) {
-    evaluator.define("TYPEOF", |stack, evaluator| shell_typeof(stack, evaluator));
+fn register_repl_builtins(evaluator: &mut Evaluator<Value>) {
+    evaluator.define("TYPEOF", |stack, evaluator| repl_typeof(stack, evaluator));
     evaluator.register_operator_with_contract("TYPEOF", typeof_scheme());
 }
 
@@ -215,13 +501,13 @@ fn typeof_scheme() -> Scheme {
     )
 }
 
-fn shell_typeof(
+fn repl_typeof(
     stack: &mut [Value],
     evaluator: &Evaluator<Value>,
 ) -> std::result::Result<(), EvalError> {
     let value = stack
         .last()
-        .ok_or_else(|| shell_operator_error("stack underflow: need at least 1 values, found 0"))?;
+        .ok_or_else(|| repl_operator_error("stack underflow: need at least 1 values, found 0"))?;
     println!("{}", typeof_value(evaluator, value)?);
     Ok(())
 }
@@ -233,14 +519,14 @@ fn typeof_value(
     match value {
         Value::Quotation(tokens) => infer_quote_type(evaluator, tokens)
             .map(|word| format_word_type(&word))
-            .map_err(|err| shell_operator_error(err.to_string())),
-        _ => Err(shell_operator_error(
+            .map_err(|err| repl_operator_error(err.to_string())),
+        _ => Err(repl_operator_error(
             "TYPEOF expects a quotation on top of the stack",
         )),
     }
 }
 
-fn shell_operator_error(message: impl AsRef<str>) -> EvalError {
+fn repl_operator_error(message: impl AsRef<str>) -> EvalError {
     SError::new("caternary-eval")
         .with_code(CODE_OPERATOR_ERROR)
         .with_message(message.as_ref())
@@ -256,7 +542,7 @@ fn expect_no_positionals(command: &str, free: &[String]) -> Result<()> {
     }
 }
 
-fn shell_runtime_tokens(tokens: &[SpannedToken]) -> Vec<Token> {
+fn repl_runtime_tokens(tokens: &[SpannedToken]) -> Vec<Token> {
     let mut skip = vec![false; tokens.len()];
     for i in 1..tokens.len() {
         let SpannedTokenKind::Word(word) = &tokens[i].kind else {
@@ -370,24 +656,72 @@ mod tests {
     }
 
     #[test]
-    fn shell_typeof_preserves_the_stack() {
-        let mut evaluator = new_evaluator();
-        let mut stack = Vec::new();
+    fn repl_typeof_preserves_the_stack() {
+        let mut state = ReplState::new();
 
-        shell_eval_line(&mut evaluator, &mut stack, "[ 1 + ] TYPEOF").unwrap();
+        state.eval_source("[ 1 + ] TYPEOF").unwrap();
 
-        assert_eq!(format_stack(&stack), "[[1 +]]");
+        assert_eq!(format_stack(&state.stack), "[[1 +]]");
     }
 
     #[test]
-    fn typeof_resolves_shell_definitions() {
-        let mut evaluator = new_evaluator();
-        let mut stack = Vec::new();
-        shell_eval_line(&mut evaluator, &mut stack, "[ 1 + ] :inc").unwrap();
-        shell_eval_line(&mut evaluator, &mut stack, "[ inc ]").unwrap();
+    fn typeof_resolves_repl_definitions() {
+        let mut state = ReplState::new();
+        state.eval_source("[ 1 + ] :inc").unwrap();
+        state.eval_source("[ inc ]").unwrap();
 
-        let rendered = typeof_value(&evaluator, stack.last().unwrap()).unwrap();
+        let rendered = typeof_value(&state.evaluator, state.stack.last().unwrap()).unwrap();
 
         assert_eq!("( 'S Num -- 'S Num )", rendered);
+    }
+
+    #[test]
+    fn repl_eval_is_transactional_on_error() {
+        let mut state = ReplState::new();
+        state.eval_source("1 2").unwrap();
+
+        let err = state.eval_source("DROP DROP DROP").unwrap_err();
+
+        assert!(err.to_string().contains("stack underflow"));
+        assert_eq!(format_stack(&state.stack), "[1 2]");
+    }
+
+    #[test]
+    fn type_source_loads_definitions_read_only() {
+        let state = ReplState::new();
+
+        let rendered = state.type_source("[ 1 + ] :inc inc").unwrap();
+
+        assert_eq!("( 'S Num -- 'S Num )", rendered);
+        assert!(!state.evaluator.has_definition("inc"));
+    }
+
+    #[test]
+    fn definition_lines_show_sorted_bodies() {
+        let mut state = ReplState::new();
+        state.eval_source("[ 2 * ] :double [ 1 + ] :inc").unwrap();
+
+        let lines = state.definition_lines();
+
+        assert_eq!(
+            vec!["double = [2 *]".to_string(), "inc = [1 +]".to_string()],
+            lines
+        );
+    }
+
+    #[test]
+    fn operator_lines_include_core_and_repl_contracts() {
+        let state = ReplState::new();
+        let lines = state.operator_lines();
+
+        assert!(lines.iter().any(|line| line.starts_with("DUP : ")));
+        assert!(lines.iter().any(|line| line.starts_with("TYPEOF : ")));
+    }
+
+    #[test]
+    fn unmatched_open_bracket_is_incomplete_input() {
+        assert!(input_is_incomplete("[ 1 2"));
+        assert!(!input_is_incomplete("[ 1 2 ]"));
+        assert!(!input_is_incomplete("]"));
     }
 }

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -203,6 +203,19 @@ pub struct Evaluator<T> {
     refinements: HashMap<String, crate::RefinementSig>,
 }
 
+impl<T> Clone for Evaluator<T> {
+    fn clone(&self) -> Self {
+        Self {
+            operators: self.operators.clone(),
+            definitions: self.definitions.clone(),
+            contracts: self.contracts.clone(),
+            definition_spans: self.definition_spans.clone(),
+            annotations: self.annotations.clone(),
+            refinements: self.refinements.clone(),
+        }
+    }
+}
+
 impl<T> Default for Evaluator<T>
 where
     T: Quotable,


### PR DESCRIPTION
Rename the `shell` subcommand to `repl` and turn it into a proper
development REPL backed by a persistent ReplState (evaluator plus
stack).

REPL behavior:
- Meta-commands: :help, :quit/:q, :stack, :clear, :reset, :defs, :ops,
  :type <prog>, :check [prog], and :load <path>.
- Transactional input: parse, load, type, check, and eval run against a
  clone that is committed only on success, so errors leave the prior
  stack and definitions intact.
- Multi-line continuation: incomplete input (unclosed bracket or shell
  quote) keeps reading under a `... ` prompt until the program parses.
- Persistent history: switch from MemHistory to FileHistory, loading and
  saving ~/.caternary_history when HOME is set.

Add a Clone impl for Evaluator<T> so the REPL can snapshot session
state for transactional evaluation and read-only :type/:check.

Document the command-line tools and REPL meta-commands in the README,
and update the binary tests to drive ReplState (transactional eval,
read-only type inference, sorted definition listings).

Co-authored-by: AI
