### PR TITLE
feat(caternary): source channel for refinement signatures

### DIFF
--- a/caternary/README.md
+++ b/caternary/README.md
@@ -132,6 +132,17 @@ definitions, and runs the whole-program checker. A checked program must define
 printf '[ 1 2 + ] :main\n' | caternary check
 ```
 
+Programs can attach a Tier-1 refinement signature to a definition from source
+text: one quoted top-level word in the signature grammar, a sibling of the
+`[ body ] :name` definition it refines. The gate proves the guarantee through
+the body (it is never taken on faith); operator axioms remain embedder-only
+(`attach_refinement`):
+
+```sh
+printf '[ 1 + ] :inc\n"inc : ( n: Num -- r: Num where r >= n + 1 )"\n[ 2 inc ] :main\n' \
+  | caternary check
+```
+
 A green gate proves stack shapes and refinement obligations — it is not a
 proof that every builtin accepts every value in its `Num` domain. The bitwise
 builtins (`|`/`&`/`^`/`<<`/`>>`/`~`) are typed `( Num Num -- Num )` under the

--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -25,12 +25,7 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 
 ## Low / polish
 
-- Refinement signatures are Rust-API-only (`attach_refinement`); the binary
-  never parses them, so through `caternary check` Tier 1 is exercisable only
-  via `assume(...)` and the four builtin arith axioms. If the surface is meant
-  to be user-writable, add a source channel (and teach `check_command`).
-
-
+(none open)
 
 
 
@@ -59,6 +54,11 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
   division is exact rational.
 - `Evaluator::load` atomicity: pinned by
   `evaluator::tests::load_is_atomic_on_error`.
+- Refinement-signature source channel (a quoted top-level word of the §10.1
+  grammar, load-attached, definitions-only): pinned by
+  `evaluator::tests::signature_word_attaches_a_refinement_at_load` and
+  `check::tests::source_attached_signature_{discharges_through_the_gate,
+  rejects_a_violating_body}`.
 - Refinement binder type names validated (`Num`/`Bool`/`List`/quote arrow):
   pinned by `refinement::tests::unknown_binder_type_is_rejected`.
 - Numeric-lexeme parity: the refinement lexer rejects trailing-dot literals,

--- a/caternary/src/bin/caternary.rs
+++ b/caternary/src/bin/caternary.rs
@@ -580,11 +580,18 @@ fn expect_no_positionals(command: &str, free: &[String]) -> Result<()> {
 
 fn repl_runtime_tokens(tokens: &[SpannedToken]) -> Vec<Token> {
     let mut skip = vec![false; tokens.len()];
-    for i in 1..tokens.len() {
+    for i in 0..tokens.len() {
         let SpannedTokenKind::Word(word) = &tokens[i].kind else {
             continue;
         };
-        if (is_definition_binder(word) || is_annotation_binder(word))
+        // A refinement-signature word (`"name : ( … -- … )"`) is a load-only
+        // directive, like the definition/annotation pairs below.
+        if is_signature_word(word) {
+            skip[i] = true;
+            continue;
+        }
+        if i > 0
+            && (is_definition_binder(word) || is_annotation_binder(word))
             && matches!(tokens[i - 1].kind, SpannedTokenKind::Bracket(_))
         {
             skip[i - 1] = true;
@@ -605,6 +612,12 @@ fn is_definition_binder(word: &str) -> bool {
 
 fn is_annotation_binder(word: &str) -> bool {
     word.strip_prefix('@').is_some_and(is_name)
+}
+
+/// Mirrors the loader's refinement-signature marker (`evaluator.rs`): only a
+/// quoted word can contain ` : (`, so ordinary program words never match.
+fn is_signature_word(word: &str) -> bool {
+    word.contains(" : (")
 }
 
 fn is_name(name: &str) -> bool {

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -2112,6 +2112,42 @@ mod tests {
     }
 
     // =======================================================================
+    // The Tier-1 refinement source channel reaches the whole-program gate
+    // (`caternary check` loads with `load_with_spans`, which attaches
+    // signature words; the gate proves each guarantee through its body)
+    // =======================================================================
+
+    #[test]
+    fn source_attached_signature_discharges_through_the_gate() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let src = r#"[ 1 + ] :inc
+                     "inc : ( n: Num -- r: Num where r >= n + 1 )"
+                     [ 2 inc ] :main"#;
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_ok(),
+            "the body proves the source-attached guarantee"
+        );
+    }
+
+    #[test]
+    fn source_attached_signature_rejects_a_violating_body() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let src = r#"[ 1 + ] :inc
+                     "inc : ( n: Num -- r: Num where r > n + 1 )"
+                     [ 2 inc ] :main"#;
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_err(),
+            "a guarantee the body refutes must fail the gate"
+        );
+    }
+
+    // =======================================================================
     // Regression: `assume(...)` must be a runtime no-op
     // =======================================================================
 

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -75,6 +75,17 @@ fn has_def_prefix(w: &str) -> bool {
     w.starts_with(':')
 }
 
+/// Is this top-level word a **refinement-signature attachment attempt**?
+/// The recorded Tier-1 source surface is one (quoted) word of the §10.1
+/// signature grammar — `name : ( … -- … )` — and the ` : (` infix is its
+/// cheap marker: only a quoted word can contain it (shell splitting would
+/// otherwise break it apart), so ordinary program words never match. The full
+/// grammar (`crate::parse_signature`) decides validity; a marked word that
+/// fails to parse is a located load error.
+pub(crate) fn is_signature_attempt(word: &str) -> bool {
+    word.contains(" : (")
+}
+
 fn is_local_name(name: &str) -> bool {
     let mut chars = name.chars();
     let Some(first) = chars.next() else {
@@ -601,8 +612,52 @@ impl<T> Evaluator<T> {
             }
         }
 
+        // Validate the stream's **refinement-signature words** — the recorded
+        // Tier-1 source channel (§10.1). The surface is one (quoted) top-level
+        // word in the signature grammar, `name : ( … -- … )`, a sibling of
+        // `[ body ] :name` and `[ effect ] @name`; the ` : (` infix marks the
+        // attempt and the full grammar decides validity, so a malformed
+        // attempt is a located error, never silently an ordinary word. A
+        // source-channel signature may only name a **definition** (its
+        // guarantee is *proven through the body* by the gate); it can never
+        // axiomize an operator — operator axioms remain the embedder's
+        // explicit attestation (`attach_refinement`, invariant 16).
+        let mut stream_sigs: Vec<crate::RefinementSig> = Vec::new();
+        for tok in tokens {
+            if let SpannedTokenKind::Word(w) = &tok.kind
+                && is_signature_attempt(w)
+            {
+                let sig = crate::parse_signature(w).map_err(|e| {
+                    definition_error(format!("malformed refinement signature: {e}"))
+                })?;
+                if self.refinements.contains_key(&sig.name)
+                    || stream_sigs.iter().any(|s| s.name == sig.name)
+                {
+                    return Err(definition_error(format!(
+                        "duplicate refinement signature: `{}` is already refined",
+                        sig.name
+                    )));
+                }
+                if !stream_defs.contains(sig.name.as_str())
+                    && !self.definitions.contains_key(&sig.name)
+                {
+                    return Err(definition_error(format!(
+                        "refinement signature for `{}` has no definition to refine \
+                         (operator axioms are attached by the embedder, not source text)",
+                        sig.name
+                    )));
+                }
+                stream_sigs.push(sig);
+            }
+        }
+
         // Validate and populate the runtime table through the existing path.
         self.load(&spanless)?;
+
+        // The stream validated end to end: attach its refinement signatures.
+        for sig in stream_sigs {
+            self.refinements.insert(sig.name.clone(), sig);
+        }
 
         // Re-walk the spanned top level to capture each definition's spanned
         // body. Validation already succeeded above, so the binder pairing is
@@ -1670,6 +1725,66 @@ mod tests {
         let eval = locals_eval();
         let tokens = parse("[5 >x] CALL [x] CALL").unwrap();
         assert_eq!(eval.eval(&tokens).unwrap(), vec![word("x")]);
+    }
+
+    // =======================================================================
+    // The Tier-1 refinement-signature source channel (one quoted word of the
+    // §10.1 grammar at top level, attached at load)
+    // =======================================================================
+
+    #[test]
+    fn signature_word_attaches_a_refinement_at_load() {
+        let mut eval = locals_eval();
+        let src = r#"[ 1 ADD ] :inc "inc : ( n: Num -- r: Num where r > n )""#;
+        let tokens = crate::parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        let sig = eval.refinement("inc").expect("signature attached");
+        assert_eq!(sig.demands.binders[0].name, "n");
+        assert_eq!(sig.guarantees.binders[0].name, "r");
+    }
+
+    /// A signature naming nothing is rejected: definitions only — operator
+    /// axioms remain the embedder's explicit attestation (invariant 16).
+    #[test]
+    fn signature_word_for_an_undefined_name_is_rejected() {
+        let mut eval = locals_eval();
+        let src = r#""ghost : ( n: Num -- r: Num )" [ 0 ] :main"#;
+        let tokens = crate::parse_with_spans(src).unwrap();
+        let err = eval.load_with_spans(&tokens).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("refinement signature for `ghost` has no definition")
+        );
+        assert!(!eval.has_definition("main"), "load stays atomic");
+    }
+
+    #[test]
+    fn duplicate_signature_word_is_rejected() {
+        let mut eval = locals_eval();
+        let src = r#"[ 1 ADD ] :inc
+                     "inc : ( n: Num -- r: Num )"
+                     "inc : ( n: Num -- r: Num where r > n )""#;
+        let tokens = crate::parse_with_spans(src).unwrap();
+        let err = eval.load_with_spans(&tokens).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("duplicate refinement signature: `inc`")
+        );
+    }
+
+    /// A marked-but-malformed signature word is a load error, never silently
+    /// an ordinary word.
+    #[test]
+    fn malformed_signature_word_is_rejected() {
+        let mut eval = locals_eval();
+        let src = r#"[ 1 ADD ] :inc "inc : ( n: Banana -- r: Num )""#;
+        let tokens = crate::parse_with_spans(src).unwrap();
+        let err = eval.load_with_spans(&tokens).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("malformed refinement signature"),
+            "got: {err}"
+        );
     }
 
     /// A **ghost** annotation — `@name` with no `:name` definition anywhere —

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -1781,8 +1781,7 @@ mod tests {
         let tokens = crate::parse_with_spans(src).unwrap();
         let err = eval.load_with_spans(&tokens).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("malformed refinement signature"),
+            err.to_string().contains("malformed refinement signature"),
             "got: {err}"
         );
     }


### PR DESCRIPTION
Refinement signatures were Rust-API-only (attach_refinement); the
binary never parsed them, so through caternary check Tier 1 was
exercisable only via assume(...) and the builtin arithmetic axioms.

Record a source surface: one quoted top-level word in the §10.1
signature grammar — "inc : ( n: Num -- r: Num where r >= n + 1 )" —
a sibling of the [ body ] :name definition it refines. The " : ("
infix marks the attempt (only a quoted word can contain it) and the
full grammar decides validity: a malformed attempt is a located load
error, never silently an ordinary word. load_with_spans validates
before mutating (atomic), rejects duplicates, and restricts the
channel to definitions — the gate proves each guarantee through the
body, so source text can never mint an operator axiom (invariant 16,
embedder-only attach_refinement). The REPL treats signature words as
load-only directives, like definition and annotation pairs.

Tests pin load attachment, ghost/duplicate/malformed rejection, and
both gate directions end to end; the README documents the surface.

Co-authored-by: AI
