### PR TITLE
fix(caternary): make assume(...) a runtime no-op

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -24,17 +24,6 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   grammar that rejects `inf`/`NaN`; make `=` numeric (or add `eqv?`-style
   token equality under a separate name and keep `=` out of the solver's Eq).
 
-### `assume(...)` is a no-op to the checker but a value at runtime
-
-- Tier 0 gives it the identity effect (`src/check.rs:1033`); Tier 1
-  intercepts it; but no operator is registered, so the runtime **pushes the
-  literal word**. `[ 5 ] :five` + `[ five "assume(x > 0)" ] :main` passes
-  the full gate (exit 0) while the runtime stack ends as
-  `[5 "assume(x > 0)"]` — one more value than the proof says exists.
-- Fix direction: treat `assume(...)` as a runtime no-op in the evaluator
-  (or strip the words before evaluation in a checked-program runner), and
-  test that a gate-passing program's runtime stack matches its proven effect.
-
 ### Parser: no literal brackets in words; deep nesting aborts the process
 
 - Shell quotes/escapes are resolved before bracket processing, so a word can
@@ -124,3 +113,6 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   `shadow_conforms_under_combinator_pressure` flake): pinned by
   `check::tests::dup_dip_rot_drop_call_does_not_spuriously_cycle`.
   When fixed, also re-run the shadow-conformance proptest repeatedly.
+- `assume(...)` runtime no-op: pinned by
+  `evaluator::tests::assume_word_is_a_runtime_no_op` and
+  `check::tests::gate_passing_assume_program_runtime_matches_proven_effect`.

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2112,6 +2112,36 @@ mod tests {
     }
 
     // =======================================================================
+    // Regression: `assume(...)` must be a runtime no-op
+    // =======================================================================
+
+    /// A gate-passing program's runtime stack must match its proven effect.
+    /// Tier 0 gives `assume(...)` the identity effect and Tier 1 intercepts
+    /// it, but the runtime used to push the literal word — the stack ended as
+    /// `[5 "assume(x > 0)"]`, one more value than the proof says exists.
+    #[test]
+    fn gate_passing_assume_program_runtime_matches_proven_effect() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let src = "[ 5 ] :five [ five \"assume(x > 0)\" ] :main";
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_ok(),
+            "the assume-bearing program passes the full gate"
+        );
+        // The proven effect of `main` is ( -- Num ): exactly one value.
+        let body = eval.definition_body("main").unwrap().to_vec();
+        let mut stack = Vec::new();
+        eval.eval_with_stack(&body, &mut stack).unwrap();
+        assert_eq!(
+            stack,
+            vec![Value::Word("5".to_string())],
+            "runtime stack must carry exactly the proven single value"
+        );
+    }
+
+    // =======================================================================
     // Regression: reasoner overflow at the gate
     // =======================================================================
 

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -654,6 +654,13 @@ where
         } else if let Some(value) = env.get(w) {
             // reference: resolved scope-first, ahead of definitions and operators
             stack.push(value.clone());
+        } else if crate::parse_assume(w).is_some() {
+            // `assume( PRED )` (§10.7) is a Tier-1 path-condition marker, not a
+            // value: Tier 0 gives it the identity stack effect and Tier 1
+            // intercepts it before word resolution, so the runtime must move no
+            // data either — a gate-passing program's runtime stack matches its
+            // proven effect. (Pushing the literal word here would leave one more
+            // value on the stack than the proof says exists.)
         } else if let Some(body) = self.definitions.get(w) {
             // function call: re-enter in a fresh scope.
             let body = body.clone();
@@ -819,6 +826,18 @@ mod tests {
             ]
         );
         println!("Stack: {result:?}");
+    }
+
+    /// `assume( PRED )` is a Tier-1 marker with the identity Tier-0 effect; the
+    /// runtime must move no data either (§10.7). Before the fix the evaluator
+    /// fell through to the literal-word push and the runtime stack carried one
+    /// more value than the proven effect.
+    #[test]
+    fn assume_word_is_a_runtime_no_op() {
+        let eval: Evaluator<Value> = Evaluator::new();
+        let tokens = parse(r#"A "assume(x > 0)""#).unwrap();
+        let result = eval.eval(&tokens).unwrap();
+        assert_eq!(result, vec![Value::Word("A".to_string())]);
     }
 
     #[test]


### PR DESCRIPTION
Tier 0 gives assume( PRED ) the identity stack effect and Tier 1
intercepts it before word resolution, but no operator was registered,
so the evaluator fell through to the literal-word push: a gate-passing
program like [ five "assume(x > 0)" ] :main ended with one more
runtime value than its proven effect claims. Recognize the assume
surface in eval_word (after locals, mirroring the checker) and move
no data.

Tests pin the evaluator no-op and the end-to-end property that a
gate-passing assume-bearing program ends with exactly its proven
stack.

Co-authored-by: AI
