### PR TITLE
fix(caternary): hard-assert solver scope underflow in release

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -36,9 +36,7 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   break despite the M13 "bit-for-bit aligned" claim.
 - Refinement binder type names are unvalidated (`n: Banana` parses and is
   treated as a `Real`); only `Quote` is load-bearing.
-- `SmtLibSolver::pop_scope` / `Z3Solver::pop_scope` guard base-scope
-  underflow only with `debug_assert` (release: silent base pop, later
-  `unwrap` panic).
+
 
 
 ## Fixed-or-pinned elsewhere
@@ -66,6 +64,8 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   division is exact rational.
 - `Evaluator::load` atomicity: pinned by
   `evaluator::tests::load_is_atomic_on_error`.
+- `pop_scope` base underflow is a hard assert in all build profiles: pinned
+  by `solver::tests::smtlib_pop_scope_underflow_panics_with_its_name`.
 - `Parser::finish` reports the outermost unmatched `[`: pinned by
   `parser::tests::unmatched_open_bracket_reports_the_outermost`.
 - Ghost / duplicate `@name` annotations rejected at load: pinned by

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -375,7 +375,10 @@ impl Solver for SmtLibSolver {
     }
 
     fn pop_scope(&mut self) {
-        debug_assert!(
+        // A hard assert (not `debug_assert`): a release-mode base pop would
+        // silently drop the base scope and surface later as an unrelated
+        // `unwrap` panic. Fail here, at the misuse, with its name.
+        assert!(
             self.scopes.len() > 1,
             "pop_scope underflow: cannot pop the base scope"
         );
@@ -515,7 +518,9 @@ impl Solver for Z3Solver {
     }
 
     fn pop_scope(&mut self) {
-        debug_assert!(
+        // See `SmtLibSolver::pop_scope`: hard assert so release-mode misuse
+        // fails at the pop, not at a later unwrap.
+        assert!(
             self.scopes.len() > 1,
             "pop_scope underflow: cannot pop the base scope"
         );
@@ -3865,6 +3870,15 @@ mod tests {
         // Exactly one push and one pop here (parity).
         assert_eq!(script.matches("(push 1)").count(), 1);
         assert_eq!(script.matches("(pop 1)").count(), 1);
+    }
+
+    /// Base-scope underflow is a hard, named panic in every build profile —
+    /// never a silent base pop that surfaces later as an unrelated `unwrap`.
+    #[test]
+    #[should_panic(expected = "pop_scope underflow")]
+    fn smtlib_pop_scope_underflow_panics_with_its_name() {
+        let mut s = SmtLibSolver::new();
+        s.pop_scope();
     }
 
     #[test]


### PR DESCRIPTION
SmtLibSolver::pop_scope and Z3Solver::pop_scope guarded base-scope
underflow with debug_assert only: a release build silently popped the
base scope and panicked later at an unrelated unwrap. Promote to a
hard assert so misuse fails at the pop, named, in every profile.

Co-authored-by: AI
