### PR TITLE
feat(caternary): add arity-2 and arity-3 quotation combinators

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -179,7 +179,11 @@ a host predicate with that name is also registered.
 |---|---|---|
 | `CALL` | `1 2 [+] CALL` | `3` |
 | `DIP` | `1 2 3 [+] DIP` | `3 3` |
+| `2DIP` | `1 2 3 4 [+] 2DIP` | `3 3 4` |
+| `3DIP` | `1 2 3 4 5 [+] 3DIP` | `3 3 4 5` |
 | `KEEP` | `5 [DUP *] KEEP` | `25 5` |
+| `2KEEP` | `3 4 [+] 2KEEP` | `7 3 4` |
+| `3KEEP` | `2 3 4 [+ +] 3KEEP` | `9 2 3 4` |
 | `BI` | `5 [DUP +] [DUP *] BI` | `10 25` |
 | `BI*` | `3 4 [DUP *] [DUP +] BI*` | `9 8` |
 | `BI@` | `3 4 [DUP *] BI@` | `9 16` |
@@ -190,6 +194,8 @@ a host predicate with that name is also registered.
 | `SPREAD` | `1 2 3 [[DUP +] [DUP *] [1 +]] SPREAD` | `2 4 4` |
 | `COMPOSE` | `[1 +] [2 *] COMPOSE` | `[1 + 2 *]` |
 | `CURRY` | `10 [+] CURRY` | `[10 +]` |
+| `2CURRY` | `10 20 [+ +] 2CURRY` | `[10 20 + +]` |
+| `3CURRY` | `1 2 3 [+ + +] 3CURRY` | `[1 2 3 + + +]` |
 
 ### Conditionals
 

--- a/caternary/src/attestation.rs
+++ b/caternary/src/attestation.rs
@@ -51,7 +51,8 @@ use crate::types::core_scheme;
 
 const CORE_PRIMITIVES: &[&str] = &[
     "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER",
-    "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
+    "2ROT", "CALL", "DIP", "2DIP", "3DIP", "IF", "KEEP", "2KEEP", "3KEEP", "BI", "BI*", "BI@",
+    "TRI", "TRI*", "TRI@", "COMPOSE",
 ];
 
 // ===========================================================================

--- a/caternary/src/attestation/tests.rs
+++ b/caternary/src/attestation/tests.rs
@@ -191,8 +191,8 @@ fn operator_table_enumerates_the_modulo() {
     let core_names: Vec<String> = table.core().map(|c| c.name.clone()).collect();
     let expected_core = [
         "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP",
-        "2OVER", "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@",
-        "COMPOSE",
+        "2OVER", "2ROT", "CALL", "DIP", "2DIP", "3DIP", "IF", "KEEP", "2KEEP", "3KEEP", "BI",
+        "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
     ];
     for p in expected_core.iter().copied() {
         assert!(

--- a/caternary/src/bin/caternary.rs
+++ b/caternary/src/bin/caternary.rs
@@ -51,7 +51,8 @@ enum Value {
 
 const CORE_OPERATOR_NAMES: &[&str] = &[
     "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER",
-    "2ROT", "CALL", "DIP", "IF", "KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
+    "2ROT", "CALL", "DIP", "2DIP", "3DIP", "IF", "KEEP", "2KEEP", "3KEEP", "BI", "BI*", "BI@",
+    "TRI", "TRI*", "TRI@", "COMPOSE",
 ];
 
 impl From<Token> for Value {

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2330,7 +2330,10 @@ mod tests {
 
     #[test]
     fn m4_core_schemes_cover_fixed_quotation_combinators() {
-        for word in ["KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE"] {
+        for word in [
+            "2DIP", "3DIP", "KEEP", "2KEEP", "3KEEP", "BI", "BI*", "BI@", "TRI", "TRI*", "TRI@",
+            "COMPOSE",
+        ] {
             assert!(
                 core_scheme(word).is_some(),
                 "missing core scheme for {word}"
@@ -2338,7 +2341,11 @@ mod tests {
         }
 
         let arrow = infer_snippet(
-            "5 [ 1 + ] KEEP DROP DROP \
+            "1 2 3 4 [ + ] 2DIP DROP DROP DROP \
+             1 2 3 4 5 [ + ] 3DIP DROP DROP DROP DROP \
+             5 [ 1 + ] KEEP DROP DROP \
+             1 2 [ + ] 2KEEP DROP DROP DROP \
+             1 2 3 [ + + ] 3KEEP DROP DROP DROP DROP \
              5 [ 1 + ] [ 2 + ] BI DROP DROP \
              5 6 [ 1 + ] [ 2 + ] BI* DROP DROP \
              5 6 [ 1 + ] BI@ DROP DROP \

--- a/caternary/src/combinators.rs
+++ b/caternary/src/combinators.rs
@@ -105,6 +105,36 @@ fn dip<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalE
     Ok(())
 }
 
+/// `2DIP`: Execute a quotation while hiding the top two elements.
+///
+/// Stack effect: `( x y [Q] -- ... x y )`
+///
+/// Pops a quotation and the two elements below it, executes the quotation,
+/// then restores the hidden pair in order.
+fn two_dip<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 3)?;
+    let quotation = pop_quotation(stack)?;
+    let hidden = stack.split_off(stack.len() - 2);
+    eval.eval_with_stack(&quotation, stack)?;
+    stack.extend(hidden);
+    Ok(())
+}
+
+/// `3DIP`: Execute a quotation while hiding the top three elements.
+///
+/// Stack effect: `( x y z [Q] -- ... x y z )`
+///
+/// Pops a quotation and the three elements below it, executes the quotation,
+/// then restores the hidden triple in order.
+fn three_dip<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 4)?;
+    let quotation = pop_quotation(stack)?;
+    let hidden = stack.split_off(stack.len() - 3);
+    eval.eval_with_stack(&quotation, stack)?;
+    stack.extend(hidden);
+    Ok(())
+}
+
 /// `KEEP`: Execute a quotation on a value, keeping the original value.
 ///
 /// Stack effect: `( x [Q] -- ... x )`
@@ -116,6 +146,34 @@ fn keep<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
     let x = stack.last().unwrap().clone();
     eval.eval_with_stack(&quotation, stack)?;
     stack.push(x);
+    Ok(())
+}
+
+/// `2KEEP`: Execute a quotation on two values, keeping the original pair.
+///
+/// Stack effect: `( x y [Q] -- ... x y )`
+///
+/// Like `KEEP`, but preserves the top two values after the quotation runs.
+fn two_keep<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 3)?;
+    let quotation = pop_quotation(stack)?;
+    let kept = stack[stack.len() - 2..].to_vec();
+    eval.eval_with_stack(&quotation, stack)?;
+    stack.extend(kept);
+    Ok(())
+}
+
+/// `3KEEP`: Execute a quotation on three values, keeping the original triple.
+///
+/// Stack effect: `( x y z [Q] -- ... x y z )`
+///
+/// Like `KEEP`, but preserves the top three values after the quotation runs.
+fn three_keep<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 4)?;
+    let quotation = pop_quotation(stack)?;
+    let kept = stack[stack.len() - 3..].to_vec();
+    eval.eval_with_stack(&quotation, stack)?;
+    stack.extend(kept);
     Ok(())
 }
 
@@ -349,6 +407,46 @@ fn curry<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), Ev
     Ok(())
 }
 
+/// `2CURRY`: Partially apply two values to a quotation.
+///
+/// Stack effect: `( x y [Q] -- [x y Q] )`
+///
+/// Creates a new quotation that pushes x and y, then executes Q.
+fn two_curry<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 3)?;
+    let q = pop_quotation(stack)?;
+    let values = stack.split_off(stack.len() - 2);
+
+    let mut combined = Vec::new();
+    for value in values {
+        combined.extend(value.to_tokens());
+    }
+    combined.extend(q);
+
+    stack.push(T::from(Token::Bracket(combined)));
+    Ok(())
+}
+
+/// `3CURRY`: Partially apply three values to a quotation.
+///
+/// Stack effect: `( x y z [Q] -- [x y z Q] )`
+///
+/// Creates a new quotation that pushes x, y, and z, then executes Q.
+fn three_curry<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
+    require_len(stack, 4)?;
+    let q = pop_quotation(stack)?;
+    let values = stack.split_off(stack.len() - 3);
+
+    let mut combined = Vec::new();
+    for value in values {
+        combined.extend(value.to_tokens());
+    }
+    combined.extend(q);
+
+    stack.push(T::from(Token::Bracket(combined)));
+    Ok(())
+}
+
 // ============================================================================
 // Conditional Combinators
 // ============================================================================
@@ -532,15 +630,20 @@ fn each<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
 
 /// Register quotation combinators on an evaluator.
 ///
-/// This registers the core combinators: `CALL`, `DIP`, `KEEP`, `BI`, `BI*`, `BI@`,
-/// `TRI`, `TRI*`, `TRI@`, `CLEAVE`, `SPREAD`, `COMPOSE`, `CURRY`.
+/// This registers: `CALL`, `DIP`, `2DIP`, `3DIP`, `KEEP`, `2KEEP`, `3KEEP`,
+/// `BI`, `BI*`, `BI@`, `TRI`, `TRI*`, `TRI@`, `CLEAVE`, `SPREAD`, `COMPOSE`,
+/// `CURRY`, `2CURRY`, `3CURRY`.
 pub fn register_combinators<T>(evaluator: &mut Evaluator<T>)
 where
     T: Quotable,
 {
     evaluator.define("CALL", call::<T>);
     evaluator.define("DIP", dip::<T>);
+    evaluator.define("2DIP", two_dip::<T>);
+    evaluator.define("3DIP", three_dip::<T>);
     evaluator.define("KEEP", keep::<T>);
+    evaluator.define("2KEEP", two_keep::<T>);
+    evaluator.define("3KEEP", three_keep::<T>);
     evaluator.define("BI", bi::<T>);
     evaluator.define("BI*", bi_star::<T>);
     evaluator.define("BI@", bi_at::<T>);
@@ -551,6 +654,8 @@ where
     evaluator.define("SPREAD", spread::<T>);
     evaluator.define("COMPOSE", compose::<T>);
     evaluator.define("CURRY", curry::<T>);
+    evaluator.define("2CURRY", two_curry::<T>);
+    evaluator.define("3CURRY", three_curry::<T>);
 }
 
 /// Register conditional combinators on an evaluator.
@@ -781,6 +886,27 @@ mod tests {
         println!("Stack: {result:?}");
     }
 
+    #[test]
+    fn two_dip_hides_top_pair() {
+        let eval = make_eval();
+        let tokens = parse("1 2 3 4 [ADD] 2DIP").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(3), Value::Int(3), Value::Int(4)]);
+        println!("Stack: {result:?}");
+    }
+
+    #[test]
+    fn three_dip_hides_top_triple() {
+        let eval = make_eval();
+        let tokens = parse("1 2 3 4 5 [ADD] 3DIP").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(
+            result,
+            vec![Value::Int(3), Value::Int(3), Value::Int(4), Value::Int(5)]
+        );
+        println!("Stack: {result:?}");
+    }
+
     // ========================================================================
     // KEEP tests
     // ========================================================================
@@ -791,6 +917,27 @@ mod tests {
         let tokens = parse("5 [DUP MUL] KEEP").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(25), Value::Int(5)]);
+        println!("Stack: {result:?}");
+    }
+
+    #[test]
+    fn two_keep_preserves_pair() {
+        let eval = make_eval();
+        let tokens = parse("3 4 [ADD] 2KEEP").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(7), Value::Int(3), Value::Int(4)]);
+        println!("Stack: {result:?}");
+    }
+
+    #[test]
+    fn three_keep_preserves_triple() {
+        let eval = make_eval();
+        let tokens = parse("2 3 4 [ADD ADD] 3KEEP").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(
+            result,
+            vec![Value::Int(9), Value::Int(2), Value::Int(3), Value::Int(4)]
+        );
         println!("Stack: {result:?}");
     }
 
@@ -921,6 +1068,24 @@ mod tests {
         let tokens = parse("10 [ADD] CURRY 5 SWAP CALL").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(15)]);
+        println!("Stack: {result:?}");
+    }
+
+    #[test]
+    fn two_curry_partial_application() {
+        let eval = make_eval();
+        let tokens = parse("10 20 [ADD ADD] 2CURRY 5 SWAP CALL").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(35)]);
+        println!("Stack: {result:?}");
+    }
+
+    #[test]
+    fn three_curry_partial_application() {
+        let eval = make_eval();
+        let tokens = parse("1 2 3 [ADD ADD ADD] 3CURRY 4 SWAP CALL").unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Int(10)]);
         println!("Stack: {result:?}");
     }
 

--- a/caternary/src/shadow.rs
+++ b/caternary/src/shadow.rs
@@ -174,10 +174,18 @@ pub enum ShadowWord {
     /// `DIP` — pop the quotation, set aside the next term, run the quotation on
     /// the rest, restore the set-aside term (the real shuffle, §10.3).
     Dip,
+    /// `2DIP` — set aside the top pair while a quotation runs on the rest.
+    TwoDip,
+    /// `3DIP` — set aside the top triple while a quotation runs on the rest.
+    ThreeDip,
     /// `CALL` — pop the quotation and run it on the whole stack.
     Call,
     /// `KEEP` — run a quotation and restore a copy of its input value.
     Keep,
+    /// `2KEEP` — run a quotation and restore copies of its input pair.
+    TwoKeep,
+    /// `3KEEP` — run a quotation and restore copies of its input triple.
+    ThreeKeep,
     /// `BI` — run two quotations against one copied value.
     Bi,
     /// `BI*` — run two quotations against two corresponding values.
@@ -231,8 +239,12 @@ pub fn core_shadow_word(name: &str) -> Option<ShadowWord> {
         "2OVER" => ShadowWord::TwoOver,
         "2ROT" => ShadowWord::TwoRot,
         "DIP" => ShadowWord::Dip,
+        "2DIP" => ShadowWord::TwoDip,
+        "3DIP" => ShadowWord::ThreeDip,
         "CALL" => ShadowWord::Call,
         "KEEP" => ShadowWord::Keep,
+        "2KEEP" => ShadowWord::TwoKeep,
+        "3KEEP" => ShadowWord::ThreeKeep,
         "BI" => ShadowWord::Bi,
         "BI*" => ShadowWord::BiStar,
         "BI@" => ShadowWord::BiAt,
@@ -579,6 +591,26 @@ impl ShadowStack {
                         self.exec(&body, resolve)?;
                         self.push_slot(hidden);
                     }
+                    ShadowWord::TwoDip => {
+                        self.require(3)?;
+                        let body = self.pop_quote()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.exec(&body, resolve)?;
+                        self.push_slot(x);
+                        self.push_slot(y);
+                    }
+                    ShadowWord::ThreeDip => {
+                        self.require(4)?;
+                        let body = self.pop_quote()?;
+                        let z = self.pop()?;
+                        let y = self.pop()?;
+                        let x = self.pop()?;
+                        self.exec(&body, resolve)?;
+                        self.push_slot(x);
+                        self.push_slot(y);
+                        self.push_slot(z);
+                    }
                     ShadowWord::Call => {
                         // Mirror combinators.rs::call: pop the quotation and run
                         // it on the whole stack.
@@ -591,6 +623,22 @@ impl ShadowStack {
                         let kept = self.slots.last().unwrap().clone();
                         self.exec(&body, resolve)?;
                         self.push_slot(kept);
+                    }
+                    ShadowWord::TwoKeep => {
+                        self.require(3)?;
+                        let body = self.pop_quote()?;
+                        let len = self.slots.len();
+                        let kept = self.slots[len - 2..].to_vec();
+                        self.exec(&body, resolve)?;
+                        self.slots.extend(kept);
+                    }
+                    ShadowWord::ThreeKeep => {
+                        self.require(4)?;
+                        let body = self.pop_quote()?;
+                        let len = self.slots.len();
+                        let kept = self.slots[len - 3..].to_vec();
+                        self.exec(&body, resolve)?;
+                        self.slots.extend(kept);
                     }
                     ShadowWord::Bi => {
                         self.require(3)?;
@@ -799,6 +847,10 @@ mod tests {
     fn core_shadow_word_requires_runtime_spelling() {
         assert_eq!(core_shadow_word("DUP"), Some(ShadowWord::Dup));
         assert_eq!(core_shadow_word("DIP"), Some(ShadowWord::Dip));
+        assert_eq!(core_shadow_word("2DIP"), Some(ShadowWord::TwoDip));
+        assert_eq!(core_shadow_word("3DIP"), Some(ShadowWord::ThreeDip));
+        assert_eq!(core_shadow_word("2KEEP"), Some(ShadowWord::TwoKeep));
+        assert_eq!(core_shadow_word("3KEEP"), Some(ShadowWord::ThreeKeep));
         assert_eq!(core_shadow_word("2ROT"), Some(ShadowWord::TwoRot));
         assert_eq!(core_shadow_word("TRI"), Some(ShadowWord::Tri));
         assert_eq!(core_shadow_word("dup"), None);
@@ -1129,8 +1181,14 @@ mod tests {
         assert_conformance("[ OVER ] DIP SWAP", 4);
         assert_conformance("[ ROT ] DIP", 4);
         assert_conformance("[ [ SWAP ] DIP ] DIP", 4);
+        assert_conformance("[ SWAP ] 2DIP", 4);
+        assert_conformance("[ DUP ] 2DIP DROP", 4);
+        assert_conformance("[ ROT ] 3DIP", 6);
+        assert_conformance("[ DUP ] 3DIP DROP", 5);
         assert_conformance("[ SWAP ] CALL", 2);
         assert_conformance("[ DUP ] KEEP", 1);
+        assert_conformance("[ SWAP ] 2KEEP", 2);
+        assert_conformance("[ ROT ] 3KEEP", 3);
         assert_conformance("[ DUP ] [ DROP ] BI", 1);
         assert_conformance("[ DUP ] [ DROP ] BI*", 2);
         assert_conformance("[ DUP ] BI@", 2);
@@ -1210,6 +1268,10 @@ mod tests {
         assert_conformance("[ DROP DUP ] DIP", 4);
         assert_conformance("[ ROT ROT ] DIP DROP", 5);
         assert_conformance("[ TUCK ] DIP NIP", 4);
+        assert_conformance("[ SWAP ] 2DIP", 4);
+        assert_conformance("[ SWAP OVER ] 2DIP DROP", 5);
+        assert_conformance("[ ROT ] 3DIP", 6);
+        assert_conformance("[ TUCK ] 3DIP NIP", 5);
     }
 
     // =======================================================================

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -1077,6 +1077,28 @@ fn apply_core<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
             stack.push_slot(hidden);
             Ok(())
         }
+        ShadowWord::TwoDip => {
+            stack.require(3)?;
+            let body = stack.pop_quote()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            verify_ctx(&body, stack, solver, resolve, ctx)?;
+            stack.push_slot(x);
+            stack.push_slot(y);
+            Ok(())
+        }
+        ShadowWord::ThreeDip => {
+            stack.require(4)?;
+            let body = stack.pop_quote()?;
+            let z = stack.pop()?;
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            verify_ctx(&body, stack, solver, resolve, ctx)?;
+            stack.push_slot(x);
+            stack.push_slot(y);
+            stack.push_slot(z);
+            Ok(())
+        }
         ShadowWord::Call => {
             let body = stack.pop_quote()?;
             verify_ctx(&body, stack, solver, resolve, ctx)
@@ -1087,6 +1109,26 @@ fn apply_core<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
             let kept = stack.slots().last().unwrap().clone();
             verify_ctx(&body, stack, solver, resolve, ctx)?;
             stack.push_slot(kept);
+            Ok(())
+        }
+        ShadowWord::TwoKeep => {
+            stack.require(3)?;
+            let body = stack.pop_quote()?;
+            let kept = stack.slots()[stack.len() - 2..].to_vec();
+            verify_ctx(&body, stack, solver, resolve, ctx)?;
+            for slot in kept {
+                stack.push_slot(slot);
+            }
+            Ok(())
+        }
+        ShadowWord::ThreeKeep => {
+            stack.require(4)?;
+            let body = stack.pop_quote()?;
+            let kept = stack.slots()[stack.len() - 3..].to_vec();
+            verify_ctx(&body, stack, solver, resolve, ctx)?;
+            for slot in kept {
+                stack.push_slot(slot);
+            }
             Ok(())
         }
         ShadowWord::Bi => {

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -226,6 +226,22 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
                 stack(1, vec![v(0)]),
             ),
         ),
+        "2DIP" => Scheme::new(
+            vec![0, 1],
+            vec![0, 1],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), Ty::quote(arrow_st(), s)]),
+                stack(1, vec![v(0), v(1)]),
+            ),
+        ),
+        "3DIP" => Scheme::new(
+            vec![0, 1, 2],
+            vec![0, 1],
+            WordTy::new(
+                stack(0, vec![v(0), v(1), v(2), Ty::quote(arrow_st(), s)]),
+                stack(1, vec![v(0), v(1), v(2)]),
+            ),
+        ),
         "IF" => Scheme::new(
             vec![],
             vec![0, 1],
@@ -247,6 +263,25 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
                 vec![0],
                 vec![0, 1],
                 WordTy::new(stack(0, vec![v(0), q]), stack(1, vec![v(0)])),
+            )
+        }
+        "2KEEP" => {
+            let q = quote(stack(0, vec![v(0), v(1)]), empty(1));
+            Scheme::new(
+                vec![0, 1],
+                vec![0, 1],
+                WordTy::new(stack(0, vec![v(0), v(1), q]), stack(1, vec![v(0), v(1)])),
+            )
+        }
+        "3KEEP" => {
+            let q = quote(stack(0, vec![v(0), v(1), v(2)]), empty(1));
+            Scheme::new(
+                vec![0, 1, 2],
+                vec![0, 1],
+                WordTy::new(
+                    stack(0, vec![v(0), v(1), v(2), q]),
+                    stack(1, vec![v(0), v(1), v(2)]),
+                ),
             )
         }
         "BI" => {


### PR DESCRIPTION
Add 2DIP, 3DIP, 2KEEP, 3KEEP, 2CURRY, and 3CURRY, generalizing the
existing DIP, KEEP, and CURRY combinators to two and three values.

Implement them across the full stack:
- combinators: runtime two_dip/three_dip, two_keep/three_keep, and
  two_curry/three_curry, registered in register_combinators.
- types: core schemes for 2DIP, 3DIP, 2KEEP, and 3KEEP so the checker
  knows their stack effects.
- shadow: ShadowWord variants and exec arms mirroring the runtime
  shuffle for the new DIP/KEEP forms.
- solver: verification arms for 2DIP, 3DIP, 2KEEP, and 3KEEP.

Register the new primitives in the attestation, binary, and shadow
core-operator tables, and document them with examples in the README
combinator tables. Extend combinator, check, shadow-conformance, and
attestation tests to cover the new words.

Co-authored-by: AI
