### PR TITLE
feat(ordsum): Add order-sensitive composable checksum crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "meta",
     "minimal_signals",
     "one_two_eight",
+    "ordsum",
     "paxos_pb",
     "protoql",
     "prototk",

--- a/ordsum/Cargo.toml
+++ b/ordsum/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ordsum"
+authors = ["Robert Escriva <robert@rescrv.net>"]
+version = "0.1.0"
+edition = "2021"
+description = "An order-sensitive, concatenation-composable checksum over the affine group of F_(2^127 - 1)."
+license = "Apache-2.0"
+keywords = ["checksum", "digest", "sequence", "homomorphic"]
+categories = ["algorithms", "data-structures"]
+
+[dependencies]
+sha3 = "0.10"
+
+[dev-dependencies]
+proptest = "1"
+num-bigint = "0.4"
+num-traits = "0.2"

--- a/ordsum/README.md
+++ b/ordsum/README.md
@@ -1,0 +1,104 @@
+# ordsum
+
+An order-sensitive, concatenation-composable checksum: the sequence sibling of
+[setsum](https://crates.io/crates/setsum).
+
+Where setsum digests a *multiset* (insertion order cannot matter), ordsum
+digests a *sequence* (insertion order must matter).  Both compose: the checksum
+of a whole can be computed from checksums of its parts without rehashing.
+
+```rust
+use ordsum::Ordsum;
+
+let mut left = Ordsum::default();
+left.push(b"fragment 1");
+let mut right = Ordsum::default();
+right.push(b"fragment 2");
+
+let mut whole = Ordsum::default();
+whole.push(b"fragment 1");
+whole.push(b"fragment 2");
+
+assert_eq!(whole, left.concat(&right));
+assert_ne!(whole, right.concat(&left));       // order matters
+assert_eq!(right, whole.remove_prefix(&left)); // prefixes subtract
+assert_eq!(left, whole.remove_suffix(&right)); // suffixes subtract
+```
+
+## How it works
+
+Each item is hashed with SHA3-256 and mapped to an affine transformation
+`t -> a*t + b` over the field of integers modulo the Mersenne prime
+`p = 2^127 - 1` (with `a` forced nonzero).  A sequence's checksum is the
+composition of its items' maps, earliest item innermost, stored as the pair
+`(A, B)` in a 32-byte digest.
+
+Composition of affine maps is associative but not commutative, which is
+exactly the algebra of concatenation.  Associativity means checksums of chunks
+reduce in any tree shape (parallel reduction is safe); non-commutativity means
+reordered streams produce different checksums.  Every affine map with `a != 0`
+is invertible, which is what makes `remove_prefix` and `remove_suffix` work.
+
+The `A` component is the product of every item's `a` and is itself
+order-independent; the `B` component carries order.  Consequently equal
+digests imply agreement on both the multiset of items and their order.
+
+## Diagnosing mismatches
+
+Because the `A` component is order-independent and `B` is not, a mismatch is
+more than one bit of information.  `diagnose` classifies it:
+
+```rust
+use ordsum::{Diagnosis, Ordsum};
+
+let mut local = Ordsum::default();
+local.push(b"fragment 1");
+local.push(b"fragment 2");
+let mut remote = Ordsum::default();
+remote.push(b"fragment 2");
+remote.push(b"fragment 1");
+
+match local.diagnose(&remote) {
+    Diagnosis::Equal => {}       // same items, same order
+    Diagnosis::Reordered => {}   // same items, wrong splice order
+    Diagnosis::Divergent => {}   // the items themselves differ
+}
+```
+
+`Divergent` is a deterministic claim (equal multisets cannot produce unequal
+`A`); `Reordered` holds unless `A` collided (~2^-127).  The two arms route to
+different repairs: `Divergent` pairs with set-reconciliation to decode which
+items differ, while `Reordered` means the symmetric difference is empty and
+order must be re-derived from other metadata.  The enum is exhaustive: the
+three arms cover every way two checksums can relate.
+
+## What it guarantees, and what it does not
+
+ordsum targets the same threat model as setsum: detecting *corruption*, not
+resisting *adversaries*.  Under the heuristic that SHA3-256 outputs behave as
+uniform field elements:
+
+- Replacing, inserting, or dropping an item yields a colliding digest with
+  probability about 2^-254.
+- Reordering items (same multiset, different order) leaves `A` unchanged by
+  construction and yields a colliding `B` with probability about 2^-127.
+
+Against an adversary who chooses inputs, ordsum offers no collision
+resistance: forging a stream with a target digest reduces to solving one
+linear equation over the field.  If digests cross a trust boundary, they must
+be protected the same way you would protect a setsum -- signed, MAC'd, or
+stored somewhere the adversary cannot write.  (A keyed variant with per-key
+item maps would give universal-hash forgery bounds; it is future work.)
+
+## Costs
+
+One SHA3-256 invocation plus two multiplications mod `2^127 - 1` per item;
+push throughput is SHA3-bound.  `concat` is two multiplications and an
+addition.  `inverse` is one 127-bit modular exponentiation (~microseconds).
+State and digest are 32 bytes.
+
+## Status
+
+Property-tested (group laws, homomorphism over random split points, and
+differential tests of the field arithmetic against num-bigint), but young.
+The digest format may change before 1.0.

--- a/ordsum/src/lib.rs
+++ b/ordsum/src/lib.rs
@@ -1,0 +1,389 @@
+#![doc = include_str!("../README.md")]
+
+use std::fmt::{Debug, Write};
+
+use sha3::{Digest, Sha3_256};
+
+/// The number of bytes in a ordsum digest: 16 bytes for each of the two field
+/// elements (A, B) that represent the affine map t -> A*t + B.
+pub const ORDSUM_BYTES: usize = 32;
+
+/// The field modulus: the Mersenne prime 2^127 - 1.
+pub const ORDSUM_PRIME: u128 = (1u128 << 127) - 1;
+
+const MASK127: u128 = (1u128 << 127) - 1;
+const MASK64: u128 = 0xffff_ffff_ffff_ffff;
+
+////////////////////////////////////// field arithmetic /////////////////////////////////////////
+
+/// Reduce a full 128-bit value into canonical range [0, p).
+#[inline(always)]
+fn reduce128(x: u128) -> u128 {
+    // 2^127 == 1 (mod p), so fold the top bit down.
+    let mut r = (x & MASK127) + (x >> 127);
+    if r >= ORDSUM_PRIME {
+        r -= ORDSUM_PRIME;
+    }
+    r
+}
+
+/// Full 256-bit product of two u128s, as (hi, lo).
+#[inline(always)]
+fn mul_wide(x: u128, y: u128) -> (u128, u128) {
+    let x0 = x & MASK64;
+    let x1 = x >> 64;
+    let y0 = y & MASK64;
+    let y1 = y >> 64;
+    let ll = x0 * y0;
+    let lh = x0 * y1;
+    let hl = x1 * y0;
+    let hh = x1 * y1;
+    let (mid, mid_c) = lh.overflowing_add(hl);
+    let (lo, lo_c) = ll.overflowing_add(mid << 64);
+    let hi = hh + (mid >> 64) + ((mid_c as u128) << 64) + (lo_c as u128);
+    (hi, lo)
+}
+
+/// Modular addition.  Inputs must be canonical.
+#[inline(always)]
+fn addmod(x: u128, y: u128) -> u128 {
+    let mut s = x + y;
+    if s >= ORDSUM_PRIME {
+        s -= ORDSUM_PRIME;
+    }
+    s
+}
+
+/// Modular subtraction.  Inputs must be canonical.
+#[inline(always)]
+fn submod(x: u128, y: u128) -> u128 {
+    let mut s = x + ORDSUM_PRIME - y;
+    if s >= ORDSUM_PRIME {
+        s -= ORDSUM_PRIME;
+    }
+    s
+}
+
+/// Modular multiplication.  Inputs must be canonical.
+#[inline(always)]
+fn mulmod(x: u128, y: u128) -> u128 {
+    let (hi, lo) = mul_wide(x, y);
+    // x, y < 2^127, so hi < 2^126 and hi << 1 cannot overflow.
+    // value = hi * 2^128 + lo, and 2^128 == 2 (mod p).
+    let sum = (lo & MASK127) + (lo >> 127) + (hi << 1);
+    reduce128(sum)
+}
+
+/// Modular exponentiation by square-and-multiply.
+#[inline]
+fn powmod(mut base: u128, mut exp: u128) -> u128 {
+    let mut acc = 1u128;
+    while exp > 0 {
+        if exp & 1 == 1 {
+            acc = mulmod(acc, base);
+        }
+        base = mulmod(base, base);
+        exp >>= 1;
+    }
+    acc
+}
+
+/// Modular inverse via Fermat's little theorem.  Input must be nonzero.
+#[inline]
+fn invmod(x: u128) -> u128 {
+    debug_assert!(x != 0);
+    powmod(x, ORDSUM_PRIME - 2)
+}
+
+////////////////////////////////////////// Ordsum ///////////////////////////////////////////////
+
+/// An order-sensitive, concatenation-composable checksum.
+///
+/// Each item is hashed to an affine map t -> a*t + b over F_p (p = 2^127 - 1),
+/// and a stream's checksum is the composition of its items' maps, earliest item
+/// innermost.  Composition of affine maps is associative but not commutative,
+/// so the checksum distinguishes order.  Every map is invertible, so prefixes
+/// and suffixes can be subtracted.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Ordsum {
+    /// The multiplicative component: the product of every item's `a`.
+    /// This component alone is order-independent.
+    a: u128,
+    /// The affine component; this is where order sensitivity lives.
+    b: u128,
+}
+
+impl Ordsum {
+    /// Hash one item to its affine map (a, b), with a != 0.
+    #[inline]
+    fn item_to_map(item: &[&[u8]]) -> (u128, u128) {
+        let mut hasher = Sha3_256::default();
+        for piece in item {
+            hasher.update(piece);
+        }
+        let d: [u8; 32] = hasher.finalize().into();
+        let a_raw = u128::from_le_bytes(d[..16].try_into().unwrap());
+        let b_raw = u128::from_le_bytes(d[16..].try_into().unwrap());
+        let mut a = reduce128(a_raw);
+        if a == 0 {
+            a = 1;
+        }
+        (a, reduce128(b_raw))
+    }
+
+    /// Append one item to the end of the stream this checksum represents.
+    pub fn push(&mut self, item: &[u8]) {
+        self.push_vectored(&[item]);
+    }
+
+    /// Append one item, provided as concatenated pieces, to the end of the
+    /// stream this checksum represents.  Hashes as if the pieces were one
+    /// contiguous buffer.
+    pub fn push_vectored(&mut self, item: &[&[u8]]) {
+        let (a, b) = Self::item_to_map(item);
+        // new = item_map . self:  t -> a*(A*t + B) + b
+        self.b = addmod(mulmod(a, self.b), b);
+        self.a = mulmod(a, self.a);
+    }
+
+    /// The checksum of `self`'s stream followed by `other`'s stream.
+    ///
+    /// This is a homomorphism: pushing items [x, y, z] one-by-one equals
+    /// concat of a checksum of [x] and a checksum of [y, z].
+    #[must_use]
+    pub fn concat(&self, other: &Ordsum) -> Ordsum {
+        // other . self:  t -> A_o*(A_s*t + B_s) + B_o
+        Ordsum {
+            a: mulmod(other.a, self.a),
+            b: addmod(mulmod(other.a, self.b), other.b),
+        }
+    }
+
+    /// The inverse element in the affine group.  `x.concat(&x.inverse())` is
+    /// the identity (the checksum of the empty stream).
+    #[must_use]
+    pub fn inverse(&self) -> Ordsum {
+        let a_inv = invmod(self.a);
+        Ordsum {
+            a: a_inv,
+            b: submod(0, mulmod(a_inv, self.b)),
+        }
+    }
+
+    /// Given that `self` is the checksum of `prefix`'s stream followed by some
+    /// rest, return the checksum of the rest.
+    ///
+    /// `prefix.concat(&self.remove_prefix(&prefix))` equals `self`.
+    #[must_use]
+    pub fn remove_prefix(&self, prefix: &Ordsum) -> Ordsum {
+        prefix.inverse().concat(self)
+    }
+
+    /// Given that `self` is the checksum of some rest followed by `suffix`'s
+    /// stream, return the checksum of the rest.
+    ///
+    /// `self.remove_suffix(&suffix).concat(&suffix)` equals `self`.
+    #[must_use]
+    pub fn remove_suffix(&self, suffix: &Ordsum) -> Ordsum {
+        self.concat(&suffix.inverse())
+    }
+
+    /// The 32-byte digest: A as 16 little-endian bytes, then B.
+    pub fn digest(&self) -> [u8; ORDSUM_BYTES] {
+        let mut d = [0u8; ORDSUM_BYTES];
+        d[..16].copy_from_slice(&self.a.to_le_bytes());
+        d[16..].copy_from_slice(&self.b.to_le_bytes());
+        d
+    }
+
+    /// Reconstruct a checksum from its digest.  Returns None unless both
+    /// components are canonical field elements and A is nonzero (A = 0 is not
+    /// an element of the affine group and cannot arise from any stream).
+    pub fn from_digest(digest: [u8; ORDSUM_BYTES]) -> Option<Ordsum> {
+        let a = u128::from_le_bytes(digest[..16].try_into().unwrap());
+        let b = u128::from_le_bytes(digest[16..].try_into().unwrap());
+        if a == 0 || a >= ORDSUM_PRIME || b >= ORDSUM_PRIME {
+            return None;
+        }
+        Some(Ordsum { a, b })
+    }
+
+    /// The digest as a lowercase hex string.
+    pub fn hexdigest(&self) -> String {
+        let d = self.digest();
+        let mut s = String::with_capacity(ORDSUM_BYTES * 2);
+        for byte in d.iter() {
+            write!(&mut s, "{:02x}", byte).expect("write to string should succeed");
+        }
+        s
+    }
+
+    /// Reconstruct a checksum from its hex digest.
+    pub fn from_hexdigest(digest: &str) -> Option<Ordsum> {
+        if digest.len() != ORDSUM_BYTES * 2 {
+            return None;
+        }
+        let mut d = [0u8; ORDSUM_BYTES];
+        for (i, byte) in d.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(digest.get(i * 2..i * 2 + 2)?, 16).ok()?;
+        }
+        Self::from_digest(d)
+    }
+}
+
+/// The result of comparing two ordsums.
+///
+/// The arms make asymmetric claims.  `Divergent` is deterministic: equal
+/// multisets always produce equal A components, so unequal A proves the
+/// multisets differ.  `Reordered` is probabilistic: it means the multisets
+/// agree unless the A components collided (~2^-127 for hash-derived streams).
+/// `Divergent` does not rule out reordering on top of the multiset
+/// difference; A is blind to order.
+///
+/// This enum classifies accidents, not attacks.  An adversary who can choose
+/// items can force any arm; see the crate-level threat model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Diagnosis {
+    /// Digests are identical: same items, same order (up to full collision).
+    Equal,
+    /// Same multiset of items, different order.
+    Reordered,
+    /// The multisets differ: at least one item changed, dropped, or
+    /// duplicated.  Order may also differ; this checksum cannot tell.
+    Divergent,
+}
+
+impl Ordsum {
+    /// Compare two checksums and classify how their streams differ.
+    ///
+    /// Symmetric: `x.diagnose(&y) == y.diagnose(&x)`.
+    pub fn diagnose(&self, other: &Ordsum) -> Diagnosis {
+        // Match on the tuple so that a future arm forces this expression to
+        // be revisited.  The wildcard on B when A differs is deliberate:
+        // B-equality carries no information once the multisets diverge.
+        match (self.a == other.a, self.b == other.b) {
+            (true, true) => Diagnosis::Equal,
+            (true, false) => Diagnosis::Reordered,
+            (false, _) => Diagnosis::Divergent,
+        }
+    }
+}
+
+impl Default for Ordsum {
+    /// The checksum of the empty stream: the identity map t -> t.
+    fn default() -> Ordsum {
+        Ordsum { a: 1, b: 0 }
+    }
+}
+
+impl Debug for Ordsum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "ordsum:{}", self.hexdigest())
+    }
+}
+
+/// `lhs * rhs` is the checksum of lhs's stream followed by rhs's stream.
+/// Multiplication is associative and NOT commutative, matching concatenation.
+impl std::ops::Mul<Ordsum> for Ordsum {
+    type Output = Ordsum;
+
+    fn mul(self, rhs: Ordsum) -> Ordsum {
+        self.concat(&rhs)
+    }
+}
+
+impl std::ops::MulAssign<Ordsum> for Ordsum {
+    fn mul_assign(&mut self, rhs: Ordsum) {
+        *self = self.concat(&rhs);
+    }
+}
+
+/// `lhs / rhs` removes rhs's stream from the end of lhs's stream.
+impl std::ops::Div<Ordsum> for Ordsum {
+    type Output = Ordsum;
+
+    fn div(self, rhs: Ordsum) -> Ordsum {
+        self.remove_suffix(&rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_identity() {
+        let e = Ordsum::default();
+        assert_eq!(e, e.concat(&e));
+        assert_eq!(e.hexdigest(), format!("01{}", "00".repeat(31)));
+    }
+
+    #[test]
+    fn order_matters() {
+        let mut xy = Ordsum::default();
+        xy.push(b"x");
+        xy.push(b"y");
+        let mut yx = Ordsum::default();
+        yx.push(b"y");
+        yx.push(b"x");
+        assert_ne!(xy, yx);
+    }
+
+    #[test]
+    fn push_vectored_matches_push() {
+        let mut whole = Ordsum::default();
+        whole.push(b"hello world");
+        let mut pieces = Ordsum::default();
+        pieces.push_vectored(&[b"hello", b" ", b"world"]);
+        assert_eq!(whole, pieces);
+    }
+
+    #[test]
+    fn concat_matches_sequential_push() {
+        let mut whole = Ordsum::default();
+        for item in [b"a".as_ref(), b"b".as_ref(), b"c".as_ref()] {
+            whole.push(item);
+        }
+        let mut left = Ordsum::default();
+        left.push(b"a");
+        let mut right = Ordsum::default();
+        right.push(b"b");
+        right.push(b"c");
+        assert_eq!(whole, left.concat(&right));
+        assert_eq!(whole, left * right);
+    }
+
+    #[test]
+    fn prefix_suffix_roundtrip() {
+        let mut left = Ordsum::default();
+        left.push(b"wal fragment 1");
+        let mut right = Ordsum::default();
+        right.push(b"wal fragment 2");
+        let whole = left.concat(&right);
+        assert_eq!(right, whole.remove_prefix(&left));
+        assert_eq!(left, whole.remove_suffix(&right));
+        assert_eq!(left, whole / right);
+    }
+
+    #[test]
+    fn digest_roundtrip() {
+        let mut c = Ordsum::default();
+        c.push(b"round");
+        c.push(b"trip");
+        assert_eq!(Some(c), Ordsum::from_digest(c.digest()));
+        assert_eq!(Some(c), Ordsum::from_hexdigest(&c.hexdigest()));
+    }
+
+    #[test]
+    fn from_digest_rejects_noncanonical() {
+        // A = 0 is not in the group.
+        let mut d = [0u8; ORDSUM_BYTES];
+        assert_eq!(None, Ordsum::from_digest(d));
+        // A = p is not canonical.
+        d[..16].copy_from_slice(&ORDSUM_PRIME.to_le_bytes());
+        assert_eq!(None, Ordsum::from_digest(d));
+        // A = p + 1 is not canonical either, and aliases A = 2 additively.
+        d[..16].copy_from_slice(&(ORDSUM_PRIME + 1).to_le_bytes());
+        assert_eq!(None, Ordsum::from_digest(d));
+    }
+}

--- a/ordsum/tests/props.rs
+++ b/ordsum/tests/props.rs
@@ -1,0 +1,191 @@
+use ordsum::{Ordsum, ORDSUM_PRIME};
+
+use num_bigint::BigUint;
+use proptest::prelude::*;
+
+fn checksum(items: &[Vec<u8>]) -> Ordsum {
+    let mut c = Ordsum::default();
+    for item in items {
+        c.push(item);
+    }
+    c
+}
+
+fn items() -> impl Strategy<Value = Vec<Vec<u8>>> {
+    prop::collection::vec(prop::collection::vec(any::<u8>(), 0..16), 0..24)
+}
+
+proptest! {
+    // Homomorphism: checksum(A ++ B) == checksum(A).concat(checksum(B)),
+    // for every split point of every stream.
+    #[test]
+    fn concat_is_homomorphic(stream in items(), split in any::<prop::sample::Index>()) {
+        let split = split.index(stream.len() + 1);
+        let whole = checksum(&stream);
+        let left = checksum(&stream[..split]);
+        let right = checksum(&stream[split..]);
+        prop_assert_eq!(whole, left.concat(&right));
+    }
+
+    // Associativity over a three-way split (tree reduction correctness).
+    #[test]
+    fn concat_is_associative(stream in items(),
+                             i in any::<prop::sample::Index>(),
+                             j in any::<prop::sample::Index>()) {
+        let mut i = i.index(stream.len() + 1);
+        let mut j = j.index(stream.len() + 1);
+        if i > j { std::mem::swap(&mut i, &mut j); }
+        let (x, y, z) = (checksum(&stream[..i]), checksum(&stream[i..j]), checksum(&stream[j..]));
+        prop_assert_eq!(x.concat(&y).concat(&z), x.concat(&y.concat(&z)));
+    }
+
+    // Identity and inverse.
+    #[test]
+    fn group_laws(stream in items()) {
+        let c = checksum(&stream);
+        let e = Ordsum::default();
+        prop_assert_eq!(c, c.concat(&e));
+        prop_assert_eq!(c, e.concat(&c));
+        prop_assert_eq!(e, c.concat(&c.inverse()));
+        prop_assert_eq!(e, c.inverse().concat(&c));
+    }
+
+    // Prefix/suffix removal recovers the counterpart.
+    #[test]
+    fn prefix_suffix(stream in items(), split in any::<prop::sample::Index>()) {
+        let split = split.index(stream.len() + 1);
+        let whole = checksum(&stream);
+        let left = checksum(&stream[..split]);
+        let right = checksum(&stream[split..]);
+        prop_assert_eq!(right, whole.remove_prefix(&left));
+        prop_assert_eq!(left, whole.remove_suffix(&right));
+    }
+
+    // Digest round-trips and stays canonical.
+    #[test]
+    fn digest_roundtrip(stream in items()) {
+        let c = checksum(&stream);
+        prop_assert_eq!(Some(c), Ordsum::from_digest(c.digest()));
+        prop_assert_eq!(Some(c), Ordsum::from_hexdigest(&c.hexdigest()));
+    }
+
+    // Swapping two distinct adjacent items changes the checksum.
+    #[test]
+    fn adjacent_swap_detected(mut stream in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..16), 2..24),
+                              at in any::<prop::sample::Index>()) {
+        let at = at.index(stream.len() - 1);
+        prop_assume!(stream[at] != stream[at + 1]);
+        let before = checksum(&stream);
+        stream.swap(at, at + 1);
+        prop_assert_ne!(before, checksum(&stream));
+    }
+}
+
+// Differential tests of the internal field arithmetic against num-bigint,
+// exercised through the public API: the B component of a two-item checksum is
+// a1*b0 + b1 mod p, which covers mulmod's full input range via hash outputs.
+// For direct coverage of the arithmetic we recompute a stream's state with
+// BigUint from the items' hashes.
+mod differential {
+    use super::*;
+    use sha3::{Digest, Sha3_256};
+
+    fn p() -> BigUint {
+        BigUint::from(ORDSUM_PRIME)
+    }
+
+    fn item_map(item: &[u8]) -> (BigUint, BigUint) {
+        let d: [u8; 32] = Sha3_256::digest(item).into();
+        let a_raw = BigUint::from(u128::from_le_bytes(d[..16].try_into().unwrap()));
+        let b_raw = BigUint::from(u128::from_le_bytes(d[16..].try_into().unwrap()));
+        let mut a = a_raw % p();
+        if a == BigUint::from(0u8) {
+            a = BigUint::from(1u8);
+        }
+        (a, b_raw % p())
+    }
+
+    proptest! {
+        #[test]
+        fn state_matches_bigint(stream in items()) {
+            let mut a_ref = BigUint::from(1u8);
+            let mut b_ref = BigUint::from(0u8);
+            for item in &stream {
+                let (a, b) = item_map(item);
+                b_ref = (&a * b_ref + b) % p();
+                a_ref = (&a * a_ref) % p();
+            }
+            let c = checksum(&stream);
+            let d = c.digest();
+            let a_got = BigUint::from(u128::from_le_bytes(d[..16].try_into().unwrap()));
+            let b_got = BigUint::from(u128::from_le_bytes(d[16..].try_into().unwrap()));
+            prop_assert_eq!(a_ref, a_got);
+            prop_assert_eq!(b_ref, b_got);
+        }
+    }
+}
+
+mod diagnosis {
+    use super::*;
+    use ordsum::Diagnosis;
+
+    proptest! {
+        // Comparing a checksum with itself, or with an independently
+        // recomputed checksum of the same stream, is Equal.
+        #[test]
+        fn identical_streams_are_equal(stream in items()) {
+            let x = checksum(&stream);
+            let y = checksum(&stream);
+            prop_assert_eq!(Diagnosis::Equal, x.diagnose(&y));
+        }
+
+        // A genuine permutation of the stream (same items, order actually
+        // changed) diagnoses as Reordered.
+        #[test]
+        fn permutation_is_reordered(stream in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..16), 2..24),
+                                    seed in any::<u64>()) {
+            // Fisher-Yates with a splitmix64-ish PRNG; deterministic per seed.
+            let mut permuted = stream.clone();
+            let mut s = seed;
+            for i in (1..permuted.len()).rev() {
+                s = s.wrapping_add(0x9e3779b97f4a7c15);
+                let mut z = s;
+                z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+                z ^= z >> 31;
+                permuted.swap(i, (z as usize) % (i + 1));
+            }
+            prop_assume!(permuted != stream);
+            let diag = checksum(&stream).diagnose(&checksum(&permuted));
+            prop_assert_eq!(Diagnosis::Reordered, diag);
+        }
+
+        // Changing the multiset -- replace an item with a different one,
+        // drop an item, or duplicate an item -- diagnoses as Divergent.
+        #[test]
+        fn multiset_change_is_divergent(stream in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..16), 1..24),
+                                        at in any::<prop::sample::Index>(),
+                                        replacement in prop::collection::vec(any::<u8>(), 0..16),
+                                        kind in 0u8..3) {
+            let at = at.index(stream.len());
+            let mut mutated = stream.clone();
+            match kind {
+                0 => {
+                    prop_assume!(stream[at] != replacement);
+                    mutated[at] = replacement;
+                }
+                1 => { mutated.remove(at); }
+                _ => { let dup = mutated[at].clone(); mutated.insert(at, dup); }
+            }
+            let diag = checksum(&stream).diagnose(&checksum(&mutated));
+            prop_assert_eq!(Diagnosis::Divergent, diag);
+        }
+
+        // diagnose is symmetric.
+        #[test]
+        fn diagnose_is_symmetric(x in items(), y in items()) {
+            let (x, y) = (checksum(&x), checksum(&y));
+            prop_assert_eq!(x.diagnose(&y), y.diagnose(&x));
+        }
+    }
+}


### PR DESCRIPTION
Add ordsum, the sequence sibling of setsum: an order-sensitive,
concatenation-composable checksum.  Where setsum digests a multiset,
ordsum digests a sequence where insertion order must matter.

Each item is hashed with SHA3-256 and mapped to an affine map
t -> a*t + b over F_(2^127 - 1) with a nonzero.  A sequence digest is
the composition of its items maps, stored as the pair (A, B) in a
32-byte digest.  Composition of affine maps is associative but not
commutative, giving the algebra of concatenation: chunks reduce in any
tree shape, reordered streams differ, and invertibility yields
remove_prefix and remove_suffix.

The public API provides push, push_vectored, concat, inverse,
remove_prefix, remove_suffix, digest/from_digest, hexdigest/from_hexdigest,
Mul/Div operators, and a diagnose method returning an exhaustive
Diagnosis enum (Equal, Reordered, Divergent) to classify mismatches.

Property-tested for group laws, homomorphism over random split
points, and differential field arithmetic against num-bigint.  Register
the crate in the workspace members list.

Co-authored-by: AI
