### PR TITLE
docs(caternary): record the bitwise value-domain gap in the gate

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -132,6 +132,13 @@ definitions, and runs the whole-program checker. A checked program must define
 printf '[ 1 2 + ] :main\n' | caternary check
 ```
 
+A green gate proves stack shapes and refinement obligations — it is not a
+proof that every builtin accepts every value in its `Num` domain. The bitwise
+builtins (`|`/`&`/`^`/`<<`/`>>`/`~`) are typed `( Num Num -- Num )` under the
+single-`Num` decision but demand integer-valued operands at runtime, so
+`[ 1 0.5 | ] :main` passes `check` and fails when run (documented on
+`register_scalar_builtins`).
+
 `caternary repl` starts the development REPL. Normal input is parsed, loaded,
 and evaluated against a persistent definition table and stack. Definition pairs
 such as `[ 1 + ] :inc` are loaded but not pushed onto the runtime stack.

--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -15,16 +15,13 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 
 (none open)
 
-### Builtin contracts overpromise (green gate ≠ crash-free)
+### Builtin contracts overpromise (green gate ≠ crash-free) — documented
 
-- Bitwise ops carry `( Num Num -- Num )` contracts but reject fractional
-  values at runtime: `[ 1 0.5 | ] :main` passes `caternary check`, then fails
-  with ``expected integer value, found `0.5` ``. Consequence of ratified
-  decision (a) (one `Num`, no Int/Float split), but currently undischarged:
-  nothing in Tier 1 demands "integer-valued" for `|`/`&`/`^`/`<<`/`>>`/`~`.
-- Fix direction: either attach Tier-1 refinements demanding integrality
-  (needs floor/frac predicates) or document explicitly that gate-green
-  programs can still fail at runtime on value domains.
+- Resolved by documentation (the ratified single-`Num` decision stands and
+  the predicate language has no floor/frac): the gap is recorded on
+  `register_scalar_builtins` and in the README's `caternary check` section.
+  Embedders needing integrality in the gate should attest their own bitwise
+  contracts. Revisit if the refinement language grows floor/frac predicates.
 
 ## Low / polish
 

--- a/caternary/src/builtins.rs
+++ b/caternary/src/builtins.rs
@@ -540,6 +540,20 @@ where
 ///
 /// Arithmetic operators use the language's single `Num` type. Bitwise operators
 /// accept integer-valued `Num` lexemes at runtime and reject fractional values.
+///
+/// # Recorded limitation: bitwise contracts overpromise (gate-green ≠ crash-free)
+///
+/// The bitwise operators (`|`/`&`/`^`/`<<`/`>>`/`~`) are attested at
+/// `( Num Num -- Num )` — a consequence of the ratified single-`Num` decision
+/// (no Int/Float split) — but their runtime demands **integer-valued**
+/// operands: `[ 1 0.5 | ] :main` passes `caternary check` and then fails at
+/// runtime with ``expected integer value, found `0.5` ``. Nothing in Tier 1
+/// demands integrality (the predicate language has no floor/frac), so this is
+/// an **explicitly documented** soundness gap of the builtin contract set: a
+/// green gate proves shape and refinement obligations, not freedom from
+/// value-domain rejections by these operators. Embedders who need the gate to
+/// carry that guarantee should register bitwise operators under their own
+/// attested, integrality-aware contracts instead of these.
 pub fn register_scalar_builtins<T>(evaluator: &mut Evaluator<T>)
 where
     T: Quotable,


### PR DESCRIPTION
The bitwise builtins are attested ( Num Num -- Num ) under the
ratified single-Num decision but demand integer-valued operands at
runtime, so [ 1 0.5 | ] :main passes caternary check and then fails
when run. Tier 1 cannot demand integrality (no floor/frac in the
predicate language), so record the gap explicitly: a doc section on
register_scalar_builtins and a README note under caternary check,
pointing embedders who need the guarantee to attest their own
integrality-aware contracts.

Co-authored-by: AI
