### PR TITLE
fix(caternary): fold refinement signatures into the attestation hash

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -11,17 +11,6 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 
 ## Medium
 
-### Attestation hash omits Tier-1 content
-
-- `ContractSet::attestation_hash` (`src/attestation.rs:222`) covers only
-  Tier-0 schemes + the operator table — not refinement signatures
-  (`Evaluator::attach_refinement`). Two builds differing only in refinement
-  axioms hash identically, contrary to the architecture section's
-  "all definition signatures + the operator table" (core entries are documented
-  to carry "Tier-0 scheme (and Tier-1 axiom)").
-- Fix direction: fold each name's `RefinementSig` (and the operator axioms)
-  into the canonical rendering before hashing.
-
 ### Optimizer: no termination bound for size-increasing rules
 
 - `Optimizer::optimize` (`src/optimizer.rs:427`) stops only at fixpoint or a
@@ -95,6 +84,8 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   `…::equality_is_numeric_not_rendering_dependent`, and neighbors. Remaining
   documented gap: fractional arithmetic rounds (f64) while the model's
   division is exact rational.
+- Attestation hash covers Tier-1 refinement signatures: pinned by
+  `attestation::tests::attestation_hash_covers_refinement_signatures`.
 - Parser literal brackets + nesting cap: pinned by
   `parser::tests::{double,single}_quoted_brackets_stay_literal`,
   `parser::tests::backslash_escaped_brackets_stay_literal`, and

--- a/caternary/src/attestation.rs
+++ b/caternary/src/attestation.rs
@@ -194,6 +194,12 @@ pub struct ContractSet {
     pub definitions: BTreeMap<String, Scheme>,
     /// The operator table (the modulo).
     pub operators: OperatorTable,
+    /// Every attached **Tier-1 refinement signature** (definitions' contracts
+    /// and operator axioms alike), keyed by name (sorted iteration). The
+    /// architecture section's "all definition signatures" includes the Tier-1
+    /// axiom a name carries: two builds differing only in refinement axioms
+    /// are different trusted bases and must hash differently.
+    pub refinements: BTreeMap<String, crate::RefinementSig>,
 }
 
 impl ContractSet {
@@ -209,6 +215,10 @@ impl ContractSet {
         Ok(ContractSet {
             definitions: schemes.into_iter().collect(),
             operators: OperatorTable::of(evaluator),
+            refinements: evaluator
+                .refinements()
+                .map(|sig| (sig.name.clone(), sig.clone()))
+                .collect(),
         })
     }
 
@@ -233,6 +243,14 @@ impl ContractSet {
             entry.name.hash(&mut h);
             entry.origin.tag().hash(&mut h);
             canonical_scheme(&entry.scheme).hash(&mut h);
+        }
+        // Tier-1 refinement signatures (definition contracts + operator
+        // axioms), in sorted name order. A build that differs only in a
+        // refinement axiom differs in its trusted base, so it must differ here.
+        h.write_usize(self.refinements.len());
+        for (name, sig) in &self.refinements {
+            name.hash(&mut h);
+            canonical_sig(sig).hash(&mut h);
         }
         h.finish()
     }
@@ -259,6 +277,57 @@ fn canonical_scheme(scheme: &Scheme) -> String {
     let mut tymap: BTreeMap<u32, usize> = BTreeMap::new();
     let mut rowmap: BTreeMap<u32, usize> = BTreeMap::new();
     render_word(&scheme.ty, &mut tymap, &mut rowmap)
+}
+
+// ---- canonical refinement rendering (stable: spans dropped) -----------------
+
+/// Canonicalize a [`crate::RefinementSig`] to a stable string: binder names,
+/// surface types, nested quote contracts, and the demand/guarantee predicates
+/// — with source spans dropped, so the hash is a property of the *axiom*, not
+/// of where it happened to be written.
+fn canonical_sig(sig: &crate::RefinementSig) -> String {
+    format!(
+        "({} -- {})",
+        canonical_side(&sig.demands),
+        canonical_side(&sig.guarantees)
+    )
+}
+
+fn canonical_side(side: &crate::RefinementSide) -> String {
+    let binders: Vec<String> = side.binders.iter().map(canonical_binder).collect();
+    let pred = side
+        .predicate
+        .as_ref()
+        .map(canonical_pred)
+        .unwrap_or_else(|| "true".to_string());
+    format!("[{}] where {}", binders.join(" "), pred)
+}
+
+fn canonical_binder(b: &crate::Binder) -> String {
+    match &b.quote {
+        None => format!("{}:{}", b.name, b.ty),
+        Some(q) => format!(
+            "{}:({} -- {})",
+            b.name,
+            canonical_side(&q.demands),
+            canonical_side(&q.guarantees)
+        ),
+    }
+}
+
+fn canonical_pred(p: &crate::Pred) -> String {
+    match p {
+        crate::Pred::Var(n) => n.clone(),
+        crate::Pred::Num(l) => l.clone(),
+        crate::Pred::Bin(op, a, b) => {
+            format!("({op:?} {} {})", canonical_pred(a), canonical_pred(b))
+        }
+        crate::Pred::Un(op, a) => format!("({op:?} {})", canonical_pred(a)),
+        crate::Pred::App(f, args) => {
+            let args: Vec<String> = args.iter().map(canonical_pred).collect();
+            format!("({f} {})", args.join(" "))
+        }
+    }
 }
 
 fn canon_id(map: &mut BTreeMap<u32, usize>, v: u32) -> usize {

--- a/caternary/src/attestation/tests.rs
+++ b/caternary/src/attestation/tests.rs
@@ -282,6 +282,39 @@ fn attestation_hash_changes_when_the_contract_set_changes() {
 }
 
 #[test]
+fn attestation_hash_covers_refinement_signatures() {
+    // (TODO "Attestation hash omits Tier-1 content") Two builds differing only
+    // in refinement axioms are different trusted bases and must hash
+    // differently — "all definition signatures" includes the Tier-1 axiom.
+    let src = "[ 1 + ] :incr [ 2 incr ] :main";
+    let base = attestation_hash(&build(src)).unwrap();
+
+    let mut refined = build(src);
+    refined
+        .attach_refinement("incr : ( n: Num -- r: Num where r = n + 1 )")
+        .unwrap();
+    let with_axiom = attestation_hash(&refined).unwrap();
+    assert_ne!(base, with_axiom, "a refinement axiom must change the hash");
+
+    let mut other = build(src);
+    other
+        .attach_refinement("incr : ( n: Num -- r: Num where r > n )")
+        .unwrap();
+    let with_other_axiom = attestation_hash(&other).unwrap();
+    assert_ne!(
+        with_axiom, with_other_axiom,
+        "different axioms are different trusted bases"
+    );
+
+    // Stability is preserved: the same source + the same axiom rehashes equal.
+    let mut again = build(src);
+    again
+        .attach_refinement("incr : ( n: Num -- r: Num where r = n + 1 )")
+        .unwrap();
+    assert_eq!(with_axiom, attestation_hash(&again).unwrap());
+}
+
+#[test]
 fn attestation_hash_ignores_internal_variable_ids() {
     // The canonical rendering renumbers variables in first-appearance order, so a
     // scheme's hash does not depend on the ids inference happened to assign — this

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -434,6 +434,14 @@ impl<T> Evaluator<T> {
         self.refinements.get(name)
     }
 
+    /// Every attached refinement signature (§10.1), in table order
+    /// (unordered). The enumeration path for the attestation hash (M14): a
+    /// refinement axiom is Tier-1 attested content, so it must be part of the
+    /// content-addressed contract set.
+    pub fn refinements(&self) -> impl Iterator<Item = &crate::RefinementSig> {
+        self.refinements.values()
+    }
+
     /// Run **first-order Tier-1 verification** (M9, §10.5) over `tokens`,
     /// deriving every call site's demands and guarantees from the **attached
     /// refinement signatures** in this evaluator's refinement table


### PR DESCRIPTION
ContractSet::attestation_hash covered only the Tier-0 schemes and the
operator table, so two builds differing only in Tier-1 refinement
axioms (Evaluator::attach_refinement) hashed identically — contrary to
the architecture section, which content-addresses "all definition
signatures + the operator table" with core entries carrying the
Tier-0 scheme and Tier-1 axiom.

ContractSet gains a refinements map (definition contracts and operator
axioms alike, keyed by name) collected from the evaluator, and the
hash folds each signature through a canonical rendering that drops
source spans, keeping the hash a property of the axiom itself. A test
pins that attaching an axiom changes the hash, different axioms hash
differently, and identical source + axiom rehashes equal.

Co-authored-by: AI
