### PR TITLE
fix(meta): bump each dependent only once per release run

### DIFF
--- a/meta/src/bin/publish.rs
+++ b/meta/src/bin/publish.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeSet, VecDeque};
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -12,7 +13,7 @@ use reqwest::blocking::Client;
 use semver::Version;
 use serde::Deserialize;
 
-use ci::{candidate_order, package};
+use ci::{candidate_order, graph, package};
 
 const PUBLISH_SCRIPT: &str = "publish.sh";
 const USAGE: &str = "usage: publish [--prepare]";
@@ -89,6 +90,11 @@ fn prepare_release() -> Result<(), Box<dyn Error>> {
         .build()?;
     let mut branch_created = false;
     let mut planned_publishes = Vec::new();
+    // Crate names whose package version has already been incremented during this run, either
+    // because they were published directly or because an earlier crate's bump cascaded into them.
+    // Passing this set to update-version keeps a shared dependent from being bumped once per
+    // dependency that happens to bump.
+    let mut already_bumped: BTreeSet<String> = BTreeSet::new();
 
     for member in candidate_order() {
         let package = package(&member);
@@ -129,10 +135,18 @@ fn prepare_release() -> Result<(), Box<dyn Error>> {
                     published_tag_exists,
                     &branch_name,
                     &mut branch_created,
+                    &already_bumped,
                 )?
                 else {
                     continue;
                 };
+                // A rewrite only happens when the version actually changed; when it does, the
+                // cascade also bumped every reverse-dependent, so freeze this crate and its
+                // dependents against any further increments this run.
+                if publish.version != package.version {
+                    already_bumped.insert(publish.crate_name.clone());
+                    already_bumped.extend(reverse_dependency_closure(&package.member));
+                }
                 planned_publishes.push(publish);
             }
         }
@@ -204,6 +218,7 @@ fn has_changed_since_tag(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn prepare_publish(
     crate_name: &str,
     current_version: &Version,
@@ -212,6 +227,7 @@ fn prepare_publish(
     published_tag_exists: bool,
     branch_name: &str,
     branch_created: &mut bool,
+    already_bumped: &BTreeSet<String>,
 ) -> Result<Option<PublishCommand>, Box<dyn Error>> {
     println!();
     println!("publishing candidate: {crate_name} {current_version}");
@@ -272,7 +288,7 @@ fn prepare_publish(
 
     if &new_version != current_version {
         let new_version = new_version.to_string();
-        run(Command::new("cargo").args([
+        let mut args = vec![
             "run",
             "-p",
             "ci",
@@ -282,7 +298,20 @@ fn prepare_publish(
             "bump",
             crate_name,
             &new_version,
-        ]))?;
+        ];
+        // Tell update-version which reverse-dependents already took their one increment so its
+        // cascade does not bump them again.
+        let frozen = already_bumped
+            .iter()
+            .filter(|name| name.as_str() != crate_name)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(",");
+        if !frozen.is_empty() {
+            args.push("--frozen");
+            args.push(&frozen);
+        }
+        run(Command::new("cargo").args(args))?;
     } else {
         println!(
             "using current unpublished version {crate_name} {new_version} without rewriting manifests"
@@ -294,6 +323,32 @@ fn prepare_publish(
         crate_name: crate_name.to_string(),
         version: new_version,
     }))
+}
+
+/// Crate names of every member that transitively depends on `member`.
+///
+/// These are exactly the crates that `update-version bump <member>` cascades an automatic version
+/// increment into, so publish uses this set to freeze them against a second increment.
+fn reverse_dependency_closure(member: &str) -> BTreeSet<String> {
+    let (_members, edges) = graph();
+    reverse_dependent_members(member, &edges)
+        .iter()
+        .map(|dependent| package(dependent).name)
+        .collect()
+}
+
+/// Members reachable from `start` by following dependency -> dependent edges.
+fn reverse_dependent_members(start: &str, edges: &[(String, String)]) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut queue = VecDeque::from([start.to_string()]);
+    while let Some(current) = queue.pop_front() {
+        for (dependency, dependent) in edges {
+            if dependency == &current && dependent != start && seen.insert(dependent.clone()) {
+                queue.push_back(dependent.clone());
+            }
+        }
+    }
+    seen
 }
 
 fn create_branch(branch_name: &str) -> Result<(), Box<dyn Error>> {
@@ -433,10 +488,31 @@ fn run(command: &mut Command) -> Result<(), Box<dyn Error>> {
 mod tests {
     use semver::Version;
 
+    use std::collections::BTreeSet;
+
     use super::{
         Action, Mode, PublishCommand, VersionSelection, classify, current_version_is_publishable,
-        parse_mode, parse_version_selection, render_publish_script,
+        parse_mode, parse_version_selection, render_publish_script, reverse_dependent_members,
     };
+
+    #[test]
+    fn reverse_dependent_members_is_transitive_and_excludes_start() {
+        // a <- b <- c and a <- d (edges point dependency -> dependent).
+        let edges = vec![
+            ("a".to_string(), "b".to_string()),
+            ("b".to_string(), "c".to_string()),
+            ("a".to_string(), "d".to_string()),
+        ];
+        assert_eq!(
+            reverse_dependent_members("a", &edges),
+            BTreeSet::from(["b".to_string(), "c".to_string(), "d".to_string()])
+        );
+        assert_eq!(
+            reverse_dependent_members("b", &edges),
+            BTreeSet::from(["c".to_string()])
+        );
+        assert_eq!(reverse_dependent_members("c", &edges), BTreeSet::new());
+    }
 
     #[test]
     fn defaults_to_print_packages_mode() {

--- a/meta/src/bin/update-version.rs
+++ b/meta/src/bin/update-version.rs
@@ -9,8 +9,7 @@ use std::process::{Command, Stdio};
 use semver::Version;
 use toml::{Table, Value};
 
-const USAGE: &str =
-    "usage: update-version (bump <crate> <new-version>|plan <crate> <new-version>|normalize)";
+const USAGE: &str = "usage: update-version (bump <crate> <new-version> [--frozen <crate,...>]|plan <crate> <new-version>|normalize)";
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
@@ -19,6 +18,9 @@ enum Mode {
     Bump {
         crate_name: String,
         new_version: Version,
+        /// Reverse-dependents that were already bumped earlier this release run and
+        /// must not have their versions incremented a second time by this cascade.
+        frozen: BTreeSet<String>,
     },
     Plan {
         crate_name: String,
@@ -63,9 +65,10 @@ fn main() -> Result<()> {
         Mode::Bump {
             crate_name,
             new_version,
+            frozen,
         } => {
             let workspace = read_workspace()?;
-            let changes = planned_bumps(&workspace, &crate_name, &new_version)?;
+            let changes = planned_bumps(&workspace, &crate_name, &new_version, &frozen)?;
             let report = apply_manifest_changes(&workspace, &changes, true)?;
             print_apply_report(&report);
             run_cargo_check()
@@ -75,7 +78,7 @@ fn main() -> Result<()> {
             new_version,
         } => {
             let workspace = read_workspace()?;
-            let changes = planned_bumps(&workspace, &crate_name, &new_version)?;
+            let changes = planned_bumps(&workspace, &crate_name, &new_version, &BTreeSet::new())?;
             let normalizations = planned_normalizations(&workspace)?;
             print_plan(&workspace, &changes, &normalizations);
             Ok(())
@@ -102,7 +105,15 @@ where
         [mode, crate_name, version] if mode == "bump" => Ok(Mode::Bump {
             crate_name: crate_name.to_string(),
             new_version: version.parse()?,
+            frozen: BTreeSet::new(),
         }),
+        [mode, crate_name, version, flag, list] if mode == "bump" && flag == "--frozen" => {
+            Ok(Mode::Bump {
+                crate_name: crate_name.to_string(),
+                new_version: version.parse()?,
+                frozen: parse_frozen(list),
+            })
+        }
         [mode, crate_name, version] if mode == "plan" => Ok(Mode::Plan {
             crate_name: crate_name.to_string(),
             new_version: version.parse()?,
@@ -110,6 +121,14 @@ where
         [mode] if mode == "normalize" => Ok(Mode::Normalize),
         _ => Err(io::Error::new(io::ErrorKind::InvalidInput, USAGE).into()),
     }
+}
+
+fn parse_frozen(list: &str) -> BTreeSet<String> {
+    list.split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 fn read_workspace() -> Result<Workspace> {
@@ -230,6 +249,7 @@ fn planned_bumps(
     workspace: &Workspace,
     crate_name: &str,
     new_version: &Version,
+    frozen: &BTreeSet<String>,
 ) -> Result<BTreeMap<String, VersionChange>> {
     let package = resolve_package(workspace, crate_name)?;
     if new_version <= &package.version {
@@ -249,6 +269,13 @@ fn planned_bumps(
         },
     );
     for dependent in reverse_dependency_closure(&package.name, &workspace.reverse_dependencies) {
+        // A dependent that was already bumped earlier in this release run keeps the version it
+        // was given then; re-incrementing it would bump the same record once per dependency that
+        // happened to bump.  Its dependency reference still tracks the freshly bumped crate via
+        // the workspace.dependencies entry, so skipping the version increment is safe.
+        if frozen.contains(&dependent) {
+            continue;
+        }
         let package = workspace
             .packages
             .get(&dependent)
@@ -734,7 +761,16 @@ mod tests {
             parse_mode(["bump", "handled", "0.8.0"]).unwrap(),
             Mode::Bump {
                 crate_name: "handled".to_string(),
-                new_version: version("0.8.0")
+                new_version: version("0.8.0"),
+                frozen: BTreeSet::new(),
+            }
+        );
+        assert_eq!(
+            parse_mode(["bump", "handled", "0.8.0", "--frozen", "lsmtk,sst"]).unwrap(),
+            Mode::Bump {
+                crate_name: "handled".to_string(),
+                new_version: version("0.8.0"),
+                frozen: BTreeSet::from(["lsmtk".to_string(), "sst".to_string()]),
             }
         );
         assert_eq!(
@@ -846,7 +882,7 @@ sync42 = "0.16"
             ]),
         };
         assert_eq!(
-            planned_bumps(&workspace, "a", &version("0.3.0")).unwrap(),
+            planned_bumps(&workspace, "a", &version("0.3.0"), &BTreeSet::new()).unwrap(),
             BTreeMap::from([
                 (
                     "a".to_string(),
@@ -870,6 +906,25 @@ sync42 = "0.16"
                     }
                 ),
             ])
+        );
+
+        // Freezing an already-bumped dependent keeps it out of the cascade so it is not
+        // incremented a second time, while the explicitly named crate is still bumped.
+        assert_eq!(
+            planned_bumps(
+                &workspace,
+                "a",
+                &version("0.3.0"),
+                &BTreeSet::from(["b".to_string(), "c".to_string()])
+            )
+            .unwrap(),
+            BTreeMap::from([(
+                "a".to_string(),
+                VersionChange {
+                    old: version("0.1.0"),
+                    new: version("0.3.0")
+                }
+            ),])
         );
     }
 


### PR DESCRIPTION
During a release, publish walks candidates in order and calls
update-version bump for each one that changed.  Each bump cascades an
increment into every reverse-dependent.  A crate that is a dependent of
several bumped candidates was therefore incremented once per bumping
dependency, bumping the same package's version multiple times in a
single run.

Track already-bumped crates in publish and pass them to
update-version via a new --frozen flag.  When a bump cascades, the named
crate and its reverse-dependency closure are frozen so later bumps skip
re-incrementing them.  Their dependency references still track the
freshly bumped crate through the workspace.dependencies entry, so
skipping the version increment is safe.

Add unit tests covering the transitive reverse-dependent closure,
--frozen parsing, and that frozen dependents are excluded from the
cascade.

Co-authored-by: AI
