### PR TITLE
fix(k8src): check .k8signore only for directories, not files

### DIFF
--- a/k8src/src/lib.rs
+++ b/k8src/src/lib.rs
@@ -781,13 +781,6 @@ data:
                             .with_message("non-UTF8 pet path encountered during copy")
                             .with_string_field(FIELD_RC_CONF_PATH, rc_conf_chain)
                     })?;
-                    if path_exists(
-                        PHASE_RC_CONF_SEARCH,
-                        &pet.join(K8SIGNORE),
-                        "checking pet .k8srcignore",
-                    )? {
-                        continue;
-                    }
                     if pet.is_dir().map_err(|err| {
                         wrap_io_error(
                             PHASE_RC_CONF_SEARCH,
@@ -797,6 +790,13 @@ data:
                             "is_dir",
                         )
                     })? {
+                        if path_exists(
+                            PHASE_RC_CONF_SEARCH,
+                            &pet.join(K8SIGNORE),
+                            "checking pet .k8srcignore",
+                        )? {
+                            continue;
+                        }
                         copied |= copy_pets_from_dir(
                             options,
                             root,

--- a/k8src/tests/cases.rs
+++ b/k8src/tests/cases.rs
@@ -124,6 +124,45 @@ svc_PORT="1234"
     assert_eq!(error_string_field(&err, "key"), Some("IMAGE".to_string()));
 }
 
+#[test]
+fn pets_files_are_copied() {
+    let case = TempCase::new();
+    case.write_rc_conf("");
+    let pets = case.root.join("pets");
+    std::fs::create_dir_all(&pets).expect("pets directory should be writable");
+    std::fs::write(
+        pets.join("kustomization.yaml"),
+        "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - postgresql.yaml\n",
+    )
+    .expect("pet kustomization should be writable");
+    std::fs::write(pets.join("postgresql.yaml"), "kind: Namespace\n")
+        .expect("pet should be writable");
+    let output = case.root.join("manifests");
+    let options = RegenerateOptions {
+        root: Some(case.root.as_str().to_string()),
+        output: Some(output.as_str().to_string()),
+        verify: false,
+        overwrite: false,
+        dry_run: false,
+        diff: false,
+    };
+    regenerate(options).expect("regenerate should copy pets");
+    assert!(
+        output.join("pets/postgresql.yaml").exists().unwrap(),
+        "pet manifest should be copied"
+    );
+    assert!(
+        output.join("pets/kustomization.yaml").exists().unwrap(),
+        "pet kustomization should be copied"
+    );
+    assert!(
+        std::fs::read_to_string(output.join("kustomization.yaml"))
+            .expect("root kustomization should be readable")
+            .contains("  - pets"),
+        "root kustomization should reference pets"
+    );
+}
+
 test_case!(case0, 0);
 test_case!(case1, 1);
 test_case!(case2, 2);


### PR DESCRIPTION
Move the .k8signore existence check inside the is_dir() branch so
that pet files in a directory are not skipped when .k8signore is
absent. Previously, the check ran before the is_dir() guard, which
meant a non-directory entry whose sibling .k8signore path happened
to resolve would be incorrectly skipped.

Add a pets_files_are_copied test that sets up a pets directory
with a kustomization.yaml and a postgresql.yaml, runs regenerate,
and asserts the files are copied to the output directory and
referenced in the root kustomization.

Co-authored-by: AI
