### PR TITLE
fix(caternary): make Evaluator::load atomic on error

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -13,9 +13,6 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 
 ### API sharp edges
 
-- `Evaluator::load` is **non-atomic**: `[ 1 ] :a :2x` errors but `:a` stays
-  defined (`src/evaluator.rs:479-543`). The REPL is transactional only
-  because it clones first. Fix: validate everything, then insert.
 - Ghost annotations are silently ignored: `[ -- Num ] @ghost` with no
   `:ghost` definition passes `check` (exit 0). A typo'd `@name` silently
   unconstrains. Fix: reject an annotation whose definition is absent.
@@ -75,6 +72,8 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   `…::equality_is_numeric_not_rendering_dependent`, and neighbors. Remaining
   documented gap: fractional arithmetic rounds (f64) while the model's
   division is exact rational.
+- `Evaluator::load` atomicity: pinned by
+  `evaluator::tests::load_is_atomic_on_error`.
 - Optimizer termination: iteration + program-size budgets, cycle detection
   by exact program equality. Pinned by
   `optimizer::tests::size_increasing_rule_terminates_at_the_size_cap` and

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -508,6 +508,10 @@ impl<T> Evaluator<T> {
         reject_nested(tokens)?;
 
         // Walk the top level, pairing each binder with the quotation before it.
+        // The walk **stages** every definition and inserts only after the whole
+        // stream validates: `load` is atomic — a stream with any invalid binder
+        // (`[ 1 ] :a :2x`) defines nothing, rather than leaving `:a` behind.
+        let mut staged: Vec<(String, Vec<Token>)> = Vec::new();
         let mut i = 0;
         while i < tokens.len() {
             if let Token::Word(w) = &tokens[i]
@@ -531,14 +535,19 @@ impl<T> Evaluator<T> {
                         )));
                     }
                 };
-                if self.definitions.contains_key(name) {
+                if self.definitions.contains_key(name)
+                    || staged.iter().any(|(staged_name, _)| staged_name == name)
+                {
                     return Err(definition_error(format!(
                         "redefinition: `:{name}` is already defined"
                     )));
                 }
-                self.definitions.insert(name.to_string(), body);
+                staged.push((name.to_string(), body));
             }
             i += 1;
+        }
+        for (name, body) in staged {
+            self.definitions.insert(name, body);
         }
         Ok(())
     }
@@ -1468,6 +1477,25 @@ mod tests {
             "[first] :x [second] :x",
             "redefinition: `:x` is already defined",
         );
+    }
+
+    /// `load` is atomic: a stream with any invalid binder defines nothing.
+    /// Before the fix `[ 1 ] :a :2x` errored but left `:a` defined, so an
+    /// erroring `load` mutated the evaluator (the REPL was transactional only
+    /// because it cloned first).
+    #[test]
+    fn load_is_atomic_on_error() {
+        let mut eval = locals_eval();
+        let tokens = parse("[ 1 ] :a :2x").unwrap();
+        assert!(eval.load(&tokens).is_err());
+        assert!(
+            !eval.has_definition("a"),
+            "a failed load must not leave earlier definitions behind"
+        );
+
+        let tokens = parse("[first] :x [second] :x").unwrap();
+        assert!(eval.load(&tokens).is_err());
+        assert!(!eval.has_definition("x"));
     }
 
     #[test]


### PR DESCRIPTION
load inserted each definition as its binder validated, so a stream
with a later invalid binder ([ 1 ] :a :2x) errored while leaving :a
defined — the REPL was transactional only because it cloned first.
Stage every (name, body) pair during the validation walk (checking
redefinition against both the live table and the staged set) and
insert only after the whole stream validates.

Co-authored-by: AI
