### PR TITLE
feat(caternary): type builtin combinators in the core

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -190,8 +190,6 @@ a host predicate with that name is also registered.
 | `TRI` | `5 [DUP +] [DUP *] [1 +] TRI` | `10 25 6` |
 | `TRI*` | `3 4 5 [DUP *] [DUP +] [1 +] TRI*` | `9 8 6` |
 | `TRI@` | `3 4 5 [DUP *] TRI@` | `9 16 25` |
-| `CLEAVE` | `5 [[DUP +] [DUP *] [1 +]] CLEAVE` | `10 25 6` |
-| `SPREAD` | `1 2 3 [[DUP +] [DUP *] [1 +]] SPREAD` | `2 4 4` |
 | `COMPOSE` | `[1 +] [2 *] COMPOSE` | `[1 + 2 *]` |
 | `CURRY` | `10 [+] CURRY` | `[10 +]` |
 | `2CURRY` | `10 20 [+ +] 2CURRY` | `[10 20 + +]` |

--- a/caternary/src/attestation.rs
+++ b/caternary/src/attestation.rs
@@ -52,7 +52,7 @@ use crate::types::core_scheme;
 const CORE_PRIMITIVES: &[&str] = &[
     "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP", "2OVER",
     "2ROT", "CALL", "DIP", "2DIP", "3DIP", "IF", "KEEP", "2KEEP", "3KEEP", "BI", "BI*", "BI@",
-    "TRI", "TRI*", "TRI@", "COMPOSE",
+    "TRI", "TRI*", "TRI@", "COMPOSE", "CURRY", "WHEN", "UNLESS", "MAP", "FILTER", "FOLD", "EACH",
 ];
 
 // ===========================================================================

--- a/caternary/src/attestation/tests.rs
+++ b/caternary/src/attestation/tests.rs
@@ -192,7 +192,8 @@ fn operator_table_enumerates_the_modulo() {
     let expected_core = [
         "DUP", "DROP", "SWAP", "OVER", "ROT", "-ROT", "NIP", "TUCK", "2DUP", "2DROP", "2SWAP",
         "2OVER", "2ROT", "CALL", "DIP", "2DIP", "3DIP", "IF", "KEEP", "2KEEP", "3KEEP", "BI",
-        "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE",
+        "BI*", "BI@", "TRI", "TRI*", "TRI@", "COMPOSE", "CURRY", "WHEN", "UNLESS", "MAP", "FILTER",
+        "FOLD", "EACH",
     ];
     for p in expected_core.iter().copied() {
         assert!(

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2426,6 +2426,285 @@ mod tests {
         assert_eq!(arrow.output.elems[1].kind, TyKind::Con(NUM.into()));
     }
 
+    /// `List a` element type with element `elem` (the higher-order MAP/FILTER
+    /// signatures track the element type, unlike the nullary `list_ty` above).
+    fn list_of(elem: Ty, s: Span) -> Ty {
+        Ty::app("List", vec![elem], s)
+    }
+
+    /// Seed an evaluator with a `List Num` source and the element words the
+    /// MAP/FILTER acceptance tests apply through a quotation.
+    fn eval_with_list_words(s: Span) -> Evaluator<Value> {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        // nums : ( 'S -- 'S (List Num) )
+        eval.register_operator_with_contract(
+            "nums",
+            Scheme::new(
+                vec![],
+                vec![0],
+                WordTy::new(
+                    StackTy::empty(0, s),
+                    StackTy::new(vec![list_of(Ty::num(s), s)], 0, s),
+                ),
+            ),
+        );
+        // inc : ( 'S Num -- 'S Num ) — an element transform Num -> Num.
+        eval.register_operator_with_contract(
+            "inc",
+            Scheme::new(
+                vec![],
+                vec![0],
+                WordTy::new(
+                    StackTy::new(vec![Ty::num(s)], 0, s),
+                    StackTy::new(vec![Ty::num(s)], 0, s),
+                ),
+            ),
+        );
+        // is_pos : ( 'S Num -- 'S Bool ) — a predicate Num -> Bool.
+        eval.register_operator_with_contract(
+            "is_pos",
+            Scheme::new(
+                vec![],
+                vec![0],
+                WordTy::new(
+                    StackTy::new(vec![Ty::num(s)], 0, s),
+                    StackTy::new(vec![Ty::bool(s)], 0, s),
+                ),
+            ),
+        );
+        eval
+    }
+
+    /// Infer a token sequence's whole effect under `eval`, fully resolved.
+    fn infer_effect(eval: &Evaluator<Value>, src: &str) -> Result<WordTy, TypeError> {
+        let tokens = parse_with_spans(src).unwrap();
+        let mut ctx = InferCtx::new();
+        let mut locals: Vec<Local> = Vec::new();
+        let def_env = DefEnv::empty();
+        let no_poly: HashMap<String, Scheme> = HashMap::new();
+        infer_seq(eval, &tokens, &mut ctx, &mut locals, &def_env, &no_poly, false)
+            .map(|arrow| ctx.resolve_word_deep(&arrow))
+    }
+
+    #[test]
+    fn map_is_a_core_scheme_not_an_unresolved_word() {
+        // Before the fix `MAP` had no checker scheme and failed as UNDEFINED
+        // (effect lookup absent). It must now resolve as a language-core
+        // primitive.
+        assert!(core_scheme("MAP").is_some(), "MAP must have a core scheme");
+        assert!(core_scheme("FILTER").is_some(), "FILTER must have a core scheme");
+    }
+
+    #[test]
+    fn map_relays_the_quotation_and_preserves_the_list() {
+        // `nums [ inc ] MAP` : ( 'S -- 'S (List Num) ). The Num->Num element
+        // transform relays through; the result is a `List Num`.
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let arrow = infer_effect(&eval, "nums [ inc ] MAP").expect("MAP must type-check");
+        assert!(arrow.input.elems.is_empty(), "consumes nothing from below");
+        assert_eq!(arrow.output.elems.len(), 1, "result is a single List");
+        match &arrow.output.elems[0].kind {
+            TyKind::App(n, args) => {
+                assert_eq!(n, "List");
+                assert_eq!(args.len(), 1, "List carries its element type");
+                assert_eq!(args[0].kind, TyKind::Con(NUM.into()), "element is Num");
+            }
+            other => panic!("expected `List Num`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_changes_the_element_type_through_the_quotation() {
+        // `nums [ is_pos ] MAP` : the Num->Bool quotation makes the output a
+        // `List Bool` — the quotation's output element `b` becomes the result
+        // list's element (the §8 higher-order relay).
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let arrow = infer_effect(&eval, "nums [ is_pos ] MAP").expect("MAP must type-check");
+        match &arrow.output.elems[0].kind {
+            TyKind::App(n, args) => {
+                assert_eq!(n, "List");
+                assert_eq!(args[0].kind, TyKind::Con(BOOL.into()), "element became Bool");
+            }
+            other => panic!("expected `List Bool`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn filter_keeps_the_element_type_and_takes_a_predicate() {
+        // `nums [ is_pos ] FILTER` : ( 'S -- 'S (List Num) ). The Num->Bool
+        // predicate relays; the element type is unchanged (List Num in, List Num
+        // out) — no post-filter length claim.
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let arrow = infer_effect(&eval, "nums [ is_pos ] FILTER").expect("FILTER must type-check");
+        assert_eq!(arrow.output.elems.len(), 1, "result is a single List");
+        match &arrow.output.elems[0].kind {
+            TyKind::App(n, args) => {
+                assert_eq!(n, "List");
+                assert_eq!(args[0].kind, TyKind::Con(NUM.into()), "element stays Num");
+            }
+            other => panic!("expected `List Num`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_rejects_an_element_transform_of_the_wrong_input_type() {
+        // The input list's element relays into the quotation's input: a Num->Bool
+        // quotation cannot map a `List Bool` source whose element a = Bool against
+        // `inc : Num -> Num`. Build a `List Bool` source and apply `inc`.
+        let s = sp();
+        let mut eval = eval_with_list_words(s);
+        // bools : ( 'S -- 'S (List Bool) )
+        eval.register_operator_with_contract(
+            "bools",
+            Scheme::new(
+                vec![],
+                vec![0],
+                WordTy::new(
+                    StackTy::empty(0, s),
+                    StackTy::new(vec![list_of(Ty::bool(s), s)], 0, s),
+                ),
+            ),
+        );
+        let err = infer_effect(&eval, "bools [ inc ] MAP")
+            .expect_err("element type must relay: Bool list vs Num transform is a mismatch");
+        assert!(
+            matches!(err, TypeError::Mismatch { .. }),
+            "wrong element type is a typed mismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn filter_rejects_a_non_boolean_predicate() {
+        // FILTER's quotation must produce Bool. An `inc : Num -> Num` quotation is
+        // not a predicate and must be rejected.
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let err = infer_effect(&eval, "nums [ inc ] FILTER")
+            .expect_err("a non-Bool-producing quotation is not a predicate");
+        assert!(
+            matches!(err, TypeError::Mismatch { .. }),
+            "non-predicate quotation is a typed mismatch, got {err:?}"
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // The remaining runtime builtins given Tier-0 contracts (mirrors MAP/FILTER):
+    // the applicative relays KEEP/BI/BI*/BI@, the quotation-builders
+    // COMPOSE/CURRY, the one-armed conditionals WHEN/UNLESS, and the sequence
+    // relays FOLD/EACH.
+    // ----------------------------------------------------------------------
+
+    /// Assert the whole effect of `src` lands `outs` `Num`s on top of an
+    /// otherwise-untouched base stack ( 'S -- 'S Num^outs ).
+    fn assert_pushes_nums(eval: &Evaluator<Value>, src: &str, outs: usize) {
+        let arrow = infer_effect(eval, src).unwrap_or_else(|e| panic!("{src:?} must check: {e:?}"));
+        assert!(
+            arrow.input.elems.is_empty(),
+            "{src:?} consumes nothing from below, got {:?}",
+            arrow.input.elems
+        );
+        assert_eq!(
+            arrow.output.elems.len(),
+            outs,
+            "{src:?} should leave {outs} values"
+        );
+        for (i, e) in arrow.output.elems.iter().enumerate() {
+            assert_eq!(
+                e.kind,
+                TyKind::Con(NUM.into()),
+                "{src:?} output {i} should be Num"
+            );
+        }
+    }
+
+    #[test]
+    fn newly_typed_builtins_have_a_core_scheme() {
+        for name in [
+            "KEEP", "BI", "BI*", "BI@", "COMPOSE", "CURRY", "WHEN", "UNLESS", "FOLD", "EACH",
+        ] {
+            assert!(
+                core_scheme(name).is_some(),
+                "{name} must resolve as a language-core primitive"
+            );
+        }
+    }
+
+    #[test]
+    fn applicative_relays_thread_their_quotations() {
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        // KEEP runs `inc` on the value and restores a copy: ( Num -- Num Num ).
+        assert_pushes_nums(&eval, "5 [ inc ] KEEP", 2);
+        // BI applies two quotations to one value; BI* to two values; both relay.
+        assert_pushes_nums(&eval, "5 [ inc ] [ inc ] BI", 2);
+        assert_pushes_nums(&eval, "5 6 [ inc ] [ inc ] BI*", 2);
+        // BI@ applies one element-transform to two same-typed values: ( -- b b ).
+        assert_pushes_nums(&eval, "5 6 [ inc ] BI@", 2);
+    }
+
+    #[test]
+    fn quotation_builders_compose_and_curry() {
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        // COMPOSE chains [inc] then [inc]; CALL runs the composite: ( -- Num ).
+        assert_pushes_nums(&eval, "5 [ inc ] [ inc ] COMPOSE CALL", 1);
+        // CURRY bakes 5 into [inc]; CALL runs the closed quotation: ( -- Num ).
+        assert_pushes_nums(&eval, "5 [ inc ] CURRY CALL", 1);
+    }
+
+    #[test]
+    fn one_armed_conditionals_require_a_stack_neutral_quotation() {
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        // An empty (identity) quotation is `'S -- 'S`; both paths agree.
+        assert_pushes_nums(&eval, "5 true [ ] WHEN", 1);
+        assert_pushes_nums(&eval, "5 false [ ] UNLESS", 1);
+    }
+
+    #[test]
+    fn when_rejects_a_shape_changing_quotation() {
+        // The absent branch is the identity, so a quotation that changes the
+        // stack shape (here `[ DROP ]` shrinks it) cannot agree with the
+        // do-nothing path.
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let err = infer_effect(&eval, "5 true [ DROP ] WHEN")
+            .expect_err("a stack-shrinking quotation is not `'S -- 'S`");
+        assert!(
+            matches!(err, TypeError::Mismatch { .. }),
+            "non-neutral WHEN quotation is a typed rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn fold_threads_an_accumulator_and_each_consumes_for_effect() {
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        // FOLD: `[ DROP ]` is a valid step ( 'r b a -- 'r b ) (drops the element,
+        // keeps the accumulator). Result is the final accumulator: ( -- Num ).
+        assert_pushes_nums(&eval, "nums 0 [ DROP ] FOLD", 1);
+        // EACH: `[ DROP ]` is a stack-neutral consumer ( 'r a -- 'r ). The list
+        // is consumed and the base stack returns unchanged: ( -- ).
+        assert_pushes_nums(&eval, "nums [ DROP ] EACH", 0);
+    }
+
+    #[test]
+    fn fold_rejects_a_step_that_does_not_preserve_the_accumulator() {
+        // An identity step `[ ]` ( 'R -- 'R ) cannot be a fold step, which must
+        // consume one element while preserving the accumulator ( 'r b a -- 'r b ).
+        let s = sp();
+        let eval = eval_with_list_words(s);
+        let err = infer_effect(&eval, "nums 0 [ ] FOLD")
+            .expect_err("an identity step does not consume the element");
+        assert!(
+            matches!(err, TypeError::Mismatch { .. }),
+            "a non-consuming FOLD step is a typed rejection, got {err:?}"
+        );
+    }
+
     #[test]
     fn m4_rank2_without_annotation_yields_the_section8_diagnostic() {
         // `>f` binds a quotation parameter applied at TWO distinct types (to a

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2482,8 +2482,16 @@ mod tests {
         let mut locals: Vec<Local> = Vec::new();
         let def_env = DefEnv::empty();
         let no_poly: HashMap<String, Scheme> = HashMap::new();
-        infer_seq(eval, &tokens, &mut ctx, &mut locals, &def_env, &no_poly, false)
-            .map(|arrow| ctx.resolve_word_deep(&arrow))
+        infer_seq(
+            eval,
+            &tokens,
+            &mut ctx,
+            &mut locals,
+            &def_env,
+            &no_poly,
+            false,
+        )
+        .map(|arrow| ctx.resolve_word_deep(&arrow))
     }
 
     #[test]
@@ -2492,7 +2500,10 @@ mod tests {
         // (effect lookup absent). It must now resolve as a language-core
         // primitive.
         assert!(core_scheme("MAP").is_some(), "MAP must have a core scheme");
-        assert!(core_scheme("FILTER").is_some(), "FILTER must have a core scheme");
+        assert!(
+            core_scheme("FILTER").is_some(),
+            "FILTER must have a core scheme"
+        );
     }
 
     #[test]
@@ -2525,7 +2536,11 @@ mod tests {
         match &arrow.output.elems[0].kind {
             TyKind::App(n, args) => {
                 assert_eq!(n, "List");
-                assert_eq!(args[0].kind, TyKind::Con(BOOL.into()), "element became Bool");
+                assert_eq!(
+                    args[0].kind,
+                    TyKind::Con(BOOL.into()),
+                    "element became Bool"
+                );
             }
             other => panic!("expected `List Bool`, got {other:?}"),
         }

--- a/caternary/src/combinators.rs
+++ b/caternary/src/combinators.rs
@@ -312,67 +312,6 @@ fn tri_at<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Ev
     Ok(())
 }
 
-/// `CLEAVE`: Apply multiple quotations to a single value.
-///
-/// Stack effect: `( x [[P] [Q] ...] -- P(x) Q(x) ... )`
-///
-/// Pops a list of quotations and a value, applies each quotation to a copy of the value.
-fn cleave<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
-    require_len(stack, 2)?;
-    let quotations_val = stack.pop().ok_or_else(|| stack_underflow(1, 0))?;
-    let quotations = quotations_val
-        .as_quotation()
-        .ok_or_else(not_a_quotation)?
-        .to_vec();
-    let x = stack.pop().unwrap();
-
-    for token in quotations {
-        if let Token::Bracket(q) = token {
-            stack.push(x.clone());
-            eval.eval_with_stack(&q, stack)?;
-        } else {
-            return Err(operator_error("CLEAVE expects a list of quotations"));
-        }
-    }
-
-    Ok(())
-}
-
-/// `SPREAD`: Apply quotations from a list to corresponding stack values.
-///
-/// Stack effect: `( x y z [[P] [Q] [R]] -- P(x) Q(y) R(z) )`
-///
-/// Pops a list of quotations, then pops that many values, applies each quotation
-/// to its corresponding value.
-fn spread<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), EvalError> {
-    require_len(stack, 1)?;
-    let quotations_val = stack.pop().ok_or_else(|| stack_underflow(1, 0))?;
-    let quotations = quotations_val
-        .as_quotation()
-        .ok_or_else(not_a_quotation)?
-        .to_vec();
-
-    let n = quotations.len();
-    require_len(stack, n)?;
-
-    let mut values: Vec<T> = Vec::with_capacity(n);
-    for _ in 0..n {
-        values.push(stack.pop().unwrap());
-    }
-    values.reverse();
-
-    for (val, token) in values.into_iter().zip(quotations) {
-        if let Token::Bracket(q) = token {
-            stack.push(val);
-            eval.eval_with_stack(&q, stack)?;
-        } else {
-            return Err(operator_error("SPREAD expects a list of quotations"));
-        }
-    }
-
-    Ok(())
-}
-
 /// `COMPOSE`: Concatenate two quotations.
 ///
 /// Stack effect: `( [P] [Q] -- [P Q] )`
@@ -631,7 +570,7 @@ fn each<T: Quotable>(stack: &mut Vec<T>, eval: &Evaluator<T>) -> Result<(), Eval
 /// Register quotation combinators on an evaluator.
 ///
 /// This registers: `CALL`, `DIP`, `2DIP`, `3DIP`, `KEEP`, `2KEEP`, `3KEEP`,
-/// `BI`, `BI*`, `BI@`, `TRI`, `TRI*`, `TRI@`, `CLEAVE`, `SPREAD`, `COMPOSE`,
+/// `BI`, `BI*`, `BI@`, `TRI`, `TRI*`, `TRI@`, `COMPOSE`,
 /// `CURRY`, `2CURRY`, `3CURRY`.
 pub fn register_combinators<T>(evaluator: &mut Evaluator<T>)
 where
@@ -650,8 +589,6 @@ where
     evaluator.define("TRI", tri::<T>);
     evaluator.define("TRI*", tri_star::<T>);
     evaluator.define("TRI@", tri_at::<T>);
-    evaluator.define("CLEAVE", cleave::<T>);
-    evaluator.define("SPREAD", spread::<T>);
     evaluator.define("COMPOSE", compose::<T>);
     evaluator.define("CURRY", curry::<T>);
     evaluator.define("2CURRY", two_curry::<T>);
@@ -1016,32 +953,6 @@ mod tests {
         let tokens = parse("3 4 5 [DUP MUL] TRI@").unwrap();
         let result = eval.eval(&tokens).unwrap();
         assert_eq!(result, vec![Value::Int(9), Value::Int(16), Value::Int(25)]);
-        println!("Stack: {result:?}");
-    }
-
-    // ========================================================================
-    // CLEAVE tests
-    // ========================================================================
-
-    #[test]
-    fn cleave_applies_multiple_quotations() {
-        let eval = make_eval();
-        let tokens = parse("5 [[DUP ADD] [DUP MUL] [1 ADD]] CLEAVE").unwrap();
-        let result = eval.eval(&tokens).unwrap();
-        assert_eq!(result, vec![Value::Int(10), Value::Int(25), Value::Int(6)]);
-        println!("Stack: {result:?}");
-    }
-
-    // ========================================================================
-    // SPREAD tests
-    // ========================================================================
-
-    #[test]
-    fn spread_distributes_quotations() {
-        let eval = make_eval();
-        let tokens = parse("1 2 3 [[DUP ADD] [DUP MUL] [1 ADD]] SPREAD").unwrap();
-        let result = eval.eval(&tokens).unwrap();
-        assert_eq!(result, vec![Value::Int(2), Value::Int(4), Value::Int(4)]);
         println!("Stack: {result:?}");
     }
 

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -109,6 +109,13 @@ const CORE_SPAN: Span = Span { start: 0, end: 0 };
 /// 2ROT   : ( 'S a b c d e f -- 'S c d e f a b )
 /// CALL   : ( 'S ('S -- 'T) -- 'T )
 /// IF     : ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
+/// CURRY  : ( 'R a ('S a -- 'T)             -- 'R ('S -- 'T) )
+/// WHEN   : ( 'S Bool ('S -- 'S)            -- 'S )
+/// UNLESS : ( 'S Bool ('S -- 'S)            -- 'S )
+/// MAP    : ( 'S (List a) ( 'r a -- 'r b )    -- 'S (List b) )
+/// FILTER : ( 'S (List a) ( 'r a -- 'r Bool ) -- 'S (List a) )
+/// FOLD   : ( 'S (List a) b ( 'r b a -- 'r b ) -- 'S b )
+/// EACH   : ( 'S (List a) ( 'r a -- 'r )    -- 'S )
 /// ```
 ///
 /// `DIP` is the M4 §8 **relay** combinator: its scheme alone states the only
@@ -116,12 +123,29 @@ const CORE_SPAN: Span = Span { start: 0, end: 0 };
 /// quotation runs on the rest. The quotation's **declared** arrow `( 'S -- 'T )`
 /// is relayed verbatim; the body is never expanded into the caller's contract
 /// (§13 invariant 8).
+///
+/// `MAP` / `FILTER` / `FOLD` / `EACH` are the **higher-order sequence relays**:
+/// their quotation argument's two arrow ends share a row (`'r`), forcing an
+/// element-to-element shape, and the element type relays through the `List`
+/// constructor. `MAP` turns `List a` into `List b` via the element transform
+/// `a -> b`; `FILTER` keeps `List a` via the predicate `a -> Bool` (no
+/// post-filter length claim); `FOLD` threads an accumulator `b` through a step
+/// `( 'r b a -- 'r b )` and returns the final accumulator; `EACH` runs a
+/// stack-neutral consumer `( 'r a -- 'r )` per element for effect. Like `DIP`,
+/// only the declared quotation arrow is relayed, never expanded (§13 inv 8).
+///
+/// `CURRY` is a **quotation-builder**: it bakes a value into a quotation's input,
+/// producing a quotation whose arrow drops that value (`a ( 'S a -- 'T ) -- ( 'S
+/// -- 'T )`). `WHEN` / `UNLESS` are the **one-armed conditionals**: the absent
+/// branch is the identity, so the single quotation must be stack-shape-preserving
+/// (`'S -- 'S`) for both control paths to agree.
 pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
     let s = CORE_SPAN;
     let v = |idx| Ty::var(idx, s);
     let stack = |row, elems| StackTy::new(elems, row, s);
     let empty = |row| StackTy::empty(row, s);
     let quote = |input, output| Ty::quote(WordTy::new(input, output), s);
+    let list = |elem| Ty::app("List", vec![elem], s);
     // The quotation argument's arrow ( 'S -- 'T ): rowvar 0 = 'S, rowvar 1 = 'T.
     let arrow_st = || WordTy::new(empty(0), empty(1));
     let scheme = match runtime_name {
@@ -351,6 +375,126 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
                 WordTy::new(stack(0, vec![p, q]), stack(0, vec![composed])),
             )
         }
+        // CURRY : ( 'R a ( 'S a -- 'T ) -- 'R ( 'S -- 'T ) ). Bake the value `a`
+        // (tyvar 0) into the quotation's input: the input quotation expects `a`
+        // on top of 'S, the result quotation supplies it itself, so its arrow
+        // drops the `a` ( 'S -- 'T ). rowvar 0='R (the outer base), 1='S, 2='T.
+        "CURRY" => Scheme::new(
+            vec![0],
+            vec![0, 1, 2],
+            WordTy::new(
+                stack(
+                    0,
+                    vec![v(0), quote(stack(1, vec![v(0)]), empty(2))],
+                ),
+                stack(0, vec![quote(empty(1), empty(2))]),
+            ),
+        ),
+        // WHEN : ( 'S Bool ( 'S -- 'S ) -- 'S ). The absent (false) branch is the
+        // identity, so for both control paths to agree the quotation must be
+        // stack-shape-preserving: both ends share row 0 ('S -- 'S). Unlike IF,
+        // there is no 'T — the result is always 'S.
+        "WHEN" => Scheme::new(
+            vec![],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![Ty::bool(s), quote(empty(0), empty(0))]),
+                empty(0),
+            ),
+        ),
+        // UNLESS : ( 'S Bool ( 'S -- 'S ) -- 'S ). As WHEN, but the quotation runs
+        // on the false branch; the typing constraint (stack-shape-preserving
+        // quotation, 'S -- 'S) is identical.
+        "UNLESS" => Scheme::new(
+            vec![],
+            vec![0],
+            WordTy::new(
+                stack(0, vec![Ty::bool(s), quote(empty(0), empty(0))]),
+                empty(0),
+            ),
+        ),
+        // MAP : ( 'S (List a) ( 'r a -- 'r b ) -- 'S (List b) ) (§8 relay,
+        // higher-order). The quotation argument is the **element transform**: it
+        // pops one `a` and pushes one `b`, leaving the rest of the stack ('r)
+        // untouched — so both ends of its arrow share row 1 ('r), forcing an
+        // element-to-element shape. The element type relays through the lists:
+        // the input list's element (tyvar 0 = a) is the quotation's input, the
+        // quotation's output (tyvar 1 = b) is the output list's element. Only the
+        // declared quotation arrow is relayed — no body expansion (§13 inv 8).
+        "MAP" => Scheme::new(
+            vec![0, 1],
+            vec![0, 1],
+            WordTy::new(
+                stack(
+                    0,
+                    vec![
+                        list(v(0)),
+                        quote(stack(1, vec![v(0)]), stack(1, vec![v(1)])),
+                    ],
+                ),
+                stack(0, vec![list(v(1))]),
+            ),
+        ),
+        // FILTER : ( 'S (List a) ( 'r a -- 'r Bool ) -- 'S (List a) ) (§8 relay,
+        // higher-order). The quotation is the **predicate**: it pops one `a` and
+        // pushes a Bool, leaving the rest of the stack ('r) untouched — both ends
+        // of its arrow share row 1 ('r). The element type (tyvar 0 = a) is
+        // unchanged across the call: the result is `List a`, same element as the
+        // input — no length claim is made. Only the declared quotation arrow is
+        // relayed — no body expansion (§13 inv 8).
+        "FILTER" => Scheme::new(
+            vec![0],
+            vec![0, 1],
+            WordTy::new(
+                stack(
+                    0,
+                    vec![
+                        list(v(0)),
+                        quote(stack(1, vec![v(0)]), stack(1, vec![Ty::bool(s)])),
+                    ],
+                ),
+                stack(0, vec![list(v(0))]),
+            ),
+        ),
+        // FOLD : ( 'S (List a) b ( 'r b a -- 'r b ) -- 'S b ). Thread an
+        // accumulator `b` (tyvar 1) through a step quotation that consumes the
+        // accumulator and one element `a` (tyvar 0) and leaves the new
+        // accumulator, sharing row 'r (rowvar 1) across both ends. The result is
+        // the final accumulator `b`. Relay only — the step arrow is never
+        // expanded (§13 inv 8).
+        "FOLD" => Scheme::new(
+            vec![0, 1],
+            vec![0, 1],
+            WordTy::new(
+                stack(
+                    0,
+                    vec![
+                        list(v(0)),
+                        v(1),
+                        quote(stack(1, vec![v(1), v(0)]), stack(1, vec![v(1)])),
+                    ],
+                ),
+                stack(0, vec![v(1)]),
+            ),
+        ),
+        // EACH : ( 'S (List a) ( 'r a -- 'r ) -- 'S ). Run a stack-neutral
+        // consumer (pops one element `a` (tyvar 0), leaves the rest of the stack
+        // 'r untouched — both ends share row 1) once per element, for effect. The
+        // list is consumed and the base stack 'S returns unchanged. Relay only.
+        "EACH" => Scheme::new(
+            vec![0],
+            vec![0, 1],
+            WordTy::new(
+                stack(
+                    0,
+                    vec![
+                        list(v(0)),
+                        quote(stack(1, vec![v(0)]), empty(1)),
+                    ],
+                ),
+                empty(0),
+            ),
+        ),
         _ => return None,
     };
     Some(scheme)
@@ -441,6 +585,14 @@ impl Ty {
     /// The `Bool` base type born at `span`.
     pub fn bool(span: Span) -> Self {
         Ty::con(BOOL, span)
+    }
+
+    /// A parameterized type `name args…` born at `span`, e.g. `List a`.
+    pub fn app(name: impl Into<String>, args: Vec<Ty>, span: Span) -> Self {
+        Ty {
+            kind: TyKind::App(name.into(), args),
+            span,
+        }
     }
 
     /// A quotation value carrying `arrow`, born at `span`.

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -383,10 +383,7 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
             vec![0],
             vec![0, 1, 2],
             WordTy::new(
-                stack(
-                    0,
-                    vec![v(0), quote(stack(1, vec![v(0)]), empty(2))],
-                ),
+                stack(0, vec![v(0), quote(stack(1, vec![v(0)]), empty(2))]),
                 stack(0, vec![quote(empty(1), empty(2))]),
             ),
         ),
@@ -485,13 +482,7 @@ pub fn core_scheme(runtime_name: &str) -> Option<Scheme> {
             vec![0],
             vec![0, 1],
             WordTy::new(
-                stack(
-                    0,
-                    vec![
-                        list(v(0)),
-                        quote(stack(1, vec![v(0)]), empty(1)),
-                    ],
-                ),
+                stack(0, vec![list(v(0)), quote(stack(1, vec![v(0)]), empty(1))]),
                 empty(0),
             ),
         ),


### PR DESCRIPTION
Give MAP, FILTER, FOLD, EACH, CURRY, WHEN, and UNLESS Tier-0 core
schemes so the checker resolves them as language-core primitives
instead of falling through to UNDEFINED word lookup.

Add an Ty::app constructor for parameterized types and wire the new
schemes through core_scheme:
- MAP/FILTER/FOLD/EACH: higher-order sequence relays that share a row
  across the quotation arrow ends to force an element-to-element shape.
- CURRY: quotation-builder that bakes a value into a quotation's input.
- WHEN/UNLESS: one-armed conditionals requiring a stack-shape-preserving
  quotation since the absent branch is identity.

Register the new primitives as LanguageCore in the attestation operator
table and keep the operator-table test's expected_core in sync.

Remove CLEAVE and SPREAD: list-of-quotations combinators that have no
faithful first-order scheme under this discipline. Drop their runtime
definitions, tests, and README rows.

Add check.rs acceptance and rejection tests covering the newly typed
combinators.

Co-authored-by: AI
