### PR TITLE
style: resolve clippy lints across workspace crates

### DIFF
--- a/arrrg/src/lib.rs
+++ b/arrrg/src/lib.rs
@@ -220,7 +220,7 @@ pub trait CommandLine: Sized + Default + Eq + PartialEq {
 provided: {:?}
 expected: {:?}
 check argument order amongst other differences",
-                &args, reconstructed_args
+                args, reconstructed_args
             );
         }
         (command_line, free)

--- a/rc_conf/src/lib.rs
+++ b/rc_conf/src/lib.rs
@@ -510,7 +510,7 @@ impl RcScript {
         if !status.success() {
             return Err(Error::invalid_invocation(format!(
                 "command {} failed with exit code {:?}",
-                &cmd[0],
+                cmd[0],
                 status.code()
             )));
         }
@@ -581,13 +581,9 @@ impl shvar::VariableProvider for EnvironmentVariableProvider {
         }
 
         let read_env = |key: &str| {
-            std::env::var(key).ok().and_then(|value| {
-                if value.contains('\0') {
-                    None // Reject values containing null bytes
-                } else {
-                    Some(value)
-                }
-            })
+            std::env::var(key)
+                .ok()
+                .filter(|value| !value.contains('\0'))
         };
 
         if let Some(prefix) = self.prefix.as_ref() {

--- a/rustrc/src/bin/rustrc.rs
+++ b/rustrc/src/bin/rustrc.rs
@@ -163,7 +163,7 @@ impl unix_sock::Invokable for UnixSockAdapter {
                 }
             }
             _ => {
-                return format!("error: unknown command {:?}", &argv[0]);
+                return format!("error: unknown command {:?}", argv[0]);
             }
         }
         response

--- a/saros/src/delta_array.rs
+++ b/saros/src/delta_array.rs
@@ -192,14 +192,13 @@ impl Iterator for DeltaDecoder<'_> {
                 self.remain = &self.remain[bytes_len..];
                 self.slice = Some(DeltaSliceDecoder::from_bits_and_bytes(bits, bytes));
                 self.resets += 1;
-            } else if let Some(slice) = self.slice.as_mut() {
+            } else {
+                let slice = self.slice.as_mut()?;
                 if let Some(decoded) = slice.next() {
                     return Some(decoded);
                 } else {
                     self.slice = None;
                 }
-            } else {
-                return None;
             }
         }
     }

--- a/scrunch/src/lib.rs
+++ b/scrunch/src/lib.rs
@@ -1098,10 +1098,9 @@ where
                 {
                     return self.correlates.pop().map(Exemplar::from);
                 }
-            } else if let Some(correlate) = self.correlates.pop() {
-                return Some(Exemplar::from(correlate));
             } else {
-                return None;
+                let correlate = self.correlates.pop()?;
+                return Some(Exemplar::from(correlate));
             }
         }
     }

--- a/sst/src/block.rs
+++ b/sst/src/block.rs
@@ -478,7 +478,7 @@ impl BlockCursor {
                 value: _,
             } => {
                 let mut ret = Vec::new();
-                key.truncate(0);
+                key.clear();
                 std::mem::swap(&mut ret, key);
                 ret
             }

--- a/sst/src/lib.rs
+++ b/sst/src/lib.rs
@@ -1892,7 +1892,7 @@ impl SstBuilder {
 
     fn assign_last_key(&mut self, key: &[u8], timestamp: u64) {
         BUILDER_ASSIGN_LAST_KEY.click();
-        self.last_key.truncate(0);
+        self.last_key.clear();
         self.last_key.extend_from_slice(key);
         self.last_timestamp = timestamp;
         if self.smallest_timestamp > timestamp {

--- a/stdioredirect/src/lib.rs
+++ b/stdioredirect/src/lib.rs
@@ -80,10 +80,9 @@ pub fn pct_substitution(subs: &HashMap<char, String>, input: &str) -> Option<Str
         if prev == '%' {
             if c == '%' {
                 output.push('%')
-            } else if let Some(sub) = subs.get(&c) {
-                output += sub;
             } else {
-                return None;
+                let sub = subs.get(&c)?;
+                output += sub;
             }
         } else if c != '%' {
             output.push(c);


### PR DESCRIPTION
Address a batch of clippy warnings with no functional changes:

- arrrg, rc_conf, rustrc: drop needless borrows on args passed to
  format macros (clippy::needless_borrow).
- rc_conf: replace map/and_then null-byte check with Option::filter
  for clarity.
- saros, scrunch, stdioredirect: collapse `else if let ... else {
  None }` chains into the `?` operator on the matched Option.
- sst: use Vec::clear() instead of truncate(0).

Co-authored-by: AI
