### PR TITLE
fix(caternary): validate refinement binder type names

### DIFF
--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -30,8 +30,7 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   via `assume(...)` and the four builtin arith axioms. If the surface is meant
   to be user-writable, add a source channel (and teach `check_command`).
 
-- Refinement binder type names are unvalidated (`n: Banana` parses and is
-  treated as a `Real`); only `Quote` is load-bearing.
+
 
 
 
@@ -60,6 +59,8 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   division is exact rational.
 - `Evaluator::load` atomicity: pinned by
   `evaluator::tests::load_is_atomic_on_error`.
+- Refinement binder type names validated (`Num`/`Bool`/`List`/quote arrow):
+  pinned by `refinement::tests::unknown_binder_type_is_rejected`.
 - Numeric-lexeme parity: the refinement lexer rejects trailing-dot literals,
   `Rat::parse` handles scientific notation exactly (capped exponent), and
   `render_smtlib` canonicalizes numerals into valid SMT-LIB. Pinned by

--- a/caternary/src/refinement.rs
+++ b/caternary/src/refinement.rs
@@ -862,6 +862,21 @@ impl<'a> Parser<'a> {
                 ));
             }
         };
+        // Validate the surface type name: only the recognized scalar surface
+        // types are admitted (`Quote` arrives via the arrow form above, never
+        // as a bare identifier). An unknown name (`n: Banana`) used to parse
+        // and be silently treated as a `Real` — a typo'd type must be a
+        // located error instead.
+        const SCALAR_SURFACE_TYPES: &[&str] = &["Num", "Bool", "List"];
+        if !SCALAR_SURFACE_TYPES.contains(&ty.as_str()) {
+            return Err(RefineParseError::new(
+                format!(
+                    "unknown binder type `{ty}`: expected one of \
+                     `Num`, `Bool`, `List`, or a `( … -- … )` quotation contract"
+                ),
+                ty_span,
+            ));
+        }
         Ok(Binder {
             name,
             ty,
@@ -1214,6 +1229,18 @@ mod tests {
             "error should be inside the quotation contract, got {:?}",
             err.span
         );
+    }
+
+    /// An unknown binder type name is a located error: `n: Banana` used to
+    /// parse and be silently treated as a `Real`, so a typo'd type never
+    /// surfaced.
+    #[test]
+    fn unknown_binder_type_is_rejected() {
+        let src = "f : ( n: Banana -- r: Num )";
+        let err = parse_signature(src).expect_err("unknown binder type must error");
+        assert!(err.to_string().contains("unknown binder type `Banana`"));
+        let start = src.find("Banana").unwrap();
+        assert_eq!(err.span, RefineSpan::new(start, start + "Banana".len()));
     }
 
     /// A trailing-dot literal (`1.`) is a located lex error: `render_smtlib`


### PR DESCRIPTION
A scalar binder type was stored as whatever identifier followed the
colon: n: Banana parsed and was silently treated as a Real, so a
typo'd type name never surfaced. Admit only the recognized scalar
surface types (Num, Bool, List) — Quote arrives via the ( ... -- ... )
arrow form — and reject anything else with a located error naming the
valid set.

Co-authored-by: AI
