### PR TITLE
fix(caternary): report the outermost unmatched opening bracket

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -39,7 +39,7 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 - `SmtLibSolver::pop_scope` / `Z3Solver::pop_scope` guard base-scope
   underflow only with `debug_assert` (release: silent base pop, later
   `unwrap` panic).
-- `Parser::finish` reports the *innermost* unmatched `[`, not the outermost.
+
 
 ## Fixed-or-pinned elsewhere
 
@@ -66,6 +66,8 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   division is exact rational.
 - `Evaluator::load` atomicity: pinned by
   `evaluator::tests::load_is_atomic_on_error`.
+- `Parser::finish` reports the outermost unmatched `[`: pinned by
+  `parser::tests::unmatched_open_bracket_reports_the_outermost`.
 - Ghost / duplicate `@name` annotations rejected at load: pinned by
   `evaluator::tests::ghost_annotation_is_rejected_at_load` and
   `evaluator::tests::duplicate_annotation_is_rejected_at_load`.

--- a/caternary/src/parser.rs
+++ b/caternary/src/parser.rs
@@ -258,15 +258,23 @@ impl Parser {
     }
 
     fn finish(mut self) -> Result<Vec<SpannedToken>, ParseError> {
-        if let Some(frame) = self.frames.pop() {
-            if let Some(open_start) = frame.open_bracket {
-                return Err(ParseError::UnmatchedOpenBracket {
-                    span: Span::point(open_start),
-                });
-            }
-            return Ok(frame.tokens);
+        // Report the OUTERMOST unmatched `[`: with `[ [ [` open, the bracket
+        // the user must close (or that was opened by mistake) is the first
+        // one, and everything after it is properly nested inside.
+        if let Some(open_start) = self
+            .frames
+            .iter()
+            .find_map(|frame| frame.open_bracket)
+        {
+            return Err(ParseError::UnmatchedOpenBracket {
+                span: Span::point(open_start),
+            });
         }
-        unreachable!("parser always has a root frame");
+        let root = self.frames.drain(..).next();
+        match root {
+            Some(frame) => Ok(frame.tokens),
+            None => unreachable!("parser always has a root frame"),
+        }
     }
 
     fn current_tokens(&mut self) -> &mut Vec<SpannedToken> {
@@ -673,6 +681,15 @@ mod tests {
             err.to_string(),
             "unmatched opening bracket '[' at byte 0".to_string()
         );
+    }
+
+    /// With several brackets left open, the error names the OUTERMOST one —
+    /// the bracket the user must actually close — not the innermost.
+    #[test]
+    fn unmatched_open_bracket_reports_the_outermost() {
+        let err = parse("a [ b [ c [ d").unwrap_err();
+        assert!(matches!(err, ParseError::UnmatchedOpenBracket { .. }));
+        assert_eq!(err.span(), Span { start: 2, end: 3 });
     }
 
     #[test]

--- a/caternary/src/parser.rs
+++ b/caternary/src/parser.rs
@@ -261,11 +261,7 @@ impl Parser {
         // Report the OUTERMOST unmatched `[`: with `[ [ [` open, the bracket
         // the user must close (or that was opened by mistake) is the first
         // one, and everything after it is properly nested inside.
-        if let Some(open_start) = self
-            .frames
-            .iter()
-            .find_map(|frame| frame.open_bracket)
-        {
+        if let Some(open_start) = self.frames.iter().find_map(|frame| frame.open_bracket) {
             return Err(ParseError::UnmatchedOpenBracket {
                 span: Span::point(open_start),
             });

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -3408,8 +3408,8 @@ impl BigInt {
         debug_assert!(BigInt::cmp_mag(a, b) != std::cmp::Ordering::Less);
         let mut out = Vec::with_capacity(a.len());
         let mut borrow = 0i64;
-        for (i, &ai) in a.iter().enumerate() {
-            let x = ai as i64;
+        for (i, &limb) in a.iter().enumerate() {
+            let x = limb as i64;
             let y = b.get(i).copied().unwrap_or(0) as i64;
             let mut v = x - y - borrow;
             if v < 0 {


### PR DESCRIPTION
Parser::finish popped the innermost frame, so `a [ b [ c [ d` blamed
the last `[` — but the bracket the user must actually close (or opened
by mistake) is the first one; everything after it is properly nested
inside. Scan frames outside-in for the first unmatched open. Also
appease clippy on the BigInt borrow loop.

Co-authored-by: AI
