### PR TITLE
feat(provsum): Add fixed-size provenance digest crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "protoql",
     "prototk",
     "prototk_derive",
+    "provsum",
     "rc_conf",
     "rc_conf/demo_crate",
     "rpc_pb",

--- a/macarunes/src/lib.rs
+++ b/macarunes/src/lib.rs
@@ -637,7 +637,7 @@ impl Secret {
         }
 
         let mut bytes = [0u8; SIGNATURE_BYTES];
-        for (index, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in hex.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let high = hex_value(pair[0]).ok_or_else(|| Error::InvalidHex {
                 what: format!("invalid character at byte {}", index * 2),
             })?;

--- a/provsum/Cargo.toml
+++ b/provsum/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "provsum"
+version = "0.1.0"
+authors = ["Robert Escriva <robert@rescrv.net>"]
+edition = { workspace = true }
+description = "Fixed-size provenance digests for computation equivalence"
+license = "Apache-2.0"
+repository = "https://github.com/rescrv/blue"
+
+[dependencies]

--- a/provsum/Cargo.toml
+++ b/provsum/Cargo.toml
@@ -10,9 +10,11 @@ repository = "https://github.com/rescrv/blue"
 [features]
 default = ["binaries"]
 
+binaries = []
+
 [dependencies]
 
-[examples]
+[[example]]
 name = "vectors"
 path = "examples/vectors.rs"
 required-features=["binaries"]

--- a/provsum/Cargo.toml
+++ b/provsum/Cargo.toml
@@ -7,4 +7,12 @@ description = "Fixed-size provenance digests for computation equivalence"
 license = "Apache-2.0"
 repository = "https://github.com/rescrv/blue"
 
+[features]
+default = ["binaries"]
+
 [dependencies]
+
+[examples]
+name = "vectors"
+path = "examples/vectors.rs"
+required-features=["binaries"]

--- a/provsum/README.md
+++ b/provsum/README.md
@@ -10,6 +10,14 @@ carried verbatim across both implementations. Each GUID is hashed to a nonzero
 point in F_p (p = 2^61−1) per lane (two lanes). The digest of an error is its
 N[X] provenance polynomial evaluated at those points:
 
+`Site` is the GUID's 16 bytes in canonical order, not a native-endian integer.
+Point derivation reads its two consecutive 8-byte chunks as little-endian, and
+digest serialization is little-endian too, so neither operation depends on the
+host architecture. A byte-array literal therefore produces the same result on
+every supported platform. When starting from textual UUID syntax, use the
+parser's canonical/RFC byte sequence in every language; in particular, do not
+mix a Windows GUID's field-wise little-endian representation with RFC bytes.
+
 | operation                      | polynomial                 | digest      |
 |--------------------------------|----------------------------|-------------|
 | `Digest::origin(site)`         | `x_site`                   | `r_site`    |

--- a/provsum/README.md
+++ b/provsum/README.md
@@ -1,0 +1,80 @@
+# provsum
+
+Fixed-size digests of error provenance, for checking that a Rust port raises
+the *same errors for the same reasons* as the code it replaces.
+
+## Construction
+
+Every error-origin, wrap, and pick site in the source gets a 16-byte GUID,
+carried verbatim across both implementations. Each GUID is hashed to a nonzero
+point in F_p (p = 2^61−1) per lane (two lanes). The digest of an error is its
+N[X] provenance polynomial evaluated at those points:
+
+| operation                      | polynomial                 | digest      |
+|--------------------------------|----------------------------|-------------|
+| `Digest::origin(site)`         | `x_site`                   | `r_site`    |
+| `d.wrap(site)`                 | `x_site · d`               | `r_site · d`|
+| `a.merge(b)`                   | `a + b`                    | `a + b`     |
+| `Digest::pick(site, [d0,d1..])`| `Σ x_{site,i} · d_i`       | `Σ r_{site,i} · d_i` |
+
+`pick` records an ordered choice: slot 0 is the error that was returned, later
+slots were considered and discarded. Order enters the commutative semiring
+through per-slot variables, not through the operators, so swapping which error
+wins changes the polynomial. Plain `wrap` order is *not* recorded (`x·y = y·x`);
+that is intentional — a port that restructures control flow but preserves
+which sites contribute and how deeply should digest identically.
+
+Digests are 18 bytes: two 8-byte lanes plus a 2-byte depth bound. Equality
+compares lanes only. Two digests of distinct polynomials of depth ≤ d collide
+with probability ≤ (d/(p−1))² ≈ 2^(2·log2 d − 122). This is a non-adversarial
+construction: it assumes nobody is choosing GUIDs or points to force a
+collision. `Digest::log2_collision_bound()` reports the bound for a given depth.
+
+## Diagnostics
+
+`provsum::poly::Poly` is the expanded polynomial with the same API.
+`Poly::digest()` evaluates it at the same points, so `poly.digest() ==
+streaming_digest` is a testable invariant, and `Poly::diff` names the monomials
+that differ between two implementations. Keep it behind a debug flag; its size
+is the number of distinct derivations, which is fine at a few thousand sites
+and shallow depth and unbounded in general.
+
+## Cross-language
+
+`python/provsum.py` is a reference implementation. `cargo run --example
+vectors` and `python3 python/provsum.py` must print identical output;
+`tests/vectors.rs` pins those values. Point derivation is a splitmix64 finalizer
+over `(seed, lane, slot)` then the two GUID halves, rejection-sampled to be
+nonzero mod p — deliberately dependency-free so it is trivial to mirror.
+
+## Usage sketch
+
+```rust
+use provsum::{Digest, Site};
+
+const PARSE: Site = Site(*b"\x01\x02..............");   // real GUIDs in practice
+const READ:  Site = Site(*b"\x03\x04..............");
+const RETRY: Site = Site(*b"\x05\x06..............");
+
+struct Error { msg: String, prov: Digest }
+
+fn read(path: &str) -> Result<Vec<u8>, Error> {
+    std::fs::read(path).map_err(|e| Error { msg: e.to_string(), prov: Digest::origin(&READ) })
+}
+
+fn parse(path: &str) -> Result<Config, Error> {
+    let bytes = read(path).map_err(|e| Error { prov: e.prov.wrap(&PARSE), ..e })?;
+    // ...
+}
+
+fn with_fallback(primary: &str, fallback: &str) -> Result<Config, Error> {
+    match (parse(primary), parse(fallback)) {
+        (Ok(c), _) | (_, Ok(c)) => Ok(c),
+        (Err(a), Err(b)) => Err(Error { prov: Digest::pick2(&RETRY, &a.prov, &b.prov), ..a }),
+    }
+}
+```
+
+The Python side does the same with `Digest.origin(READ).wrap(PARSE)` etc.;
+the differential harness runs both on the same inputs and compares
+`prov.to_bytes()`.

--- a/provsum/examples/vectors.rs
+++ b/provsum/examples/vectors.rs
@@ -9,13 +9,21 @@ fn main() {
         ("origin_a", Digest::origin(&a)),
         ("wrap", Digest::origin(&a).wrap(&w1)),
         ("merge", Digest::origin(&a).merge(&Digest::origin(&b))),
-        ("pick_ab", Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b))),
-        ("pick_ba", Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a))),
+        (
+            "pick_ab",
+            Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b)),
+        ),
+        (
+            "pick_ba",
+            Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a)),
+        ),
         (
             "nested",
             Digest::pick2(
                 &ch,
-                &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
+                &Digest::origin(&a)
+                    .wrap(&w1)
+                    .merge(&Digest::origin(&b).wrap(&w1)),
                 &Digest::origin(&c).wrap(&w2),
             )
             .wrap(&w2),

--- a/provsum/examples/vectors.rs
+++ b/provsum/examples/vectors.rs
@@ -5,7 +5,12 @@ fn main() {
     let s = Site::from_label;
     let (a, b, c) = (s("a"), s("b"), s("c"));
     let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
+    let raw = Site([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f,
+    ]);
     let vectors = [
+        ("origin_raw_bytes", Digest::origin(&raw)),
         ("origin_a", Digest::origin(&a)),
         ("wrap", Digest::origin(&a).wrap(&w1)),
         ("merge", Digest::origin(&a).merge(&Digest::origin(&b))),

--- a/provsum/examples/vectors.rs
+++ b/provsum/examples/vectors.rs
@@ -1,0 +1,27 @@
+//! Prints test vectors; `python3 python/provsum.py` must print identical lines.
+use provsum::{Digest, Site};
+
+fn main() {
+    let s = Site::from_label;
+    let (a, b, c) = (s("a"), s("b"), s("c"));
+    let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
+    let vectors = [
+        ("origin_a", Digest::origin(&a)),
+        ("wrap", Digest::origin(&a).wrap(&w1)),
+        ("merge", Digest::origin(&a).merge(&Digest::origin(&b))),
+        ("pick_ab", Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b))),
+        ("pick_ba", Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a))),
+        (
+            "nested",
+            Digest::pick2(
+                &ch,
+                &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
+                &Digest::origin(&c).wrap(&w2),
+            )
+            .wrap(&w2),
+        ),
+    ];
+    for (k, v) in vectors {
+        println!("{k} {} {}", v.to_hex(), v.depth());
+    }
+}

--- a/provsum/python/provsum.py
+++ b/provsum/python/provsum.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     a, b, c = (site_from_label(x) for x in ("a", "b", "c"))
     w1, w2, ch = (site_from_label(x) for x in ("w1", "w2", "choose"))
     vectors = {
+        "origin_raw_bytes": Digest.origin(bytes(range(16))),
         "origin_a": Digest.origin(a),
         "wrap": Digest.origin(a).wrap(w1),
         "merge": Digest.origin(a).merge(Digest.origin(b)),

--- a/provsum/python/provsum.py
+++ b/provsum/python/provsum.py
@@ -1,0 +1,133 @@
+"""Reference implementation of provsum, byte-compatible with the Rust crate.
+
+Digest = N[X] provenance polynomial evaluated at pinned points in F_p,
+p = 2^61 - 1, two lanes.  See src/lib.rs for the construction.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+LANES = 2
+P = (1 << 61) - 1
+MASK64 = (1 << 64) - 1
+NO_SLOT = 0xFFFFFFFF
+SEED = 0x70726F767375_6D31  # "provsum1"
+DIGEST_BYTES = LANES * 8 + 2
+
+
+def mix(z: int) -> int:
+    z = (z + 0x9E3779B97F4A7C15) & MASK64
+    z = ((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9) & MASK64
+    z = ((z ^ (z >> 27)) * 0x94D049BB133111EB) & MASK64
+    return z ^ (z >> 31)
+
+
+def site_from_label(label: str) -> bytes:
+    """Test/example convenience only; assign real GUIDs in production."""
+    s = mix(0x6C6162656C5F7369)
+    data = label.encode()
+    for i in range(0, max(len(data), 1), 8):
+        chunk = data[i:i + 8]
+        if not chunk and i > 0:
+            break
+        w = int.from_bytes(chunk.ljust(8, b"\0"), "little")
+        s = mix(s ^ w ^ (i // 8))
+    return s.to_bytes(8, "little") + mix(s).to_bytes(8, "little")
+
+
+def point(site: bytes, slot: int, lane: int) -> int:
+    assert len(site) == 16
+    s = mix(SEED ^ (lane << 32) ^ slot)
+    for i in (0, 8):
+        s = mix(s ^ int.from_bytes(site[i:i + 8], "little"))
+    while True:
+        r = s % P
+        if r != 0:
+            return r
+        s = mix(s)
+
+
+@dataclass(frozen=True)
+class Digest:
+    lanes: tuple[int, ...]
+    depth: int = 0
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Digest) and self.lanes == other.lanes
+
+    def __hash__(self) -> int:
+        return hash(self.lanes)
+
+    @staticmethod
+    def zero() -> "Digest":
+        return Digest((0,) * LANES, 0)
+
+    @staticmethod
+    def _points(site: bytes, slot: int) -> tuple[int, ...]:
+        return tuple(point(site, slot, lane) for lane in range(LANES))
+
+    @staticmethod
+    def origin(site: bytes) -> "Digest":
+        return Digest(Digest._points(site, NO_SLOT), 1)
+
+    def wrap(self, site: bytes) -> "Digest":
+        r = Digest._points(site, NO_SLOT)
+        return Digest(
+            tuple((r[i] * self.lanes[i]) % P for i in range(LANES)),
+            min(self.depth + 1, 0xFFFF),
+        )
+
+    def merge(self, other: "Digest") -> "Digest":
+        return Digest(
+            tuple((self.lanes[i] + other.lanes[i]) % P for i in range(LANES)),
+            max(self.depth, other.depth),
+        )
+
+    @staticmethod
+    def pick(site: bytes, ranked: list["Digest"]) -> "Digest":
+        acc = Digest.zero()
+        for slot, d in enumerate(ranked):
+            r = Digest._points(site, slot)
+            term = Digest(
+                tuple((r[i] * d.lanes[i]) % P for i in range(LANES)),
+                min(d.depth + 1, 0xFFFF),
+            )
+            acc = acc.merge(term)
+        return acc
+
+    @staticmethod
+    def pick2(site: bytes, returned: "Digest", discarded: "Digest") -> "Digest":
+        return Digest.pick(site, [returned, discarded])
+
+    def to_bytes(self) -> bytes:
+        return b"".join(l.to_bytes(8, "little") for l in self.lanes) + self.depth.to_bytes(2, "little")
+
+    @staticmethod
+    def from_bytes(b: bytes) -> "Digest":
+        assert len(b) == DIGEST_BYTES
+        lanes = tuple(int.from_bytes(b[i * 8:i * 8 + 8], "little") for i in range(LANES))
+        assert all(l < P for l in lanes)
+        return Digest(lanes, int.from_bytes(b[LANES * 8:], "little"))
+
+    def to_hex(self) -> str:
+        return "".join(f"{l:016x}" for l in self.lanes)
+
+
+if __name__ == "__main__":
+    # Emit the same vectors as examples/vectors.rs for cross-checking.
+    a, b, c = (site_from_label(x) for x in ("a", "b", "c"))
+    w1, w2, ch = (site_from_label(x) for x in ("w1", "w2", "choose"))
+    vectors = {
+        "origin_a": Digest.origin(a),
+        "wrap": Digest.origin(a).wrap(w1),
+        "merge": Digest.origin(a).merge(Digest.origin(b)),
+        "pick_ab": Digest.pick2(ch, Digest.origin(a), Digest.origin(b)),
+        "pick_ba": Digest.pick2(ch, Digest.origin(b), Digest.origin(a)),
+        "nested": Digest.pick2(
+            ch,
+            Digest.origin(a).wrap(w1).merge(Digest.origin(b).wrap(w1)),
+            Digest.origin(c).wrap(w2),
+        ).wrap(w2),
+    }
+    for k, v in vectors.items():
+        print(f"{k} {v.to_hex()} {v.depth}")

--- a/provsum/src/lib.rs
+++ b/provsum/src/lib.rs
@@ -40,7 +40,9 @@ pub const P: u64 = (1u64 << 61) - 1;
 pub const DIGEST_BYTES: usize = LANES * 8 + 2;
 
 /// A 16-byte site identifier.  Assign one per error-origin / wrap / pick site
-/// in the source, and carry the same value across implementations.
+/// in the source, and carry the same bytes in the same order across
+/// implementations.  Point derivation interprets each consecutive 8-byte
+/// chunk as little-endian; it never uses the host's native byte order.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Site(pub [u8; 16]);
 

--- a/provsum/src/lib.rs
+++ b/provsum/src/lib.rs
@@ -72,22 +72,14 @@ pub(crate) fn reduce128(x: u128) -> u64 {
     let hi = (x >> 61) as u64; // < 2^61
     let s = lo + hi; // < 2^62
     let s = (s & P) + (s >> 61);
-    if s >= P {
-        s - P
-    } else {
-        s
-    }
+    if s >= P { s - P } else { s }
 }
 
 #[inline]
 pub(crate) fn fadd(a: u64, b: u64) -> u64 {
     let s = a + b; // < 2^62
     let s = (s & P) + (s >> 61);
-    if s >= P {
-        s - P
-    } else {
-        s
-    }
+    if s >= P { s - P } else { s }
 }
 
 #[inline]
@@ -204,8 +196,8 @@ impl Digest {
     #[must_use]
     pub fn merge(&self, other: &Digest) -> Digest {
         let mut lanes = [0u64; LANES];
-        for i in 0..LANES {
-            lanes[i] = fadd(self.lanes[i], other.lanes[i]);
+        for (i, lane) in lanes.iter_mut().enumerate() {
+            *lane = fadd(self.lanes[i], other.lanes[i]);
         }
         Digest {
             lanes,

--- a/provsum/src/lib.rs
+++ b/provsum/src/lib.rs
@@ -1,0 +1,385 @@
+//! # provsum
+//!
+//! Fixed-size digests of provenance polynomials.
+//!
+//! Every error-origin site in a codebase gets a 16-byte GUID.  Each GUID is
+//! hashed to a nonzero point in `F_p` (one per lane, `p = 2^61 - 1`).  The
+//! digest of an error is its `N[X]` provenance polynomial evaluated at those
+//! points:
+//!
+//! * `origin(site)`             → `r_site`
+//! * `wrap(site, d)`            → `r_site · d`
+//! * `merge(a, b)`              → `a + b`
+//! * `pick(site, [d_0, d_1,…])` → `Σ r_{site,slot_i} · d_i`
+//!
+//! `pick` is how order enters a commutative semiring: the site contributes a
+//! distinct variable per *slot*, so returning `a` and discarding `b` yields a
+//! different polynomial from the reverse.  Slot 0 is the returned error.
+//!
+//! Two digests are equal iff the two polynomials are equal, except with
+//! probability at most `(d/(p-1))^LANES` where `d` is the max wrap depth
+//! (Schwartz–Zippel, lanes independent).  The construction is not designed
+//! against an adversary who controls GUIDs or points; it is meant for
+//! comparing two implementations of the same code.
+//!
+//! The point derivation is pinned (splitmix64 finalizer over the GUID bytes)
+//! so that a second implementation (see `python/provsum.py`) reproduces the
+//! same digests byte-for-byte.
+
+#![forbid(unsafe_code)]
+
+pub mod poly;
+
+/// Number of independent lanes.  Each lane is an independent evaluation point.
+pub const LANES: usize = 2;
+
+/// The Mersenne prime 2^61 - 1.
+pub const P: u64 = (1u64 << 61) - 1;
+
+/// Serialized digest size in bytes: `LANES * 8` for the lanes, plus 2 for depth.
+pub const DIGEST_BYTES: usize = LANES * 8 + 2;
+
+/// A 16-byte site identifier.  Assign one per error-origin / wrap / pick site
+/// in the source, and carry the same value across implementations.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Site(pub [u8; 16]);
+
+impl Site {
+    /// Convenience for tests and examples: a site from a short label.  Do not
+    /// use in production—assign real GUIDs so sites survive renames.
+    pub fn from_label(label: &str) -> Site {
+        let mut b = [0u8; 16];
+        let mut s = mix(0x6c61_6265_6c5f_7369 /* "label_si" */);
+        for (i, chunk) in label.as_bytes().chunks(8).enumerate() {
+            let mut w = [0u8; 8];
+            w[..chunk.len()].copy_from_slice(chunk);
+            s = mix(s ^ u64::from_le_bytes(w) ^ (i as u64));
+        }
+        b[..8].copy_from_slice(&s.to_le_bytes());
+        b[8..].copy_from_slice(&mix(s).to_le_bytes());
+        Site(b)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field arithmetic over F_p, p = 2^61 - 1.
+// ---------------------------------------------------------------------------
+
+#[inline]
+pub(crate) fn reduce128(x: u128) -> u64 {
+    // x < 2^122.  Split at 61 bits twice.
+    let lo = (x as u64) & P;
+    let hi = (x >> 61) as u64; // < 2^61
+    let s = lo + hi; // < 2^62
+    let s = (s & P) + (s >> 61);
+    if s >= P {
+        s - P
+    } else {
+        s
+    }
+}
+
+#[inline]
+pub(crate) fn fadd(a: u64, b: u64) -> u64 {
+    let s = a + b; // < 2^62
+    let s = (s & P) + (s >> 61);
+    if s >= P {
+        s - P
+    } else {
+        s
+    }
+}
+
+#[inline]
+pub(crate) fn fmul(a: u64, b: u64) -> u64 {
+    reduce128((a as u128) * (b as u128))
+}
+
+// ---------------------------------------------------------------------------
+// Point derivation.  Pinned; mirrored in python/provsum.py.
+// ---------------------------------------------------------------------------
+
+/// splitmix64 finalizer.
+#[inline]
+pub(crate) fn mix(mut z: u64) -> u64 {
+    z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+const SEED: u64 = 0x7072_6f76_7375_6d31; // "provsum1"
+
+/// Slot value used by `origin`/`wrap` (no positional slot).
+pub const NO_SLOT: u32 = u32::MAX;
+
+/// Derive the evaluation point for `(site, slot, lane)`.  `pick` uses slots
+/// `0..n`; `origin`/`wrap` use `NO_SLOT`.
+pub fn point(site: &Site, slot: u32, lane: u32) -> u64 {
+    let mut s = mix(SEED ^ ((lane as u64) << 32) ^ (slot as u64));
+    for chunk in site.0.chunks(8) {
+        let mut w = [0u8; 8];
+        w.copy_from_slice(chunk);
+        s = mix(s ^ u64::from_le_bytes(w));
+    }
+    loop {
+        let r = s % P;
+        if r != 0 {
+            return r;
+        }
+        s = mix(s);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Digest.
+// ---------------------------------------------------------------------------
+
+/// A provenance digest: the polynomial's value in each lane, plus an upper
+/// bound on its total degree (used only for the collision bound; equality
+/// compares lanes only).
+#[derive(Clone, Copy, Debug)]
+pub struct Digest {
+    lanes: [u64; LANES],
+    depth: u16,
+}
+
+impl PartialEq for Digest {
+    fn eq(&self, other: &Self) -> bool {
+        self.lanes == other.lanes
+    }
+}
+impl Eq for Digest {}
+
+impl core::hash::Hash for Digest {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.lanes.hash(state)
+    }
+}
+
+impl Digest {
+    /// The zero polynomial: identity for `merge`, annihilator for `wrap`.
+    pub const ZERO: Digest = Digest {
+        lanes: [0; LANES],
+        depth: 0,
+    };
+
+    /// The constant polynomial 1: identity for `wrap`.  Rarely needed.
+    pub const ONE: Digest = Digest {
+        lanes: [1; LANES],
+        depth: 0,
+    };
+
+    fn points(site: &Site, slot: u32) -> [u64; LANES] {
+        let mut r = [0u64; LANES];
+        for (lane, out) in r.iter_mut().enumerate() {
+            *out = point(site, slot, lane as u32);
+        }
+        r
+    }
+
+    /// An error originating at `site`.  Polynomial: `x_site`.
+    pub fn origin(site: &Site) -> Digest {
+        Digest {
+            lanes: Self::points(site, NO_SLOT),
+            depth: 1,
+        }
+    }
+
+    /// Wrap `self` at `site`.  Polynomial: `x_site · self`.
+    #[must_use]
+    pub fn wrap(&self, site: &Site) -> Digest {
+        let r = Self::points(site, NO_SLOT);
+        let mut lanes = [0u64; LANES];
+        for i in 0..LANES {
+            lanes[i] = fmul(r[i], self.lanes[i]);
+        }
+        Digest {
+            lanes,
+            depth: self.depth.saturating_add(1),
+        }
+    }
+
+    /// Alternative derivations.  Polynomial: `self + other`.  Commutative.
+    #[must_use]
+    pub fn merge(&self, other: &Digest) -> Digest {
+        let mut lanes = [0u64; LANES];
+        for i in 0..LANES {
+            lanes[i] = fadd(self.lanes[i], other.lanes[i]);
+        }
+        Digest {
+            lanes,
+            depth: self.depth.max(other.depth),
+        }
+    }
+
+    /// Ordered choice at `site`.  `ranked[0]` is the error that was returned;
+    /// the rest were considered and discarded, in priority order.
+    /// Polynomial: `Σ_i x_{site,i} · ranked[i]`.  Not commutative in `ranked`.
+    pub fn pick(site: &Site, ranked: &[Digest]) -> Digest {
+        let mut acc = Digest::ZERO;
+        for (slot, d) in ranked.iter().enumerate() {
+            let r = Self::points(site, slot as u32);
+            let mut lanes = [0u64; LANES];
+            for i in 0..LANES {
+                lanes[i] = fmul(r[i], d.lanes[i]);
+            }
+            let term = Digest {
+                lanes,
+                depth: d.depth.saturating_add(1),
+            };
+            acc = acc.merge(&term);
+        }
+        acc
+    }
+
+    /// Binary convenience for `pick`.
+    pub fn pick2(site: &Site, returned: &Digest, discarded: &Digest) -> Digest {
+        Self::pick(site, &[*returned, *discarded])
+    }
+
+    /// Upper bound on the total degree of the polynomial this digest evaluates.
+    pub fn depth(&self) -> u16 {
+        self.depth
+    }
+
+    /// Raw lane values.
+    pub fn lanes(&self) -> [u64; LANES] {
+        self.lanes
+    }
+
+    /// `log2` of the Schwartz–Zippel false-equality bound for comparing this
+    /// digest against another of at most the same depth: `LANES · log2(d/(p-1))`.
+    pub fn log2_collision_bound(&self) -> f64 {
+        let d = self.depth.max(1) as f64;
+        (LANES as f64) * (d.log2() - ((P - 1) as f64).log2())
+    }
+
+    pub fn to_bytes(&self) -> [u8; DIGEST_BYTES] {
+        let mut b = [0u8; DIGEST_BYTES];
+        for (i, l) in self.lanes.iter().enumerate() {
+            b[i * 8..i * 8 + 8].copy_from_slice(&l.to_le_bytes());
+        }
+        b[LANES * 8..].copy_from_slice(&self.depth.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8; DIGEST_BYTES]) -> Option<Digest> {
+        let mut lanes = [0u64; LANES];
+        for (i, l) in lanes.iter_mut().enumerate() {
+            let mut w = [0u8; 8];
+            w.copy_from_slice(&b[i * 8..i * 8 + 8]);
+            *l = u64::from_le_bytes(w);
+            if *l >= P {
+                return None;
+            }
+        }
+        let depth = u16::from_le_bytes([b[LANES * 8], b[LANES * 8 + 1]]);
+        Some(Digest { lanes, depth })
+    }
+
+    /// Hex of the lanes only (what equality compares).
+    pub fn to_hex(&self) -> String {
+        let mut s = String::with_capacity(LANES * 16);
+        for l in self.lanes {
+            s.push_str(&format!("{:016x}", l));
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(l: &str) -> Site {
+        Site::from_label(l)
+    }
+
+    #[test]
+    fn field_laws() {
+        let a = point(&s("a"), NO_SLOT, 0);
+        let b = point(&s("b"), NO_SLOT, 0);
+        let c = point(&s("c"), NO_SLOT, 0);
+        assert_eq!(fmul(a, fmul(b, c)), fmul(fmul(a, b), c));
+        assert_eq!(fmul(a, fadd(b, c)), fadd(fmul(a, b), fmul(a, c)));
+        assert_eq!(fadd(a, P - a), 0);
+        assert_eq!(fmul(P - 1, P - 1), 1);
+    }
+
+    #[test]
+    fn points_nonzero_and_distinct_per_lane_and_slot() {
+        let site = s("x");
+        let p0 = point(&site, NO_SLOT, 0);
+        let p1 = point(&site, NO_SLOT, 1);
+        let q0 = point(&site, 0, 0);
+        let q1 = point(&site, 1, 0);
+        assert!(p0 != 0 && p1 != 0 && q0 != 0 && q1 != 0);
+        assert_ne!(p0, p1);
+        assert_ne!(q0, q1);
+        assert_ne!(p0, q0);
+    }
+
+    #[test]
+    fn semiring_laws_on_digests() {
+        let a = Digest::origin(&s("a"));
+        let b = Digest::origin(&s("b"));
+        let w = s("w");
+        // distributivity: w·(a+b) == w·a + w·b
+        assert_eq!(a.merge(&b).wrap(&w), a.wrap(&w).merge(&b.wrap(&w)));
+        // commutativity of merge
+        assert_eq!(a.merge(&b), b.merge(&a));
+        // wrap order is invisible (commutative multiplication) — by design
+        assert_eq!(a.wrap(&s("p")).wrap(&s("q")), a.wrap(&s("q")).wrap(&s("p")));
+        // identities
+        assert_eq!(a.merge(&Digest::ZERO), a);
+        assert_eq!(Digest::ZERO.wrap(&w), Digest::ZERO);
+    }
+
+    #[test]
+    fn pick_is_order_sensitive() {
+        let a = Digest::origin(&s("a"));
+        let b = Digest::origin(&s("b"));
+        let site = s("choose");
+        let ab = Digest::pick2(&site, &a, &b);
+        let ba = Digest::pick2(&site, &b, &a);
+        assert_ne!(ab, ba);
+        // and still distinguishes from a plain merge at that site
+        assert_ne!(ab, a.merge(&b).wrap(&site));
+        // n-ary: permutation matters
+        let c = Digest::origin(&s("c"));
+        assert_ne!(
+            Digest::pick(&site, &[a, b, c]),
+            Digest::pick(&site, &[a, c, b])
+        );
+    }
+
+    #[test]
+    fn missing_wrap_is_detected() {
+        let a = Digest::origin(&s("a"));
+        let full = a.wrap(&s("io")).wrap(&s("handler"));
+        let short = a.wrap(&s("handler"));
+        assert_ne!(full, short);
+        assert_ne!(full, full.wrap(&s("io"))); // double wrap
+    }
+
+    #[test]
+    fn bytes_roundtrip() {
+        let d = Digest::origin(&s("a")).wrap(&s("b"));
+        let b = d.to_bytes();
+        let back = Digest::from_bytes(&b).unwrap();
+        assert_eq!(d, back);
+        assert_eq!(d.depth(), back.depth());
+    }
+
+    #[test]
+    fn depth_bound() {
+        let mut d = Digest::origin(&s("a"));
+        for i in 0..9 {
+            d = d.wrap(&s(&format!("w{i}")));
+        }
+        assert_eq!(d.depth(), 10);
+        // two lanes at depth 10: about 2 * (log2 10 - 61) ≈ -115
+        assert!(d.log2_collision_bound() < -114.0);
+    }
+}

--- a/provsum/src/poly.rs
+++ b/provsum/src/poly.rs
@@ -8,7 +8,7 @@
 //! `poly.digest() == streaming_digest` is a checkable invariant, and
 //! `Poly::diff` localizes divergence between two implementations.
 
-use crate::{fadd, fmul, point, Digest, Site, LANES, NO_SLOT};
+use crate::{Digest, LANES, NO_SLOT, Site, fadd, fmul, point};
 use std::collections::BTreeMap;
 
 /// A variable: a site, optionally with a positional slot.
@@ -99,7 +99,7 @@ impl Poly {
         let mut lanes = [0u64; LANES];
         for (m, c) in &self.0 {
             let c = c % crate::P;
-            for lane in 0..LANES {
+            for (lane, lane_acc) in lanes.iter_mut().enumerate() {
                 let mut term = c;
                 for (v, e) in m {
                     let r = point(&v.site, v.slot, lane as u32);
@@ -107,7 +107,7 @@ impl Poly {
                         term = fmul(term, r);
                     }
                 }
-                lanes[lane] = fadd(lanes[lane], term);
+                *lane_acc = fadd(*lane_acc, term);
             }
         }
         // Reconstruct through the public API so `depth` is populated
@@ -152,14 +152,18 @@ mod tests {
 
         let d = Digest::pick2(
             &ch,
-            &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
+            &Digest::origin(&a)
+                .wrap(&w1)
+                .merge(&Digest::origin(&b).wrap(&w1)),
             &Digest::origin(&c).wrap(&w2),
         )
         .wrap(&w2);
 
         let p = Poly::pick2(
             &ch,
-            &Poly::origin(&a).wrap(&w1).merge(&Poly::origin(&b).wrap(&w1)),
+            &Poly::origin(&a)
+                .wrap(&w1)
+                .merge(&Poly::origin(&b).wrap(&w1)),
             &Poly::origin(&c).wrap(&w2),
         )
         .wrap(&w2);
@@ -189,33 +193,37 @@ mod tests {
         let sites: Vec<Site> = (0..32).map(|i| s(&format!("s{i}"))).collect();
         let mut seen: Vec<(Poly, Digest)> = Vec::new();
         for _ in 0..300 {
-            let (p, d) = gen(&mut rng, &sites, 4);
+            let (p, d) = gen_poly(&mut rng, &sites, 4);
             assert_eq!(p.digest(), d, "expanded != streaming");
             for (q, e) in &seen {
-                assert_eq!(&p == q, &d == e, "digest equality disagrees with polynomial equality");
+                assert_eq!(
+                    &p == q,
+                    &d == e,
+                    "digest equality disagrees with polynomial equality"
+                );
             }
             seen.push((p, d));
         }
     }
 
-    fn gen(rng: &mut impl FnMut() -> u64, sites: &[Site], depth: u32) -> (Poly, Digest) {
+    fn gen_poly(rng: &mut impl FnMut() -> u64, sites: &[Site], depth: u32) -> (Poly, Digest) {
         let site = sites[(rng() % sites.len() as u64) as usize];
-        if depth == 0 || rng() % 4 == 0 {
+        if depth == 0 || rng().is_multiple_of(4) {
             return (Poly::origin(&site), Digest::origin(&site));
         }
         match rng() % 3 {
             0 => {
-                let (p, d) = gen(rng, sites, depth - 1);
+                let (p, d) = gen_poly(rng, sites, depth - 1);
                 (p.wrap(&site), d.wrap(&site))
             }
             1 => {
-                let (p1, d1) = gen(rng, sites, depth - 1);
-                let (p2, d2) = gen(rng, sites, depth - 1);
+                let (p1, d1) = gen_poly(rng, sites, depth - 1);
+                let (p2, d2) = gen_poly(rng, sites, depth - 1);
                 (p1.merge(&p2), d1.merge(&d2))
             }
             _ => {
-                let (p1, d1) = gen(rng, sites, depth - 1);
-                let (p2, d2) = gen(rng, sites, depth - 1);
+                let (p1, d1) = gen_poly(rng, sites, depth - 1);
+                let (p2, d2) = gen_poly(rng, sites, depth - 1);
                 (Poly::pick2(&site, &p1, &p2), Digest::pick2(&site, &d1, &d2))
             }
         }

--- a/provsum/src/poly.rs
+++ b/provsum/src/poly.rs
@@ -1,0 +1,223 @@
+//! Expanded `N[X]` provenance for diagnostics.
+//!
+//! `Poly` is the literal polynomial the digest evaluates.  It costs space
+//! proportional to the number of monomials, which is exponential in merge
+//! depth in the worst case, but for a few thousand sites and shallow wrap
+//! depth it is cheap enough to keep behind a debug flag.  `Poly::digest()`
+//! evaluates it at the same points the streaming digest uses, so
+//! `poly.digest() == streaming_digest` is a checkable invariant, and
+//! `Poly::diff` localizes divergence between two implementations.
+
+use crate::{fadd, fmul, point, Digest, Site, LANES, NO_SLOT};
+use std::collections::BTreeMap;
+
+/// A variable: a site, optionally with a positional slot.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Var {
+    pub site: Site,
+    pub slot: u32,
+}
+
+impl Var {
+    pub fn plain(site: Site) -> Var {
+        Var {
+            site,
+            slot: NO_SLOT,
+        }
+    }
+}
+
+/// A monomial: variable → exponent.
+pub type Monomial = BTreeMap<Var, u32>;
+
+/// A polynomial over `N`: monomial → coefficient.  Zero coefficients are never
+/// stored.
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct Poly(pub BTreeMap<Monomial, u64>);
+
+impl Poly {
+    pub fn zero() -> Poly {
+        Poly::default()
+    }
+
+    pub fn origin(site: &Site) -> Poly {
+        let mut m = Monomial::new();
+        m.insert(Var::plain(*site), 1);
+        let mut p = BTreeMap::new();
+        p.insert(m, 1);
+        Poly(p)
+    }
+
+    fn mul_var(&self, v: Var) -> Poly {
+        let mut out = BTreeMap::new();
+        for (m, c) in &self.0 {
+            let mut m2 = m.clone();
+            *m2.entry(v).or_insert(0) += 1;
+            *out.entry(m2).or_insert(0) += c;
+        }
+        Poly(out)
+    }
+
+    pub fn wrap(&self, site: &Site) -> Poly {
+        self.mul_var(Var::plain(*site))
+    }
+
+    pub fn merge(&self, other: &Poly) -> Poly {
+        let mut out = self.0.clone();
+        for (m, c) in &other.0 {
+            *out.entry(m.clone()).or_insert(0) += c;
+        }
+        Poly(out)
+    }
+
+    pub fn pick(site: &Site, ranked: &[Poly]) -> Poly {
+        let mut acc = Poly::zero();
+        for (slot, p) in ranked.iter().enumerate() {
+            acc = acc.merge(&p.mul_var(Var {
+                site: *site,
+                slot: slot as u32,
+            }));
+        }
+        acc
+    }
+
+    pub fn pick2(site: &Site, returned: &Poly, discarded: &Poly) -> Poly {
+        Poly::pick(site, &[returned.clone(), discarded.clone()])
+    }
+
+    /// Total degree.
+    pub fn degree(&self) -> u32 {
+        self.0
+            .keys()
+            .map(|m| m.values().sum::<u32>())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Evaluate at the crate's pinned points.  Must equal the streaming digest.
+    pub fn digest(&self) -> Digest {
+        let mut lanes = [0u64; LANES];
+        for (m, c) in &self.0 {
+            let c = c % crate::P;
+            for lane in 0..LANES {
+                let mut term = c;
+                for (v, e) in m {
+                    let r = point(&v.site, v.slot, lane as u32);
+                    for _ in 0..*e {
+                        term = fmul(term, r);
+                    }
+                }
+                lanes[lane] = fadd(lanes[lane], term);
+            }
+        }
+        // Reconstruct through the public API so `depth` is populated
+        // consistently: degree is an exact bound here.
+        let mut b = [0u8; crate::DIGEST_BYTES];
+        for (i, l) in lanes.iter().enumerate() {
+            b[i * 8..i * 8 + 8].copy_from_slice(&l.to_le_bytes());
+        }
+        let d = self.degree().min(u16::MAX as u32) as u16;
+        b[LANES * 8..].copy_from_slice(&d.to_le_bytes());
+        Digest::from_bytes(&b).expect("lanes are reduced")
+    }
+
+    /// Monomials whose coefficients differ: `(monomial, coeff_in_self, coeff_in_other)`.
+    pub fn diff(&self, other: &Poly) -> Vec<(Monomial, u64, u64)> {
+        let mut keys: Vec<&Monomial> = self.0.keys().chain(other.0.keys()).collect();
+        keys.sort();
+        keys.dedup();
+        keys.into_iter()
+            .filter_map(|m| {
+                let a = *self.0.get(m).unwrap_or(&0);
+                let b = *other.0.get(m).unwrap_or(&0);
+                (a != b).then(|| (m.clone(), a, b))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(l: &str) -> Site {
+        Site::from_label(l)
+    }
+
+    /// Build the same expression both ways and check the digests agree.
+    #[test]
+    fn expanded_matches_streaming() {
+        let (a, b, c) = (s("a"), s("b"), s("c"));
+        let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
+
+        let d = Digest::pick2(
+            &ch,
+            &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
+            &Digest::origin(&c).wrap(&w2),
+        )
+        .wrap(&w2);
+
+        let p = Poly::pick2(
+            &ch,
+            &Poly::origin(&a).wrap(&w1).merge(&Poly::origin(&b).wrap(&w1)),
+            &Poly::origin(&c).wrap(&w2),
+        )
+        .wrap(&w2);
+
+        assert_eq!(p.digest(), d);
+        assert_eq!(p.degree() as u16, d.depth());
+    }
+
+    #[test]
+    fn diff_localizes_missing_wrap() {
+        let (a, io, h) = (s("a"), s("io"), s("handler"));
+        let full = Poly::origin(&a).wrap(&io).wrap(&h);
+        let short = Poly::origin(&a).wrap(&h);
+        let diff = full.diff(&short);
+        assert_eq!(diff.len(), 2);
+        assert_ne!(full.digest(), short.digest());
+    }
+
+    /// Randomized: distinct polynomials get distinct digests; equal ones agree.
+    #[test]
+    fn random_expressions() {
+        let mut seed = 0xdead_beefu64;
+        let mut rng = move || {
+            seed = crate::mix(seed);
+            seed
+        };
+        let sites: Vec<Site> = (0..32).map(|i| s(&format!("s{i}"))).collect();
+        let mut seen: Vec<(Poly, Digest)> = Vec::new();
+        for _ in 0..300 {
+            let (p, d) = gen(&mut rng, &sites, 4);
+            assert_eq!(p.digest(), d, "expanded != streaming");
+            for (q, e) in &seen {
+                assert_eq!(&p == q, &d == e, "digest equality disagrees with polynomial equality");
+            }
+            seen.push((p, d));
+        }
+    }
+
+    fn gen(rng: &mut impl FnMut() -> u64, sites: &[Site], depth: u32) -> (Poly, Digest) {
+        let site = sites[(rng() % sites.len() as u64) as usize];
+        if depth == 0 || rng() % 4 == 0 {
+            return (Poly::origin(&site), Digest::origin(&site));
+        }
+        match rng() % 3 {
+            0 => {
+                let (p, d) = gen(rng, sites, depth - 1);
+                (p.wrap(&site), d.wrap(&site))
+            }
+            1 => {
+                let (p1, d1) = gen(rng, sites, depth - 1);
+                let (p2, d2) = gen(rng, sites, depth - 1);
+                (p1.merge(&p2), d1.merge(&d2))
+            }
+            _ => {
+                let (p1, d1) = gen(rng, sites, depth - 1);
+                let (p2, d2) = gen(rng, sites, depth - 1);
+                (Poly::pick2(&site, &p1, &p2), Digest::pick2(&site, &d1, &d2))
+            }
+        }
+    }
+}

--- a/provsum/tests/vectors.rs
+++ b/provsum/tests/vectors.rs
@@ -8,14 +8,49 @@ fn pinned_vectors() {
     let (a, b, c) = (s("a"), s("b"), s("c"));
     let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
     let cases: [(&str, Digest, &str, u16); 6] = [
-        ("origin_a", Digest::origin(&a), "0c5b01102d3aa5381bbbf5c617af80f9", 1),
-        ("wrap", Digest::origin(&a).wrap(&w1), "0e44a29fd575961e1efdb24d645c699a", 2),
-        ("merge", Digest::origin(&a).merge(&Digest::origin(&b)), "0be2208396b0ddb91a91f5252af36ed8", 1),
-        ("pick_ab", Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b)), "051ad0515135f32600c1f2c5601f2f74", 2),
-        ("pick_ba", Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a)), "19c61ed8dd4a36b41520984763516d0a", 2),
-        ("nested", Digest::pick2(&ch,
-            &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
-            &Digest::origin(&c).wrap(&w2)).wrap(&w2), "1cd542f9fa81fc621d99cc3e93d019f7", 4),
+        (
+            "origin_a",
+            Digest::origin(&a),
+            "0c5b01102d3aa5381bbbf5c617af80f9",
+            1,
+        ),
+        (
+            "wrap",
+            Digest::origin(&a).wrap(&w1),
+            "0e44a29fd575961e1efdb24d645c699a",
+            2,
+        ),
+        (
+            "merge",
+            Digest::origin(&a).merge(&Digest::origin(&b)),
+            "0be2208396b0ddb91a91f5252af36ed8",
+            1,
+        ),
+        (
+            "pick_ab",
+            Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b)),
+            "051ad0515135f32600c1f2c5601f2f74",
+            2,
+        ),
+        (
+            "pick_ba",
+            Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a)),
+            "19c61ed8dd4a36b41520984763516d0a",
+            2,
+        ),
+        (
+            "nested",
+            Digest::pick2(
+                &ch,
+                &Digest::origin(&a)
+                    .wrap(&w1)
+                    .merge(&Digest::origin(&b).wrap(&w1)),
+                &Digest::origin(&c).wrap(&w2),
+            )
+            .wrap(&w2),
+            "1cd542f9fa81fc621d99cc3e93d019f7",
+            4,
+        ),
     ];
     for (name, d, hex, depth) in cases {
         assert_eq!(d.to_hex(), hex, "{name}");

--- a/provsum/tests/vectors.rs
+++ b/provsum/tests/vectors.rs
@@ -7,7 +7,17 @@ fn pinned_vectors() {
     let s = Site::from_label;
     let (a, b, c) = (s("a"), s("b"), s("c"));
     let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
-    let cases: [(&str, Digest, &str, u16); 6] = [
+    let raw = Site([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f,
+    ]);
+    let cases: [(&str, Digest, &str, u16); 7] = [
+        (
+            "origin_raw_bytes",
+            Digest::origin(&raw),
+            "1a6431e103907e631af361a78c4c2724",
+            1,
+        ),
         (
             "origin_a",
             Digest::origin(&a),

--- a/provsum/tests/vectors.rs
+++ b/provsum/tests/vectors.rs
@@ -1,0 +1,24 @@
+//! Pinned vectors shared with python/provsum.py.  If these change, the wire
+//! format changed and every stored digest is invalidated.
+use provsum::{Digest, Site};
+
+#[test]
+fn pinned_vectors() {
+    let s = Site::from_label;
+    let (a, b, c) = (s("a"), s("b"), s("c"));
+    let (w1, w2, ch) = (s("w1"), s("w2"), s("choose"));
+    let cases: [(&str, Digest, &str, u16); 6] = [
+        ("origin_a", Digest::origin(&a), "0c5b01102d3aa5381bbbf5c617af80f9", 1),
+        ("wrap", Digest::origin(&a).wrap(&w1), "0e44a29fd575961e1efdb24d645c699a", 2),
+        ("merge", Digest::origin(&a).merge(&Digest::origin(&b)), "0be2208396b0ddb91a91f5252af36ed8", 1),
+        ("pick_ab", Digest::pick2(&ch, &Digest::origin(&a), &Digest::origin(&b)), "051ad0515135f32600c1f2c5601f2f74", 2),
+        ("pick_ba", Digest::pick2(&ch, &Digest::origin(&b), &Digest::origin(&a)), "19c61ed8dd4a36b41520984763516d0a", 2),
+        ("nested", Digest::pick2(&ch,
+            &Digest::origin(&a).wrap(&w1).merge(&Digest::origin(&b).wrap(&w1)),
+            &Digest::origin(&c).wrap(&w2)).wrap(&w2), "1cd542f9fa81fc621d99cc3e93d019f7", 4),
+    ];
+    for (name, d, hex, depth) in cases {
+        assert_eq!(d.to_hex(), hex, "{name}");
+        assert_eq!(d.depth(), depth, "{name}");
+    }
+}

--- a/sst/src/lib.rs
+++ b/sst/src/lib.rs
@@ -2402,19 +2402,18 @@ fn divide_keys(
         shared += 1;
     }
     let mut d_key: Vec<u8> = Vec::with_capacity(shared + 1);
-    let d_timestamp: u64;
-    if shared < max_shared && key_lhs[shared] + 1 < key_rhs[shared] {
+    let d_timestamp = if shared < max_shared && key_lhs[shared] + 1 < key_rhs[shared] {
         assert!(key_lhs.len() > shared);
         assert!(key_rhs.len() > shared);
         assert!(key_lhs[shared] < key_rhs[shared]);
         assert!(key_lhs[shared] < 0xff);
         d_key.extend_from_slice(&key_lhs[0..shared + 1]);
         d_key[shared] = key_lhs[shared] + 1;
-        d_timestamp = 0;
+        0
     } else {
         d_key.extend_from_slice(key_lhs);
-        d_timestamp = timestamp_lhs;
-    }
+        timestamp_lhs
+    };
     let cmp_lhs = KeyRef::new(key_lhs, timestamp_lhs).cmp(&KeyRef::new(&d_key, d_timestamp));
     let cmp_rhs = KeyRef::new(&d_key, d_timestamp).cmp(&KeyRef::new(key_rhs, timestamp_rhs));
     assert!(cmp_lhs == Ordering::Less || cmp_lhs == Ordering::Equal);


### PR DESCRIPTION
Introduce the provsum crate for checking that a Rust port raises the
same errors for the same reasons as the code it replaces.  Each
error-origin, wrap, and pick site gets a 16-byte GUID carried across
both implementations; the digest of an error is its provenance
polynomial over N[X] evaluated at points derived from those GUIDs.

Order enters the commutative semiring through pick, which assigns a
distinct variable per slot so that returning one error and discarding
another yields a different polynomial from the reverse.  Plain wrap
order is intentionally not recorded, so a port that restructures
control flow but preserves which sites contribute still digests
identically.

Point derivation is pinned (splitmix64 finalizer, p = 2^61-1, two
lanes) so the reference Python implementation reproduces digests
byte-for-byte.  poly::Poly keeps the expanded polynomial for
diagnostics, with Poly::digest as a testable invariant and Poly::diff
to name differing monomials.  Registers the crate in the workspace and
ships README, example, tests, and shared vectors.

Co-authored-by: AI
