### PR TITLE
fix(caternary): resolve definitions before operators in both tiers

### DIFF
--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -1038,22 +1038,11 @@ where
         ));
     }
 
-    // A registered operator (embedder attestation): instantiate its scheme with
-    // fresh vars and re-anchor the spans at this call site (§5 `lookup`).
-    if let Some(scheme) = evaluator.contract(w) {
-        let scheme = scheme.clone();
-        let inst = ctx.instantiate(&scheme);
-        return Ok(respan_word(&inst, span));
-    }
-
-    // A language-core primitive (DUP/DROP/SWAP/OVER/CALL/IF), looked up under
-    // its runtime UPPER_SNAKE_CASE spelling. The spec uses runtime spelling
-    // directly; there is no lowercase translation layer.
-    if let Some(scheme) = core_scheme(w) {
-        let inst = ctx.instantiate(&scheme);
-        return Ok(respan_word(&inst, span));
-    }
-
+    // Definitions resolve BEFORE operators and core primitives — the runtime's
+    // resolution order is locals → definitions → operators (README), so a
+    // definition may shadow a registered operator or a language-core word and
+    // the checker must type the call against what the runtime will run.
+    //
     // A definition under inference in the *current* SCC: use its monomorphic
     // arrow assumption directly (recursive calls share the un-generalized type,
     // the no-polymorphic-recursion rule, §6). Re-anchor the spans at this call
@@ -1067,6 +1056,22 @@ where
     // re-anchor at this call site (§6, §5 `lookup`).
     if let Some(scheme) = def_env.schemes.get(w) {
         let inst = ctx.instantiate(scheme);
+        return Ok(respan_word(&inst, span));
+    }
+
+    // A registered operator (embedder attestation): instantiate its scheme with
+    // fresh vars and re-anchor the spans at this call site (§5 `lookup`).
+    if let Some(scheme) = evaluator.contract(w) {
+        let scheme = scheme.clone();
+        let inst = ctx.instantiate(&scheme);
+        return Ok(respan_word(&inst, span));
+    }
+
+    // A language-core primitive (DUP/DROP/SWAP/OVER/CALL/IF), looked up under
+    // its runtime UPPER_SNAKE_CASE spelling. The spec uses runtime spelling
+    // directly; there is no lowercase translation layer.
+    if let Some(scheme) = core_scheme(w) {
+        let inst = ctx.instantiate(&scheme);
         return Ok(respan_word(&inst, span));
     }
 
@@ -1910,6 +1915,56 @@ mod tests {
         assert_eq!(
             inst.output.elems[0].kind,
             crate::types::TyKind::Con(NUM.to_string())
+        );
+    }
+
+    // =======================================================================
+    // Regression: definitions must shadow language-core words
+    // (README: "a definition may shadow a builtin operator"; runtime
+    // resolution is locals → definitions → operators, but the checker
+    // resolved contracts/`core_scheme` BEFORE definitions)
+    // =======================================================================
+
+    /// The user's `DUP` takes no inputs; typed as the definition, `main`
+    /// closes against the empty stack. Mis-resolved as core `DUP`
+    /// ( 'S a -- 'S a a ), `main` underflows the empty stack.
+    #[test]
+    fn definition_shadowing_core_word_types_main_against_the_definition() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        let tokens = parse_with_spans("[ 0 ] :DUP [ DUP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            type_check(&eval).is_ok(),
+            "definition `DUP` must shadow the core word (README resolution order)"
+        );
+    }
+
+    /// The other direction of the same desync: borrowing core `DUP`'s arity for
+    /// a user `DUP` that *consumes* two values makes `5 DUP` type-check against
+    /// the empty stack while the runtime underflows. The checker must reject.
+    #[test]
+    fn definition_shadowing_core_word_cannot_borrow_core_arity() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        let tokens = parse_with_spans("[ DROP DROP 0 ] :DUP [ 5 DUP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            type_check(&eval).is_err(),
+            "checker must not type `DUP` via the core scheme when a definition shadows it"
+        );
+    }
+
+    /// Gate-level pin covering BOTH tiers: Tier 0 must type `DUP` from the
+    /// definition, and the Tier-1 shadow must move data per the definition's
+    /// arrow rather than `core_shadow_word("DUP")` (which would underflow the
+    /// shadow stack here and spuriously reject a runtime-fine program).
+    #[test]
+    fn gate_accepts_definition_shadowing_core_word() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        let tokens = parse_with_spans("[ 0 ] :DUP [ DUP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_ok(),
+            "gate must verify the definition the runtime will actually call"
         );
     }
 

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -825,6 +825,12 @@ pub struct SigResolver<'a, L> {
     /// shadow data flow silently diverges from the runtime's — the §10.3
     /// mis-shuffle failure class (wrong slots zipped at the next §10.2 binding).
     arrows: Option<ArrowLookup<'a>>,
+    /// The loaded definition names. The runtime's resolution order is
+    /// locals → definitions → operators, so a definition may **shadow** a
+    /// language-core word (`DUP`, `DIP`, …) or an interpreted operator; the
+    /// shadow evaluator must then move data per the definition's Tier 0 arrow,
+    /// not per the core word's baked-in semantics.
+    definitions: Option<&'a BTreeSet<String>>,
 }
 
 impl<'a, L> SigResolver<'a, L>
@@ -838,6 +844,7 @@ where
         SigResolver {
             lookup,
             arrows: None,
+            definitions: None,
         }
     }
 
@@ -848,6 +855,23 @@ where
         SigResolver {
             lookup,
             arrows: Some(arrows),
+            definitions: None,
+        }
+    }
+
+    /// Like [`SigResolver::with_arrows`], additionally carrying the loaded
+    /// **definition names** so a definition that shadows a language-core word
+    /// resolves to its own Tier 0 arrow (the runtime's resolution order is
+    /// locals → definitions → operators).
+    pub fn with_arrows_and_definitions(
+        lookup: &'a L,
+        arrows: ArrowLookup<'a>,
+        definitions: &'a BTreeSet<String>,
+    ) -> Self {
+        SigResolver {
+            lookup,
+            arrows: Some(arrows),
+            definitions: Some(definitions),
         }
     }
 
@@ -870,7 +894,18 @@ where
     L: Fn(&str) -> Option<RefinementSig>,
 {
     fn resolve(&self, word: &str) -> VerifyWord {
-        let resolved = refinement_verify_word(word, (self.lookup)(word).as_ref());
+        let sig = (self.lookup)(word);
+        // A loaded definition shadows a core word / interpreted operator (the
+        // runtime resolves definitions BEFORE operators). An unrefined
+        // definition must move data per its own inferred Tier 0 arrow — never
+        // per the shadowed core word's semantics.
+        if sig.is_none()
+            && self.definitions.is_some_and(|defs| defs.contains(word))
+            && let Some(arrow) = self.tier0_arrow(word)
+        {
+            return VerifyWord::Core(ShadowWord::Opaque(arrow));
+        }
+        let resolved = refinement_verify_word(word, sig.as_ref());
         // The Var fallback is only honest for a word with NO known Tier 0
         // arrow (a free symbolic variable). A word that Tier 0 typed — an
         // unrefined registered operator (MAP/FILTER/FOLD/EACH, embedder ops)
@@ -2162,13 +2197,14 @@ fn check_definition_ctx<L, S>(
     def: &Definition,
     lookup: &L,
     arrows: ArrowLookup<'_>,
+    definitions: &BTreeSet<String>,
     solver: &mut S,
 ) -> Result<VerifyCtx, ShadowError>
 where
     L: Fn(&str) -> Option<RefinementSig>,
     S: Solver + CounterModel + FactSnapshot,
 {
-    let resolve = SigResolver::with_arrows(lookup, arrows);
+    let resolve = SigResolver::with_arrows_and_definitions(lookup, arrows, definitions);
     let mut stack = ShadowStack::new();
     let mut ctx = VerifyCtx::with_site(&def.name);
 
@@ -2244,11 +2280,12 @@ where
 {
     let mut ledger = Ledger::new();
     let mut own: BTreeMap<String, Vec<Pred>> = BTreeMap::new();
+    let definition_names: BTreeSet<String> = defs.iter().map(|d| d.name.clone()).collect();
 
     // Pass 1: verify each body; collect its own accepted/rejected assumes.
     for def in defs {
         let mut solver = mk_solver();
-        let ctx = check_definition_ctx(def, lookup, arrows, &mut solver)?;
+        let ctx = check_definition_ctx(def, lookup, arrows, &definition_names, &mut solver)?;
         // Fail closed on any UNDISCHARGED obligation (§10.5/§10.7 Situation B):
         // `verify` records a `Sat` (refuted demand/guarantee, with a
         // counterexample model) or `Unknown` (undecided — fails closed for


### PR DESCRIPTION
The runtime resolves a word locals -> definitions -> operators, so a
definition may shadow a registered operator or a language-core word
(README). Both checker tiers resolved the other way around:

- Tier 0 (word_effect) consulted registered contracts and core
  schemes before the definition environment, typing a call against
  the core scheme the runtime would never run. A no-input user DUP
  was typed as ( 'S a -- 'S a a ) (spurious underflow), and a
  two-input user DUP borrowed the core arity (accepted a program
  that underflows at runtime).
- Tier 1 (SigResolver::resolve) hit core_shadow_word before the
  arrow lookup, moving shadow data per core semantics instead of
  the definition's inferred arrow.

Reorder word_effect to check the in-SCC assumptions and generalized
definition schemes ahead of contracts/core schemes, and thread the
loaded definition names through check_program_with_arrows so the
resolver treats a shadowing definition as an opaque word driven by
its own Tier 0 arrow. Regression tests pin both desync directions
and the whole-program gate.

Co-authored-by: AI
