### PR TITLE
feat(sstdb): single-SST linearizable KV database on object storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "sig_fig_histogram",
     "split_channel",
     "sst",
+    "sstdb",
     "statslicer",
     "stdioredirect",
     "symphonize",

--- a/sst/src/log.rs
+++ b/sst/src/log.rs
@@ -157,13 +157,31 @@ impl<W: Write> Write for BufWriter<W> {
 //////////////////////////////////////////// WriteBatch ////////////////////////////////////////////
 
 /// A WriteBatch for appending to a log.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct WriteBatch {
     buffer: Vec<u8>,
     setsum: Setsum,
 }
 
 impl WriteBatch {
+    /// Create an empty write batch.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return true if this batch contains no key/value entries.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Iterate over the entries in insertion order.
+    pub fn iter(&self) -> WriteBatchIterator<'_> {
+        WriteBatchIterator {
+            buffer: &self.buffer,
+            buffer_idx: 0,
+        }
+    }
+
     /// Insert the key-value pair into the write batch.
     pub fn insert(&mut self, kvr: KeyValueRef<'_>) -> Result<(), SError> {
         if let Some(value) = kvr.value {
@@ -179,6 +197,63 @@ impl WriteBatch {
         self.buffer.extend_from_slice(&wb.buffer);
         self.setsum += wb.setsum;
         Ok(())
+    }
+}
+
+/// An iterator over the entries of a [`WriteBatch`].
+pub struct WriteBatchIterator<'a> {
+    buffer: &'a [u8],
+    buffer_idx: usize,
+}
+
+impl<'a> WriteBatchIterator<'a> {
+    /// Return the next key/value entry from the batch.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<KeyValueRef<'a>>, SError> {
+        if self.buffer_idx >= self.buffer.len() {
+            return Ok(None);
+        }
+        let (kve, rem) = <KeyValueEntry as Unpackable>::unpack(&self.buffer[self.buffer_idx..])
+            .map_err(unpack_key_value_entry_prototk)?;
+        self.buffer_idx = self.buffer.len() - rem.len();
+        key_value_ref_from_entry(&kve).map(Some)
+    }
+}
+
+fn key_value_ref_from_entry<'a>(kve: &KeyValueEntry<'a>) -> Result<KeyValueRef<'a>, SError> {
+    fn check_shared(shared: u64) -> Result<(), SError> {
+        if shared != 0 {
+            Err(corruption_shared_not_zero())
+        } else {
+            Ok(())
+        }
+    }
+    match kve {
+        KeyValueEntry::Put(KeyValuePut {
+            shared,
+            key_frag,
+            timestamp,
+            value,
+        }) => {
+            check_shared(*shared)?;
+            Ok(KeyValueRef {
+                key: key_frag,
+                timestamp: *timestamp,
+                value: Some(value),
+            })
+        }
+        KeyValueEntry::Del(KeyValueDel {
+            shared,
+            key_frag,
+            timestamp,
+        }) => {
+            check_shared(*shared)?;
+            Ok(KeyValueRef {
+                key: key_frag,
+                timestamp: *timestamp,
+                value: None,
+            })
+        }
     }
 }
 
@@ -687,14 +762,7 @@ impl<R: Read + Seek> LogIterator<R> {
         let (kve, rem) = <KeyValueEntry as Unpackable>::unpack(&self.buffer[self.buffer_idx..])
             .map_err(unpack_key_value_entry_prototk)?;
         self.buffer_idx = self.buffer.len() - rem.len();
-        if kve.shared() != 0 {
-            return Err(corruption_shared_not_zero());
-        }
-        Ok(Some(KeyValueRef {
-            key: kve.key_frag(),
-            timestamp: kve.timestamp(),
-            value: kve.value(),
-        }))
+        key_value_ref_from_entry(&kve).map(Some)
     }
 
     fn next_frame(&mut self) -> Result<Option<Header>, SError> {
@@ -945,6 +1013,28 @@ mod builder {
         ];
         let got: &[u8] = &write;
         assert_eq!(exp, got);
+    }
+
+    #[test]
+    fn write_batch_iterator() {
+        let mut batch = WriteBatch::new();
+        assert!(batch.is_empty());
+        batch.put(b"alpha", 7, b"one").unwrap();
+        batch.del(b"beta", 6).unwrap();
+        assert!(!batch.is_empty());
+
+        let mut iter = batch.iter();
+        let first = iter.next().unwrap().unwrap();
+        assert_eq!(b"alpha", first.key);
+        assert_eq!(7, first.timestamp);
+        assert_eq!(Some(&b"one"[..]), first.value);
+
+        let second = iter.next().unwrap().unwrap();
+        assert_eq!(b"beta", second.key);
+        assert_eq!(6, second.timestamp);
+        assert_eq!(None, second.value);
+
+        assert!(iter.next().unwrap().is_none());
     }
 
     #[test]

--- a/sstdb/Cargo.toml
+++ b/sstdb/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sstdb"
+version = "0.1.0"
+edition.workspace = true
+description = "sstdb: a single-SST linearizable key-value database on object storage."
+license = "Apache-2.0"
+repository = "https://github.com/rescrv/blue"
+
+[features]
+# Back the store with S3 (object_store's `aws` backend).  Off by default so the crate builds and
+# tests run with the in-memory store; enable with `--features s3` for production.
+default = []
+s3 = ["object_store/aws"]
+
+[dependencies]
+async-trait = "0.1"
+bytes = "1"
+object_store = { version = "0.13.2" }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
+
+handled = { workspace = true }
+setsum = { workspace = true }
+sst = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "test-util"] }

--- a/sstdb/src/db.rs
+++ b/sstdb/src/db.rs
@@ -1,0 +1,384 @@
+//! The [`Database`]: read path, write path, recovery, and transactions.
+//!
+//! This ties together the conditional store (§3), the materialized snapshot (§4.1, §8), and the
+//! read-coalescing reader (§5) into the single-stepped write loop (§6), the writer-driven
+//! roll-forward recovery (§6.1), and the ETag-as-read-version transactions (§7).
+//!
+//! Object layout (§4):
+//!
+//! ```text
+//! <prefix>/fragment/<016x offset>   # immutable, If-None-Match claim
+//! <prefix>/sst/CURRENT              # the live SST; CAS'd via If-Match
+//! ```
+
+use std::ops::Bound;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sst::Builder;
+use sst::log::WriteBatch;
+
+use crate::fragment::{SSTDB_TIMESTAMP, check_batch, decode, encode};
+use crate::reader::{DEFAULT_WINDOW, Reader};
+use crate::snapshot::Snapshot;
+use crate::store::{ConditionalStore, WriteOutcome};
+use crate::{Result, capacity_exceeded, conflict, setsum_mismatch};
+
+/// The default capacity cap: 32 MiB, the expected operating regime given "most reads under 32 MB"
+/// (§9).
+pub const DEFAULT_CAP: usize = 32 * 1024 * 1024;
+
+/// The position a write was assigned in the total order.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LogPosition {
+    /// The fragment offset this write claimed (and at which it linearized).
+    pub offset: u64,
+}
+
+/// Configuration for a [`Database`].
+#[derive(Clone, Debug)]
+pub struct DatabaseOptions {
+    /// The object-key prefix under which fragments and the SST slot live.
+    pub prefix: String,
+    /// The capacity cap, in bytes (§9).  Writes whose resulting SST would exceed this are rejected.
+    pub cap: usize,
+    /// The read-coalescing window (§5).
+    pub window: Duration,
+    /// Whether coalesced reads verify the SST setsum on fetch (the opt-in paranoid read of §8).
+    pub verify_reads: bool,
+}
+
+impl Default for DatabaseOptions {
+    fn default() -> Self {
+        DatabaseOptions {
+            prefix: "db".to_string(),
+            cap: DEFAULT_CAP,
+            window: DEFAULT_WINDOW,
+            verify_reads: false,
+        }
+    }
+}
+
+/// A snapshot of the SST slot together with its ETag (the transaction read-version), or `None` for
+/// the ETag if the slot does not yet exist (genesis).
+struct CurrentState {
+    snapshot: Snapshot,
+    etag: Option<String>,
+}
+
+/// The single-SST database.
+#[derive(Clone)]
+pub struct Database {
+    store: Arc<dyn ConditionalStore>,
+    reader: Reader,
+    options: DatabaseOptions,
+    slot_path: String,
+    fragment_prefix: String,
+}
+
+impl Database {
+    /// Open a database over `store` with `options`.  Nothing is read or written until the first
+    /// operation; an absent slot is treated as the empty genesis.
+    pub fn open(store: Arc<dyn ConditionalStore>, options: DatabaseOptions) -> Self {
+        let slot_path = format!("{}/sst/CURRENT", options.prefix);
+        let fragment_prefix = format!("{}/fragment", options.prefix);
+        let reader = Reader::new(
+            Arc::clone(&store),
+            slot_path.clone(),
+            options.window,
+            options.verify_reads,
+        );
+        Database {
+            store,
+            reader,
+            options,
+            slot_path,
+            fragment_prefix,
+        }
+    }
+
+    /// The object path for a fragment at `offset`.  The path is fully specified so future layout
+    /// changes do not invalidate existing data (§4).
+    fn fragment_path(&self, offset: u64) -> String {
+        format!("{}/{:016x}", self.fragment_prefix, offset)
+    }
+
+    // ----------------------------------------------------------------------------- read path
+
+    /// Fetch the current snapshot through the 100 ms read-coalescing window (§5).
+    pub async fn snapshot(&self) -> Result<Arc<Snapshot>> {
+        self.reader.current().await
+    }
+
+    /// Point lookup.  Returns the value for `key`, or `None` if absent.  Meta keys are never
+    /// visible.
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let snap = self.snapshot().await?;
+        Ok(snap.get(key).map(|v| v.to_vec()))
+    }
+
+    /// Range scan, returning owned key/value pairs in sorted order over `[start, end)`-style bounds.
+    pub async fn scan<S, E>(
+        &self,
+        start: Bound<S>,
+        end: Bound<E>,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>>
+    where
+        S: AsRef<[u8]>,
+        E: AsRef<[u8]>,
+    {
+        let snap = self.snapshot().await?;
+        Ok(snap.scan(start, end))
+    }
+
+    // ----------------------------------------------------------------------------- write path
+
+    /// Load the current SST slot directly (bypassing the read window) with writer-side setsum
+    /// verification (§8).  A missing slot resolves to the empty genesis with no ETag.
+    async fn load_current(&self) -> Result<CurrentState> {
+        match self.store.get(&self.slot_path).await? {
+            Some(obj) => {
+                let snapshot = Snapshot::from_sst_bytes(&obj.bytes, true)?;
+                Ok(CurrentState {
+                    snapshot,
+                    etag: Some(obj.etag),
+                })
+            }
+            None => Ok(CurrentState {
+                snapshot: Snapshot::empty(),
+                etag: None,
+            }),
+        }
+    }
+
+    /// Install `bytes` into the slot: `If-Match` when advancing a known version, or `If-None-Match`
+    /// to create the genesis slot.  Both are the same conditional-PUT primitive (§7).
+    async fn install(&self, bytes: Vec<u8>, etag: &Option<String>) -> Result<WriteOutcome> {
+        match etag {
+            Some(e) => self.store.put_if_match(&self.slot_path, bytes, e).await,
+            None => self.store.put_if_none_match(&self.slot_path, bytes).await,
+        }
+    }
+
+    /// Convenience: write a single key/value.
+    pub async fn put(
+        &self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<LogPosition> {
+        let key = key.into();
+        let value = value.into();
+        let mut batch = WriteBatch::new();
+        batch.put(&key, SSTDB_TIMESTAMP, &value)?;
+        self.write(&batch).await
+    }
+
+    /// Convenience: delete a single key.
+    pub async fn delete(&self, key: impl Into<Vec<u8>>) -> Result<LogPosition> {
+        let key = key.into();
+        let mut batch = WriteBatch::new();
+        batch.del(&key, SSTDB_TIMESTAMP)?;
+        self.write(&batch).await
+    }
+
+    /// The §6 write loop, end to end: exact pre-claim capacity check, fragment claim
+    /// (`If-None-Match`), rollup, and install (`If-Match`).  On any precondition collision it rolls
+    /// the SST forward (§6.1) and retries.
+    ///
+    /// `write` carries a fixed batch, so re-applying it is idempotent; the operation
+    /// linearizes exactly once at the install that incorporates its offset, regardless of who
+    /// performs that install.
+    pub async fn write(&self, batch: &WriteBatch) -> Result<LogPosition> {
+        check_batch(batch)?;
+        loop {
+            let current = self.load_current().await?;
+            let offset = current.snapshot.next_offset();
+
+            // Step 0: exact, pre-claim capacity check (§9).  Gates the claim so we never make an
+            // over-cap fragment durable.
+            let new_snapshot = current.snapshot.apply(batch, offset)?;
+            let bytes = new_snapshot.to_sst_bytes()?;
+            if bytes.len() > self.options.cap {
+                return Err(capacity_exceeded(bytes.len(), self.options.cap));
+            }
+
+            // Step 1: claim the offset durably (If-None-Match).
+            let frag = encode(batch)?;
+            match self
+                .store
+                .put_if_none_match(&self.fragment_path(offset), frag)
+                .await?
+            {
+                WriteOutcome::Written(_) => {}
+                WriteOutcome::PreconditionFailed => {
+                    // Someone already owns this offset; they may have crashed before installing.
+                    self.recover().await?;
+                    continue;
+                }
+            }
+
+            // --- fragment is now durable.  The operation is PENDING. ---
+
+            // Step 2: roll the SST forward over the fragment we just claimed and install it.
+            match self.install(bytes, &current.etag).await? {
+                WriteOutcome::Written(_) => {
+                    // --- SST now incorporates the offset.  The operation is LINEARIZED. ---
+                    return Ok(LogPosition { offset });
+                }
+                WriteOutcome::PreconditionFailed => {
+                    // The slot moved underneath us.  The only claimable next offset was ours, so
+                    // whoever advanced the slot must have rolled our fragment forward — our write
+                    // is already linearized at `offset`.  Confirm by reloading; if for any reason
+                    // it is not yet incorporated, retry the loop.
+                    self.recover().await?;
+                    let after = self.load_current().await?;
+                    if after.snapshot.log_hi() >= offset {
+                        return Ok(LogPosition { offset });
+                    }
+                    continue;
+                }
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------------- recovery
+
+    /// Writer-driven roll-forward recovery (§6.1).  Brings the SST up to the durable log: while the
+    /// fragment at `log_hi + 1` exists, apply it and install the result, verifying the multiset is
+    /// exactly what the log says (§8).  `If-Match` collisions are ignored — another writer advanced
+    /// it; we re-observe and proceed.  Terminates when the SST is caught up to the log.
+    pub async fn recover(&self) -> Result<()> {
+        loop {
+            let current = self.load_current().await?;
+            let next = current.snapshot.next_offset();
+            let frag_obj = match self.store.get(&self.fragment_path(next)).await? {
+                Some(obj) => obj,
+                None => return Ok(()), // SST is caught up to the log.
+            };
+            let batch = decode(&frag_obj.bytes)?;
+            let new_snapshot = current.snapshot.apply(&batch, next)?;
+
+            // Turn roll-forward from "trust the offset pointer" into "verify the multiset is
+            // exactly what the log says it should be" (§8): the incrementally-maintained setsum must
+            // agree with a full recompute over the resulting user keyspace.
+            let stamped = new_snapshot.setsum().hexdigest();
+            let computed = new_snapshot.recompute_setsum().hexdigest();
+            if stamped != computed {
+                return Err(setsum_mismatch(&stamped, &computed));
+            }
+
+            let bytes = new_snapshot.to_sst_bytes()?;
+            // Ignore PreconditionFailed: someone else advanced it; loop and re-observe.
+            let _ = self.install(bytes, &current.etag).await?;
+        }
+    }
+
+    // ----------------------------------------------------------------------------- transactions
+
+    /// Begin an optimistic transaction.  Reads are served from the SST snapshot captured here, and
+    /// the captured ETag is the transaction's read-version (§7).
+    pub async fn transaction(&self) -> Result<Transaction> {
+        let current = self.load_current().await?;
+        Ok(Transaction {
+            db: self.clone(),
+            snapshot: Arc::new(current.snapshot),
+            etag: current.etag,
+            batch: WriteBatch::new(),
+        })
+    }
+}
+
+/// A single-object optimistic, serializable transaction (§7).
+///
+/// The ETag captured at [`Database::transaction`] *is* the read-version: the transaction commits
+/// iff no other writer has advanced the SST since it read (first-committer-wins).  On conflict,
+/// [`Transaction::commit`] returns a `conflict` [`SError`] and the caller should re-read, reapply its
+/// read-modify-write logic, and retry.
+pub struct Transaction {
+    db: Database,
+    snapshot: Arc<Snapshot>,
+    etag: Option<String>,
+    batch: WriteBatch,
+}
+
+impl Transaction {
+    /// The snapshot this transaction reads from.  All reads in the transaction are served from this
+    /// single version.
+    pub fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    /// Read a key at the transaction's snapshot.
+    pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
+        self.snapshot.get(key)
+    }
+
+    /// Stage a put.
+    pub fn put(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Result<&mut Self> {
+        let key = key.into();
+        let value = value.into();
+        self.batch.put(&key, SSTDB_TIMESTAMP, &value)?;
+        Ok(self)
+    }
+
+    /// Stage a delete.
+    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Result<&mut Self> {
+        let key = key.into();
+        self.batch.del(&key, SSTDB_TIMESTAMP)?;
+        Ok(self)
+    }
+
+    /// Commit by advancing the tag.  A single first-committer-wins attempt against the captured
+    /// read-version: success serializes the transaction immediately after the version it read;
+    /// failure returns a `conflict` [`SError`].
+    ///
+    /// A transaction that stages no writes is a read-only transaction and commits trivially
+    /// without writing a fragment.
+    pub async fn commit(self) -> Result<LogPosition> {
+        check_batch(&self.batch)?;
+
+        if self.batch.is_empty() {
+            return Ok(LogPosition {
+                offset: self.snapshot.log_hi(),
+            });
+        }
+
+        let offset = self.snapshot.next_offset();
+        let new_snapshot = self.snapshot.apply(&self.batch, offset)?;
+        let bytes = new_snapshot.to_sst_bytes()?;
+        if bytes.len() > self.db.options.cap {
+            return Err(capacity_exceeded(bytes.len(), self.db.options.cap));
+        }
+
+        // Claim the offset.  If we lose the claim, a conflicting transaction got there first.
+        let frag = encode(&self.batch)?;
+        match self
+            .db
+            .store
+            .put_if_none_match(&self.db.fragment_path(offset), frag)
+            .await?
+        {
+            WriteOutcome::Written(_) => {}
+            WriteOutcome::PreconditionFailed => {
+                self.db.recover().await?;
+                return Err(conflict());
+            }
+        }
+
+        // Commit by advancing the tag.
+        match self.db.install(bytes, &self.etag).await? {
+            WriteOutcome::Written(_) => Ok(LogPosition { offset }),
+            WriteOutcome::PreconditionFailed => {
+                // The slot moved.  The only claimable next offset was ours, so whoever advanced it
+                // rolled our fragment forward — our transaction committed at `offset`.  Confirm.
+                self.db.recover().await?;
+                let after = self.db.load_current().await?;
+                if after.snapshot.log_hi() >= offset {
+                    Ok(LogPosition { offset })
+                } else {
+                    Err(conflict())
+                }
+            }
+        }
+    }
+}

--- a/sstdb/src/fragment.rs
+++ b/sstdb/src/fragment.rs
@@ -112,10 +112,10 @@ mod tests {
     #[test]
     fn reserved_detection() {
         let mut batch = WriteBatch::new();
-        batch.put(&vec![0xff; 6], SSTDB_TIMESTAMP, b"x").unwrap();
+        batch.put(&[0xff; 6], SSTDB_TIMESTAMP, b"x").unwrap();
         assert!(check_batch(&batch).is_err());
         let mut ok = WriteBatch::new();
-        ok.put(&vec![0xff; 4], SSTDB_TIMESTAMP, b"x").unwrap();
+        ok.put(&[0xff; 4], SSTDB_TIMESTAMP, b"x").unwrap();
         assert!(check_batch(&ok).is_ok());
     }
 

--- a/sstdb/src/fragment.rs
+++ b/sstdb/src/fragment.rs
@@ -1,0 +1,128 @@
+//! Fragments: the immutable, ordered log records.
+//!
+//! A fragment is a single immutable encoding of one write's [`WriteBatch`] (§4).  Once written, a
+//! fragment is never mutated (Invariant 4), and `apply(SST, fragment)` is a pure, deterministic
+//! function so that whoever installs the resulting SST computes the same bytes.
+//!
+//! A fragment is encoded as an `sst` log: the caller's [`WriteBatch`] is written through a
+//! [`LogBuilder`] into an in-memory `Vec<u8>` — the bytes we upload as the fragment object.
+//! Decoding replays the log with a [`LogIterator`] back into a [`WriteBatch`].  Reusing the `sst`
+//! batch and log keeps a single, tested mutation model rather than a second hand-rolled one.
+
+use sst::log::WriteBatch;
+use sst::{Builder, KeyValueRef, LogBuilder, LogIterator, LogOptions};
+
+use crate::{META_PREFIX_LEN, Result, invalid_timestamp, reserved_key};
+
+/// sstdb materializes exactly one user-visible version in the SST.
+pub(crate) const SSTDB_TIMESTAMP: u64 = 0;
+
+/// Returns true if `key` is in the reserved meta-key range (begins with [`META_PREFIX_LEN`]
+/// `0xff` bytes).
+pub fn is_reserved_key(key: &[u8]) -> bool {
+    key.len() >= META_PREFIX_LEN && key[..META_PREFIX_LEN].iter().all(|b| *b == 0xff)
+}
+
+fn check_entry(kvr: &KeyValueRef<'_>) -> Result<()> {
+    if kvr.timestamp != SSTDB_TIMESTAMP {
+        return Err(invalid_timestamp(kvr.timestamp));
+    }
+    if is_reserved_key(kvr.key) {
+        return Err(reserved_key());
+    }
+    Ok(())
+}
+
+/// Reject the batch if any entry targets a reserved meta key or uses a non-zero timestamp.
+pub(crate) fn check_batch(batch: &WriteBatch) -> Result<()> {
+    let mut iter = batch.iter();
+    while let Some(kvr) = iter.next()? {
+        check_entry(&kvr)?;
+    }
+    Ok(())
+}
+
+/// Encode a batch into a fragment's bytes: an `sst` log holding one write batch.  An empty batch
+/// encodes as an empty log (no batch is appended, because the log rejects empty batches).
+pub(crate) fn encode(batch: &WriteBatch) -> Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut log = LogBuilder::from_write(LogOptions::default(), &mut buf)?;
+        if !batch.is_empty() {
+            log.append(batch)?;
+        }
+        log.seal()?;
+    }
+    Ok(buf)
+}
+
+/// Decode a fragment's bytes back into a [`WriteBatch`] by replaying the `sst` log.
+pub(crate) fn decode(bytes: &[u8]) -> Result<WriteBatch> {
+    let mut iter = LogIterator::from_reader(LogOptions::default(), std::io::Cursor::new(bytes))?;
+    let mut batch = WriteBatch::new();
+    while let Some(kvr) = iter.next()? {
+        check_entry(&kvr)?;
+        batch.insert(kvr)?;
+    }
+    Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", SSTDB_TIMESTAMP, b"1").unwrap();
+        batch.del(b"b", SSTDB_TIMESTAMP).unwrap();
+        batch.put(b"c", SSTDB_TIMESTAMP, b"").unwrap();
+        let bytes = encode(&batch).unwrap();
+        let back = decode(&bytes).unwrap();
+        assert_eq!(batch, back);
+    }
+
+    #[test]
+    fn empty_round_trip() {
+        let batch = WriteBatch::new();
+        // An empty batch appends no batch, so the log seals to zero bytes.
+        let bytes = encode(&batch).unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(batch, decode(&bytes).unwrap());
+    }
+
+    /// A small fragment seals to a small object: the sst log writes `header + batch` and only
+    /// trues-up to the 1 MiB block boundary when a batch crosses one, so a single tiny write is
+    /// not padded out to a block.
+    #[test]
+    fn small_fragment_is_compact() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", SSTDB_TIMESTAMP, b"1").unwrap();
+        let bytes = encode(&batch).unwrap();
+        assert!(!bytes.is_empty());
+        // Far below the 1 MiB block boundary: no block-sized padding crept in.
+        assert!(
+            bytes.len() < 1024,
+            "fragment unexpectedly large: {} bytes",
+            bytes.len()
+        );
+        assert_eq!(batch, decode(&bytes).unwrap());
+    }
+
+    #[test]
+    fn reserved_detection() {
+        let mut batch = WriteBatch::new();
+        batch.put(&vec![0xff; 6], SSTDB_TIMESTAMP, b"x").unwrap();
+        assert!(check_batch(&batch).is_err());
+        let mut ok = WriteBatch::new();
+        ok.put(&vec![0xff; 4], SSTDB_TIMESTAMP, b"x").unwrap();
+        assert!(check_batch(&ok).is_ok());
+    }
+
+    #[test]
+    fn timestamp_detection() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", 1, b"x").unwrap();
+        assert!(check_batch(&batch).is_err());
+    }
+}

--- a/sstdb/src/lib.rs
+++ b/sstdb/src/lib.rs
@@ -1,0 +1,106 @@
+//! sstdb — a single-SST, linearizable, capacity-bounded key-value database that lives entirely on
+//! object storage.
+//!
+//! The entire live dataset is one SST object (`db/sst/CURRENT`).  Writes are single-stepped: a
+//! writer claims an offset by writing an immutable log fragment with `If-None-Match`, then rolls
+//! the whole SST forward by applying that fragment and installing the result with `If-Match`.
+//! Reads fetch the whole SST.  **Conditional PUT is the only synchronization mechanism in the
+//! system** — there is no external coordination service.
+//!
+//! The crate is organized into the following pieces:
+//!
+//! * [`ConditionalStore`] — the thin object-store abstraction exposing exactly the three
+//!   conditional operations the design needs ([`store`]).
+//! * [`Snapshot`] — the materialized database, (de)serialized to/from a real SST via the `sst`
+//!   crate, with in-keyspace meta keys ([`snapshot`]).
+//! * [`Reader`] — the 100 ms read-coalescing window ([`reader`]).
+//! * [`Database`] — the read path, the write path (fragment claim → rollup → install), recovery
+//!   (writer-driven roll-forward), and ETag-as-read-version transactions ([`db`]).
+
+mod db;
+mod fragment;
+mod reader;
+mod snapshot;
+mod store;
+
+pub use db::{Database, DatabaseOptions, LogPosition, Transaction};
+pub use reader::Reader;
+pub use snapshot::{META_PREFIX, Snapshot};
+pub use sst::log::WriteBatch;
+pub use store::{ConditionalStore, Object, ObjectStoreConditional, WriteOutcome};
+
+/// The reserved meta-key prefix length: any key beginning with this many `0xff` bytes is a meta
+/// key and is not part of the user keyspace.
+pub const META_PREFIX_LEN: usize = 5;
+
+pub use handled::SError;
+
+/// The phase tag stamped on every [`SError`] this crate produces.
+const ERROR_PHASE: &str = "sstdb";
+
+/// The crate result type.  Every fallible operation reports failures as a [`handled::SError`]; the
+/// `code` field discriminates the cases the old hand-rolled enum used to express.
+pub type Result<T> = std::result::Result<T, SError>;
+
+/// An object-store operation failed for a non-precondition reason (code `store-error`).
+pub(crate) fn store_error(e: object_store::Error) -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("store-error")
+        .with_message("object store operation failed")
+        .with_debug_field("cause", e)
+}
+
+/// The proposed write would push the database over its configured capacity (code
+/// `capacity-exceeded`).  `size` is the size the new SST would have had and `cap` the configured
+/// limit, both in bytes.
+pub(crate) fn capacity_exceeded(size: usize, cap: usize) -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("capacity-exceeded")
+        .with_message("write would exceed configured capacity")
+        .with_atom_field("size", size)
+        .with_atom_field("cap", cap)
+}
+
+/// A client tried to write to or read across the reserved meta-key range (code `reserved-key`).
+pub(crate) fn reserved_key() -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("reserved-key")
+        .with_message("key is in the reserved meta-key range")
+}
+
+/// A client-supplied [`WriteBatch`] used a timestamp other than sstdb's materialized timestamp 0
+/// (code `invalid-timestamp`).
+pub(crate) fn invalid_timestamp(timestamp: u64) -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("invalid-timestamp")
+        .with_message("sstdb write batches must use timestamp 0")
+        .with_atom_field("timestamp", timestamp)
+}
+
+/// A loaded SST's recomputed setsum did not match its stamped setsum: corruption (code
+/// `setsum-mismatch`).  Per the design, this halts the writer for human attention.  `stamped` is
+/// the setsum stamped in the SST's meta keys; `computed` is the setsum recomputed over the loaded
+/// user keyspace.
+pub(crate) fn setsum_mismatch(stamped: &str, computed: &str) -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("setsum-mismatch")
+        .with_message("recomputed setsum disagrees with the stamped setsum")
+        .with_string_field("stamped", stamped)
+        .with_string_field("computed", computed)
+}
+
+/// An object or invariant that should have held did not (code `corruption`).
+pub(crate) fn corruption(message: impl AsRef<str>) -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("corruption")
+        .with_message(message.as_ref())
+}
+
+/// An optimistic transaction lost the first-committer-wins race: the SST moved underneath the
+/// transaction's read-version (code `conflict`).  The caller should re-read, reapply its
+/// read-modify-write logic, and retry (§7).
+pub(crate) fn conflict() -> SError {
+    SError::new(ERROR_PHASE)
+        .with_code("conflict")
+        .with_message("transaction conflict: the SST moved; reapply and retry")
+}

--- a/sstdb/src/reader.rs
+++ b/sstdb/src/reader.rs
@@ -1,0 +1,162 @@
+//! The read path with a 100 ms read-coalescing window (§5).
+//!
+//! Because reads dominate 10:1 and a read is a full-SST fetch, concurrent reads over a short window
+//! are satisfied by a single object-storage fetch and share the result.  This is the time-symmetric
+//! mirror of wal3's write batching: there it accumulates *writes* to amortize a PUT; here it
+//! accumulates *reads* to amortize a GET.
+//!
+//! There is exactly one rendezvous point — the open batch — so a single `Mutex` is the honest
+//! primitive at cardinality one.  **The lock is never held across an await**: the batch is sealed
+//! and the lock released *before* any object-store round trip, so a slow fetch never blocks new
+//! readers from forming the next batch.
+//!
+//! **Every window talks to object storage.**  The HEAD optimization (§5) collapses a full GET into
+//! a HEAD when the ETag is unchanged since the previous window, reusing the bytes already held — but
+//! it is still a fetch-time check every window, never a window trusting an earlier window's `Arc`
+//! without asking object storage.  Coalescing changes only cost, never what a reader sees.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
+use crate::snapshot::Snapshot;
+use crate::store::ConditionalStore;
+use crate::{Result, SError, corruption};
+
+/// The default read-batching window.
+pub const DEFAULT_WINDOW: Duration = Duration::from_millis(100);
+
+type Waiter = oneshot::Sender<std::result::Result<Arc<Snapshot>, Arc<SError>>>;
+
+/// The open batch: the set of readers awaiting the current window plus the window's arm-state.
+struct Batch {
+    waiters: Vec<Waiter>,
+    armed: bool,
+}
+
+impl Batch {
+    fn empty() -> Self {
+        Batch {
+            waiters: Vec::new(),
+            armed: false,
+        }
+    }
+}
+
+struct ReaderInner {
+    store: Arc<dyn ConditionalStore>,
+    slot: String,
+    window: Duration,
+    verify: bool,
+    // Held only to mutate the waiter set; never across an await.
+    batch: std::sync::Mutex<Batch>,
+    // The previous window's fetch, for the HEAD optimization.  tokio mutex because it is touched
+    // across awaits in the driver.
+    cached: tokio::sync::Mutex<Option<(String, Arc<Snapshot>)>>,
+}
+
+/// The read-coalescing reader.  Cheap to clone; clones share one window.
+#[derive(Clone)]
+pub struct Reader {
+    inner: Arc<ReaderInner>,
+}
+
+impl Reader {
+    /// Create a reader over `store`, resolving the SST slot at `slot`, batching over `window`.  If
+    /// `verify` is set, every fetched SST has its setsum verified (the opt-in paranoid read of §8).
+    pub fn new(
+        store: Arc<dyn ConditionalStore>,
+        slot: impl Into<String>,
+        window: Duration,
+        verify: bool,
+    ) -> Self {
+        Reader {
+            inner: Arc::new(ReaderInner {
+                store,
+                slot: slot.into(),
+                window,
+                verify,
+                batch: std::sync::Mutex::new(Batch::empty()),
+                cached: tokio::sync::Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Join the open batch and await the window's shared SST.  Every in-flight request is satisfied
+    /// by its own window's fetch against object storage.
+    pub async fn current(&self) -> Result<Arc<Snapshot>> {
+        let (tx, rx) = oneshot::channel();
+        let arm = {
+            let mut b = self.inner.batch.lock().unwrap();
+            b.waiters.push(tx);
+            let first = !b.armed;
+            b.armed = true;
+            first
+        }; // <- lock released here
+        if arm {
+            let inner = Arc::clone(&self.inner);
+            let window = inner.window;
+            tokio::spawn(async move {
+                tokio::time::sleep(window).await;
+                Reader::drive(inner).await;
+            });
+        }
+        match rx.await {
+            Ok(Ok(snap)) => Ok(snap),
+            Ok(Err(shared)) => Err((*shared).clone()),
+            Err(_canceled) => Err(corruption("read window driver dropped before resolving")),
+        }
+    }
+
+    /// Seal the batch, resolve exactly one SST, and distribute `Arc<Snapshot>` clones to every
+    /// sealed waiter.  Readers arriving after the seal form the next window.
+    async fn drive(inner: Arc<ReaderInner>) {
+        let sealed = {
+            let mut b = inner.batch.lock().unwrap();
+            std::mem::replace(&mut *b, Batch::empty())
+        }; // <- lock released before any I/O
+        let resolved = Reader::resolve_current(&inner).await;
+        match resolved {
+            Ok(snap) => {
+                for tx in sealed.waiters {
+                    let _ = tx.send(Ok(Arc::clone(&snap)));
+                }
+            }
+            Err(e) => {
+                let shared = Arc::new(e);
+                for tx in sealed.waiters {
+                    let _ = tx.send(Err(Arc::clone(&shared)));
+                }
+            }
+        }
+    }
+
+    /// Resolve the current SST.  Uses the HEAD optimization: if the slot's ETag is unchanged since
+    /// the previous window, reuse the cached `Arc<Snapshot>` (HEAD only, no byte transfer);
+    /// otherwise GET and parse.  A missing slot resolves to the empty genesis snapshot.
+    async fn resolve_current(inner: &ReaderInner) -> Result<Arc<Snapshot>> {
+        let prev = inner.cached.lock().await.clone();
+        if let Some((prev_etag, prev_snap)) = prev {
+            match inner.store.head(&inner.slot).await? {
+                Some(etag) if etag == prev_etag => {
+                    // Unchanged since our previous fetch: reuse, no byte transfer.
+                    return Ok(prev_snap);
+                }
+                _ => {} // changed or vanished: fall through to a full GET.
+            }
+        }
+        match inner.store.get(&inner.slot).await? {
+            Some(obj) => {
+                let snap = Snapshot::from_sst_bytes(&obj.bytes, inner.verify)?;
+                let snap = Arc::new(snap);
+                *inner.cached.lock().await = Some((obj.etag, Arc::clone(&snap)));
+                Ok(snap)
+            }
+            None => {
+                // No slot yet: serve the empty genesis.  Do not cache (no ETag to key on).
+                Ok(Arc::new(Snapshot::empty()))
+            }
+        }
+    }
+}

--- a/sstdb/src/snapshot.rs
+++ b/sstdb/src/snapshot.rs
@@ -1,0 +1,406 @@
+//! The [`Snapshot`]: the materialized database.
+//!
+//! The entire live dataset is one SST (Invariant 1).  In memory we keep it as a sorted map of the
+//! user keyspace plus three pieces of metadata (`log_lo`, `log_hi`, `setsum`).  On object storage
+//! it is a genuine SST produced by the `sst` crate, with the metadata stored *in-keyspace* as
+//! reserved meta keys (§4.1):
+//!
+//! * `\xff\xff\xff\xff\xff/log_lo`  — lowest fragment offset still represented in this SST.
+//! * `\xff\xff\xff\xff\xff/log_hi`  — highest fragment offset incorporated into this SST.
+//! * `\xff\xff\xff\xff\xff/setsum`  — the setsum of the *user* keyspace (meta keys excluded).
+//!
+//! Because `0xff`×5 sorts after all plausible user keys, the meta keys live at the tail of the SST
+//! and are trivially separable on scan.
+//!
+//! Offsets follow the §6 pseudocode: `log_hi` is the highest incorporated offset and the next
+//! offset to claim is `log_hi + 1`.  The genesis (empty) database has `log_hi == 0`; fragment 0 is
+//! the implicit empty genesis and is never written as an object, so the first real write claims
+//! offset 1.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use setsum::Setsum;
+use sst::log::WriteBatch;
+use sst::{Builder, Cursor, Key, Sst, SstBuilder, SstOptions};
+
+use crate::fragment::{SSTDB_TIMESTAMP, is_reserved_key};
+use crate::{
+    META_PREFIX_LEN, Result, corruption, invalid_timestamp, reserved_key, setsum_mismatch,
+};
+
+/// The reserved meta-key prefix: any key beginning with these bytes is a meta key.
+pub const META_PREFIX: [u8; META_PREFIX_LEN] = [0xff; META_PREFIX_LEN];
+
+const META_LOG_LO: &[u8] = b"/log_lo";
+const META_LOG_HI: &[u8] = b"/log_hi";
+const META_SETSUM: &[u8] = b"/setsum";
+
+/// All SSTs in sstdb share one fixed option set so that `apply` is byte-deterministic across
+/// writers (Invariant 4).
+fn sst_options() -> SstOptions {
+    SstOptions::default()
+}
+
+/// Build the full meta key for a given suffix.
+fn meta_key(suffix: &[u8]) -> Vec<u8> {
+    let mut k = Vec::with_capacity(META_PREFIX_LEN + suffix.len());
+    k.extend_from_slice(&META_PREFIX);
+    k.extend_from_slice(suffix);
+    k
+}
+
+/// The framed setsum item for a single key/value pair.  Framing the key length prevents a key/value
+/// boundary ambiguity from aliasing distinct pairs into the same multiset element.
+fn setsum_item(key: &[u8], value: &[u8]) -> Vec<u8> {
+    let mut item = Vec::with_capacity(8 + key.len() + value.len());
+    item.extend_from_slice(&(key.len() as u64).to_le_bytes());
+    item.extend_from_slice(key);
+    item.extend_from_slice(value);
+    item
+}
+
+fn snapshot_key(key: &[u8]) -> Key {
+    Key {
+        key: key.to_vec(),
+        timestamp: SSTDB_TIMESTAMP,
+    }
+}
+
+/// The materialized database: the user keyspace plus the log metadata.
+#[derive(Clone, Debug)]
+pub struct Snapshot {
+    /// The live user keyspace, sorted.  Tombstones are not represented — a deleted key is simply
+    /// absent.
+    map: BTreeMap<Key, Vec<u8>>,
+    /// Lowest fragment offset still represented (0 for v1 without GC).
+    log_lo: u64,
+    /// Highest fragment offset incorporated.  The recovery anchor.
+    log_hi: u64,
+    /// The setsum over the user keyspace.  Maintained incrementally by [`Snapshot::apply`].
+    setsum: Setsum,
+}
+
+impl Default for Snapshot {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl Snapshot {
+    /// The genesis (empty) database: no user keys, `log_lo == log_hi == 0`.
+    pub fn empty() -> Self {
+        Snapshot {
+            map: BTreeMap::new(),
+            log_lo: 0,
+            log_hi: 0,
+            setsum: Setsum::default(),
+        }
+    }
+
+    /// Lowest fragment offset still represented.
+    pub fn log_lo(&self) -> u64 {
+        self.log_lo
+    }
+
+    /// Highest fragment offset incorporated.  The next offset to claim is `log_hi() + 1`.
+    pub fn log_hi(&self) -> u64 {
+        self.log_hi
+    }
+
+    /// The next offset a writer would claim.
+    pub fn next_offset(&self) -> u64 {
+        self.log_hi + 1
+    }
+
+    /// The setsum over the user keyspace.
+    pub fn setsum(&self) -> Setsum {
+        self.setsum
+    }
+
+    /// Number of live user keys.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// True if there are no live user keys.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Point lookup over the user keyspace.  Meta keys are never visible to clients.
+    pub fn get(&self, key: &[u8]) -> Option<&[u8]> {
+        if is_reserved_key(key) {
+            return None;
+        }
+        self.map.get(&snapshot_key(key)).map(|v| v.as_slice())
+    }
+
+    /// Range scan over the user keyspace, returning owned key/value pairs in sorted order.  Meta
+    /// keys are excluded.
+    pub fn scan<S, E>(&self, start: Bound<S>, end: Bound<E>) -> Vec<(Vec<u8>, Vec<u8>)>
+    where
+        S: AsRef<[u8]>,
+        E: AsRef<[u8]>,
+    {
+        let start = match &start {
+            Bound::Included(s) => Bound::Included(snapshot_key(s.as_ref())),
+            Bound::Excluded(s) => Bound::Excluded(snapshot_key(s.as_ref())),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let end = match &end {
+            Bound::Included(e) => Bound::Included(snapshot_key(e.as_ref())),
+            Bound::Excluded(e) => Bound::Excluded(snapshot_key(e.as_ref())),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        self.map
+            .range((start, end))
+            .filter(|(k, _)| !is_reserved_key(&k.key))
+            .map(|(k, v)| (k.key.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Iterate over all live user key/value pairs in sorted order.
+    pub fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
+        self.map
+            .iter()
+            .map(|(k, v)| (k.key.as_slice(), v.as_slice()))
+    }
+
+    /// Produce a new snapshot with `batch` applied and `log_hi` advanced to `offset`.
+    ///
+    /// This is the pure, deterministic rollup `apply(SST, fragment)` (Invariant 4).  The setsum is
+    /// maintained incrementally: `setsum' = setsum + additions - removals` (§8).
+    pub fn apply(&self, batch: &WriteBatch, offset: u64) -> Result<Snapshot> {
+        let mut map = self.map.clone();
+        let mut setsum = self.setsum;
+        let mut iter = batch.iter();
+        while let Some(kvr) = iter.next()? {
+            if kvr.timestamp != SSTDB_TIMESTAMP {
+                return Err(invalid_timestamp(kvr.timestamp));
+            }
+            if is_reserved_key(kvr.key) {
+                return Err(reserved_key());
+            }
+            let key = snapshot_key(kvr.key);
+            match kvr.value {
+                Some(value) => {
+                    if let Some(old) = map.insert(key.clone(), value.to_vec()) {
+                        setsum.remove(&setsum_item(&key.key, &old));
+                    }
+                    setsum.insert(&setsum_item(&key.key, value));
+                }
+                None => {
+                    if let Some(old) = map.remove(&key) {
+                        setsum.remove(&setsum_item(&key.key, &old));
+                    }
+                }
+            }
+        }
+        Ok(Snapshot {
+            map,
+            log_lo: self.log_lo,
+            log_hi: offset,
+            setsum,
+        })
+    }
+
+    /// Recompute the setsum from scratch over the user keyspace.  Used by writers to verify a
+    /// loaded SST before building on it (§8).
+    pub fn recompute_setsum(&self) -> Setsum {
+        let mut s = Setsum::default();
+        for (k, v) in &self.map {
+            s.insert(&setsum_item(&k.key, v));
+        }
+        s
+    }
+
+    /// Serialize this snapshot to a real SST's bytes.  The meta keys are stamped from the
+    /// snapshot's own `log_lo`/`log_hi`/`setsum` (§8: stamping the setsum does not perturb it,
+    /// because meta keys are excluded from the setsum domain).
+    pub fn to_sst_bytes(&self) -> Result<Vec<u8>> {
+        let path = temp_path("build");
+        // Best-effort: ensure no stale file at this unique path.
+        let _ = std::fs::remove_file(&path);
+        let mut builder = SstBuilder::new(sst_options(), &path)?;
+        // User keys first (already sorted), all at timestamp 0 for a single materialized version.
+        for (k, v) in &self.map {
+            builder.put(&k.key, k.timestamp, v)?;
+        }
+        // Meta keys sort after all user keys; emit them in sorted order among themselves.
+        let mut metas: Vec<(Vec<u8>, Vec<u8>)> = vec![
+            (
+                meta_key(META_LOG_LO),
+                format!("{:016x}", self.log_lo).into_bytes(),
+            ),
+            (
+                meta_key(META_LOG_HI),
+                format!("{:016x}", self.log_hi).into_bytes(),
+            ),
+            (meta_key(META_SETSUM), self.setsum.hexdigest().into_bytes()),
+        ];
+        metas.sort();
+        for (k, v) in &metas {
+            builder.put(k, 0, v)?;
+        }
+        let sst = builder.seal()?;
+        drop(sst);
+        let bytes = std::fs::read(&path)?;
+        let _ = std::fs::remove_file(&path);
+        Ok(bytes)
+    }
+
+    /// Parse an SST's bytes back into a snapshot, separating meta keys from the user keyspace.
+    ///
+    /// If `verify` is set, the recomputed setsum over the user keyspace is checked against the
+    /// stamped setsum and a `setsum-mismatch` [`SError`] is returned on disagreement.  Writers verify
+    /// on load; readers trust the stamp by default (§8).
+    pub fn from_sst_bytes(bytes: &[u8], verify: bool) -> Result<Snapshot> {
+        let path = temp_path("load");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, bytes)?;
+        let result = Self::from_sst_path(&path, verify);
+        let _ = std::fs::remove_file(&path);
+        result
+    }
+
+    fn from_sst_path(path: &std::path::Path, verify: bool) -> Result<Snapshot> {
+        let sst = Sst::<sst::file_manager::FileHandle>::new(sst_options(), path)?;
+        let mut cursor = sst.cursor();
+        cursor.seek_to_first()?;
+        cursor.next()?;
+
+        let mut map = BTreeMap::new();
+        let mut log_lo: Option<u64> = None;
+        let mut log_hi: Option<u64> = None;
+        let mut stamped_setsum: Option<String> = None;
+
+        while let Some(kvr) = cursor.key_value() {
+            let key = kvr.key;
+            if kvr.timestamp != SSTDB_TIMESTAMP {
+                return Err(invalid_timestamp(kvr.timestamp));
+            }
+            if is_reserved_key(key) {
+                let suffix = &key[META_PREFIX_LEN..];
+                let value = kvr.value.unwrap_or(&[]);
+                if suffix == META_LOG_LO {
+                    log_lo = Some(parse_hex_u64(value)?);
+                } else if suffix == META_LOG_HI {
+                    log_hi = Some(parse_hex_u64(value)?);
+                } else if suffix == META_SETSUM {
+                    stamped_setsum = Some(
+                        std::str::from_utf8(value)
+                            .map_err(|_| corruption("meta: setsum not utf8"))?
+                            .to_string(),
+                    );
+                }
+                // Unknown meta keys are ignored for forward compatibility.
+            } else if let Some(v) = kvr.value {
+                map.insert(snapshot_key(key), v.to_vec());
+            }
+            cursor.next()?;
+        }
+
+        let log_lo = log_lo.ok_or_else(|| corruption("meta: missing log_lo"))?;
+        let log_hi = log_hi.ok_or_else(|| corruption("meta: missing log_hi"))?;
+        let stamped = stamped_setsum.ok_or_else(|| corruption("meta: missing setsum"))?;
+
+        let snapshot = Snapshot {
+            map,
+            log_lo,
+            log_hi,
+            setsum: Setsum::from_hexdigest(&stamped)
+                .ok_or_else(|| corruption("meta: setsum not valid hex"))?,
+        };
+
+        if verify {
+            let computed = snapshot.recompute_setsum().hexdigest();
+            if computed != stamped {
+                return Err(setsum_mismatch(&stamped, &computed));
+            }
+        }
+
+        Ok(snapshot)
+    }
+}
+
+fn parse_hex_u64(bytes: &[u8]) -> Result<u64> {
+    let s = std::str::from_utf8(bytes).map_err(|_| corruption("meta: offset not utf8"))?;
+    u64::from_str_radix(s, 16).map_err(|_| corruption("meta: offset not hex"))
+}
+
+/// A process-unique temp path for staging SST encode/decode.
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "sstdb-{tag}-{}-{nanos}-{n}.sst",
+        std::process::id()
+    ));
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_round_trip() {
+        let snap = Snapshot::empty();
+        let bytes = snap.to_sst_bytes().unwrap();
+        let back = Snapshot::from_sst_bytes(&bytes, true).unwrap();
+        assert_eq!(back.log_lo(), 0);
+        assert_eq!(back.log_hi(), 0);
+        assert!(back.is_empty());
+        assert_eq!(back.setsum().hexdigest(), Setsum::default().hexdigest());
+    }
+
+    #[test]
+    fn apply_and_round_trip() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"alpha", SSTDB_TIMESTAMP, b"1").unwrap();
+        batch.put(b"beta", SSTDB_TIMESTAMP, b"2").unwrap();
+        let snap = Snapshot::empty().apply(&batch, 1).unwrap();
+        assert_eq!(snap.log_hi(), 1);
+        assert_eq!(snap.get(b"alpha"), Some(&b"1"[..]));
+
+        let bytes = snap.to_sst_bytes().unwrap();
+        let back = Snapshot::from_sst_bytes(&bytes, true).unwrap();
+        assert_eq!(back.get(b"alpha"), Some(&b"1"[..]));
+        assert_eq!(back.get(b"beta"), Some(&b"2"[..]));
+        assert_eq!(back.log_hi(), 1);
+        // The stamped setsum survived the round trip and verifies.
+        assert_eq!(back.setsum().hexdigest(), snap.setsum().hexdigest());
+    }
+
+    #[test]
+    fn incremental_setsum_matches_recompute() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", SSTDB_TIMESTAMP, b"x").unwrap();
+        batch.put(b"b", SSTDB_TIMESTAMP, b"y").unwrap();
+        batch.put(b"a", SSTDB_TIMESTAMP, b"z").unwrap(); // overwrite
+        batch.del(b"b", SSTDB_TIMESTAMP).unwrap();
+        let snap = Snapshot::empty().apply(&batch, 1).unwrap();
+        assert_eq!(snap.get(b"a"), Some(&b"z"[..]));
+        assert_eq!(snap.get(b"b"), None);
+        assert_eq!(
+            snap.setsum().hexdigest(),
+            snap.recompute_setsum().hexdigest()
+        );
+    }
+
+    #[test]
+    fn meta_keys_not_visible() {
+        let snap = Snapshot::empty().apply(&WriteBatch::new(), 5).unwrap();
+        // No user key equals a meta key.
+        assert_eq!(snap.get(&META_PREFIX), None);
+        let all = snap.scan::<&[u8], &[u8]>(Bound::Unbounded, Bound::Unbounded);
+        assert!(all.is_empty());
+    }
+}

--- a/sstdb/src/store.rs
+++ b/sstdb/src/store.rs
@@ -1,0 +1,158 @@
+//! The object-store abstraction.
+//!
+//! Per the design (§3, §11), **conditional PUT is the only synchronization primitive**, and it is
+//! used at exactly two points:
+//!
+//! * claim an empty offset with `PUT fragment_N` and `If-None-Match: *`
+//!   ([`ConditionalStore::put_if_none_match`]); and
+//! * advance a known version with `PUT <sst-slot>` and `If-Match: <etag>`
+//!   ([`ConditionalStore::put_if_match`]).
+//!
+//! Everything else in sstdb sits on this trait.  [`ObjectStoreConditional`] backs it with any
+//! [`object_store::ObjectStore`] — `InMemory` for tests, `AmazonS3` for production — both of which
+//! support the standard HTTP precondition headers this design relies upon.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+#[cfg(feature = "s3")]
+use object_store::aws::AmazonS3Builder;
+use object_store::memory::InMemory;
+use object_store::path::Path as ObjectPath;
+use object_store::{
+    Error as OsError, ObjectStore, ObjectStoreExt, PutMode, PutOptions, UpdateVersion,
+};
+
+use crate::{Result, corruption, store_error};
+
+/// An object fetched from the store: its bytes and its ETag.
+#[derive(Clone, Debug)]
+pub struct Object {
+    /// The object's bytes.
+    pub bytes: Bytes,
+    /// The object's ETag, used as the read-version for conditional updates.
+    pub etag: String,
+}
+
+/// The outcome of a conditional PUT.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WriteOutcome {
+    /// The PUT succeeded; carries the new ETag of the object.
+    Written(String),
+    /// The conditional PUT's precondition failed: the slot was already claimed
+    /// (`If-None-Match`) or the version moved underneath us (`If-Match`).
+    PreconditionFailed,
+}
+
+/// The thin conditional object-store trait sstdb is built on.
+#[async_trait]
+pub trait ConditionalStore: Send + Sync {
+    /// Fetch the object at `path`, or `None` if it does not exist.
+    async fn get(&self, path: &str) -> Result<Option<Object>>;
+
+    /// Fetch just the ETag of the object at `path` (a HEAD), or `None` if it does not exist.
+    async fn head(&self, path: &str) -> Result<Option<String>>;
+
+    /// `PUT path` with `If-None-Match: *`: claim an empty slot.  Returns
+    /// [`WriteOutcome::PreconditionFailed`] if the object already exists.
+    async fn put_if_none_match(&self, path: &str, bytes: Vec<u8>) -> Result<WriteOutcome>;
+
+    /// `PUT path` with `If-Match: <etag>`: advance a known version.  Returns
+    /// [`WriteOutcome::PreconditionFailed`] if the current ETag no longer matches.
+    async fn put_if_match(&self, path: &str, bytes: Vec<u8>, etag: &str) -> Result<WriteOutcome>;
+}
+
+/// A [`ConditionalStore`] backed by any [`object_store::ObjectStore`].
+#[derive(Clone, Debug)]
+pub struct ObjectStoreConditional {
+    inner: Arc<dyn ObjectStore>,
+}
+
+impl ObjectStoreConditional {
+    /// Wrap an existing object store.
+    pub fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self { inner }
+    }
+
+    /// An in-memory store, suitable for tests.  It supports the conditional puts this design
+    /// requires, so it exercises the same code paths as S3.
+    pub fn in_memory() -> Self {
+        Self::new(Arc::new(InMemory::new()))
+    }
+
+    /// Back the store with S3 (or an S3-compatible service), configured from the standard
+    /// `AWS_*` environment variables, for the given bucket.  Conditional PUT (`ETagMatch`) is the
+    /// default for the AWS backend, which is exactly what this design requires.
+    ///
+    /// Available with the `s3` cargo feature.
+    #[cfg(feature = "s3")]
+    pub fn s3_from_env(bucket: &str) -> Result<Self> {
+        let s3 = AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()
+            .map_err(store_error)?;
+        Ok(Self::new(Arc::new(s3)))
+    }
+}
+
+/// Extract the ETag from an object's metadata, synthesizing a deterministic placeholder when the
+/// backend does not surface one (some stores omit it for HEAD on tiny objects).
+fn require_etag(e_tag: Option<String>) -> Result<String> {
+    e_tag.ok_or_else(|| corruption("object store returned no ETag"))
+}
+
+#[async_trait]
+impl ConditionalStore for ObjectStoreConditional {
+    async fn get(&self, path: &str) -> Result<Option<Object>> {
+        let location = ObjectPath::from(path);
+        let result = match self.inner.get(&location).await {
+            Ok(r) => r,
+            Err(OsError::NotFound { .. }) => return Ok(None),
+            Err(e) => return Err(store_error(e)),
+        };
+        let etag = require_etag(result.meta.e_tag.clone())?;
+        let bytes = result.bytes().await.map_err(store_error)?;
+        Ok(Some(Object { bytes, etag }))
+    }
+
+    async fn head(&self, path: &str) -> Result<Option<String>> {
+        let location = ObjectPath::from(path);
+        match self.inner.head(&location).await {
+            Ok(meta) => Ok(Some(require_etag(meta.e_tag)?)),
+            Err(OsError::NotFound { .. }) => Ok(None),
+            Err(e) => Err(store_error(e)),
+        }
+    }
+
+    async fn put_if_none_match(&self, path: &str, bytes: Vec<u8>) -> Result<WriteOutcome> {
+        let location = ObjectPath::from(path);
+        let opts = PutOptions::from(PutMode::Create);
+        match self.inner.put_opts(&location, bytes.into(), opts).await {
+            Ok(res) => Ok(WriteOutcome::Written(require_etag(res.e_tag)?)),
+            // Both spellings can surface for a failed create-precondition depending on backend.
+            Err(OsError::AlreadyExists { .. }) | Err(OsError::Precondition { .. }) => {
+                Ok(WriteOutcome::PreconditionFailed)
+            }
+            Err(e) => Err(store_error(e)),
+        }
+    }
+
+    async fn put_if_match(&self, path: &str, bytes: Vec<u8>, etag: &str) -> Result<WriteOutcome> {
+        let location = ObjectPath::from(path);
+        let version = UpdateVersion {
+            e_tag: Some(etag.to_string()),
+            version: None,
+        };
+        let opts = PutOptions::from(PutMode::Update(version));
+        match self.inner.put_opts(&location, bytes.into(), opts).await {
+            Ok(res) => Ok(WriteOutcome::Written(require_etag(res.e_tag)?)),
+            Err(OsError::Precondition { .. }) | Err(OsError::NotModified { .. }) => {
+                Ok(WriteOutcome::PreconditionFailed)
+            }
+            // A vanished object also means our version no longer holds.
+            Err(OsError::NotFound { .. }) => Ok(WriteOutcome::PreconditionFailed),
+            Err(e) => Err(store_error(e)),
+        }
+    }
+}


### PR DESCRIPTION
Add the sstdb crate: a single-SST, linearizable, capacity-bounded
key-value database that lives entirely on object storage.  Conditional
PUT is the only synchronization primitive — there is no external
coordination service.

The crate is organized as:
- store: the thin ConditionalStore trait (get/head/put_if_none_match/
  put_if_match), backed by any object_store::ObjectStore (InMemory for
  tests, AmazonS3 behind the s3 feature).
- snapshot: the materialized database, (de)serialized to/from a real
  SST with log metadata stamped as in-keyspace reserved meta keys and
  an incrementally-maintained setsum.
- fragment: immutable, ordered log records encoded as sst logs.
- reader: the 100 ms read-coalescing window mirroring wal3 write
  batching, never holding the lock across an await.
- db: the read/write paths (fragment claim, rollup, install),
  writer-driven roll-forward recovery, and ETag-as-read-version
  optimistic transactions.

Extend sst::log::WriteBatch to support this crate: add new(),
is_empty(), and an iter() returning WriteBatchIterator over the
batch entries.  Factor the shared KeyValueEntry-to-KeyValueRef
conversion out of LogIterator into key_value_ref_from_entry so both
the log iterator and the batch iterator decode entries identically.
Derive Eq/PartialEq on WriteBatch and cover the new iterator with a
unit test.

Register sstdb in the workspace members list.

Co-authored-by: AI
