### PR TITLE
feat(sstdb): support client-supplied strictly-increasing timestamps

### DIFF
--- a/sstdb/src/db.rs
+++ b/sstdb/src/db.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use sst::Builder;
 use sst::log::WriteBatch;
 
-use crate::fragment::{SSTDB_TIMESTAMP, check_batch, decode, encode};
+use crate::fragment::{check_batch, decode, encode};
 use crate::reader::{DEFAULT_WINDOW, Reader};
 use crate::snapshot::Snapshot;
 use crate::store::{ConditionalStore, WriteOutcome};
@@ -160,24 +160,29 @@ impl Database {
         }
     }
 
-    /// Convenience: write a single key/value.
+    /// Convenience: write a single key/value at a client-supplied `timestamp`.  The timestamp must
+    /// be strictly greater than the highest timestamp the database has incorporated; `write`
+    /// enforces this and returns an `invalid-timestamp` [`SError`] otherwise.
     pub async fn put(
         &self,
         key: impl Into<Vec<u8>>,
         value: impl Into<Vec<u8>>,
+        timestamp: u64,
     ) -> Result<LogPosition> {
         let key = key.into();
         let value = value.into();
         let mut batch = WriteBatch::new();
-        batch.put(&key, SSTDB_TIMESTAMP, &value)?;
+        batch.put(&key, timestamp, &value)?;
         self.write(&batch).await
     }
 
-    /// Convenience: delete a single key.
-    pub async fn delete(&self, key: impl Into<Vec<u8>>) -> Result<LogPosition> {
+    /// Convenience: delete a single key at a client-supplied `timestamp`.  The timestamp must be
+    /// strictly greater than the highest timestamp the database has incorporated; `write` enforces
+    /// this and returns an `invalid-timestamp` [`SError`] otherwise.
+    pub async fn delete(&self, key: impl Into<Vec<u8>>, timestamp: u64) -> Result<LogPosition> {
         let key = key.into();
         let mut batch = WriteBatch::new();
-        batch.del(&key, SSTDB_TIMESTAMP)?;
+        batch.del(&key, timestamp)?;
         self.write(&batch).await
     }
 
@@ -313,18 +318,28 @@ impl Transaction {
         self.snapshot.get(key)
     }
 
-    /// Stage a put.
-    pub fn put(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Result<&mut Self> {
+    /// Stage a put at a client-supplied `timestamp`.  The timestamp must be strictly greater than
+    /// the highest timestamp incorporated at the transaction's read-version; `commit` enforces this
+    /// (against the captured snapshot's high-water mark) and returns an `invalid-timestamp`
+    /// [`SError`] otherwise.
+    pub fn put(
+        &mut self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+        timestamp: u64,
+    ) -> Result<&mut Self> {
         let key = key.into();
         let value = value.into();
-        self.batch.put(&key, SSTDB_TIMESTAMP, &value)?;
+        self.batch.put(&key, timestamp, &value)?;
         Ok(self)
     }
 
-    /// Stage a delete.
-    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Result<&mut Self> {
+    /// Stage a delete at a client-supplied `timestamp`.  The timestamp must be strictly greater
+    /// than the highest timestamp incorporated at the transaction's read-version; `commit` enforces
+    /// this and returns an `invalid-timestamp` [`SError`] otherwise.
+    pub fn delete(&mut self, key: impl Into<Vec<u8>>, timestamp: u64) -> Result<&mut Self> {
         let key = key.into();
-        self.batch.del(&key, SSTDB_TIMESTAMP)?;
+        self.batch.del(&key, timestamp)?;
         Ok(self)
     }
 
@@ -382,3 +397,64 @@ impl Transaction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::ObjectStoreConditional;
+
+    fn db() -> Database {
+        Database::open(
+            Arc::new(ObjectStoreConditional::in_memory()),
+            DatabaseOptions {
+                window: Duration::from_millis(0),
+                ..DatabaseOptions::default()
+            },
+        )
+    }
+
+    /// The full S-expression [`handled::SError`] emits for an `invalid-timestamp` rejection, with
+    /// `ts` the offending entry's timestamp and `hwm` the high-water mark it failed to beat.  We
+    /// assert the exact serialized form rather than a substring, so a wrong code or field shows up
+    /// as a concrete diff.
+    fn invalid_timestamp_sexp(ts: u64, hwm: u64) -> String {
+        format!(
+            "(error (phase sstdb) (code invalid-timestamp) \
+             (message \"sstdb write batches must use strictly-increasing timestamps\") \
+             (timestamp {ts}) (high-water-mark {hwm}))"
+        )
+    }
+
+    #[tokio::test]
+    async fn put_enforces_strictly_increasing_timestamps() {
+        let db = db();
+        // The genesis high-water mark is 0, so timestamp 0 is rejected.
+        let err = db.put(b"k", b"v", 0).await.unwrap_err();
+        assert_eq!(format!("{err}"), invalid_timestamp_sexp(0, 0));
+        // A strictly-increasing sequence is accepted and readable.
+        let p1 = db.put(b"k", b"v1", 1).await.unwrap();
+        assert_eq!(p1.offset, 1);
+        assert_eq!(db.get(b"k").await.unwrap(), Some(b"v1".to_vec()));
+        let p2 = db.put(b"k", b"v2", 2).await.unwrap();
+        assert_eq!(p2.offset, 2);
+        assert_eq!(db.get(b"k").await.unwrap(), Some(b"v2".to_vec()));
+        assert_eq!(db.snapshot().await.unwrap().timestamp_hi(), 2);
+        // Reusing the last timestamp is rejected.
+        let err = db.put(b"k", b"v3", 2).await.unwrap_err();
+        assert_eq!(format!("{err}"), invalid_timestamp_sexp(2, 2));
+        // Going backwards is rejected.
+        let err = db.put(b"k", b"v3", 1).await.unwrap_err();
+        assert_eq!(format!("{err}"), invalid_timestamp_sexp(1, 2));
+    }
+
+    #[tokio::test]
+    async fn delete_carries_a_timestamp() {
+        let db = db();
+        db.put(b"k", b"v", 1).await.unwrap();
+        assert_eq!(db.get(b"k").await.unwrap(), Some(b"v".to_vec()));
+        db.delete(b"k", 2).await.unwrap();
+        assert_eq!(db.get(b"k").await.unwrap(), None);
+        assert_eq!(db.snapshot().await.unwrap().timestamp_hi(), 2);
+    }
+}
+

--- a/sstdb/src/db.rs
+++ b/sstdb/src/db.rs
@@ -457,4 +457,3 @@ mod tests {
         assert_eq!(db.snapshot().await.unwrap().timestamp_hi(), 2);
     }
 }
-

--- a/sstdb/src/fragment.rs
+++ b/sstdb/src/fragment.rs
@@ -12,10 +12,7 @@
 use sst::log::WriteBatch;
 use sst::{Builder, KeyValueRef, LogBuilder, LogIterator, LogOptions};
 
-use crate::{META_PREFIX_LEN, Result, invalid_timestamp, reserved_key};
-
-/// sstdb materializes exactly one user-visible version in the SST.
-pub(crate) const SSTDB_TIMESTAMP: u64 = 0;
+use crate::{META_PREFIX_LEN, Result, reserved_key};
 
 /// Returns true if `key` is in the reserved meta-key range (begins with [`META_PREFIX_LEN`]
 /// `0xff` bytes).
@@ -24,16 +21,15 @@ pub fn is_reserved_key(key: &[u8]) -> bool {
 }
 
 fn check_entry(kvr: &KeyValueRef<'_>) -> Result<()> {
-    if kvr.timestamp != SSTDB_TIMESTAMP {
-        return Err(invalid_timestamp(kvr.timestamp));
-    }
     if is_reserved_key(kvr.key) {
         return Err(reserved_key());
     }
     Ok(())
 }
 
-/// Reject the batch if any entry targets a reserved meta key or uses a non-zero timestamp.
+/// Reject the batch if any entry targets a reserved meta key.  Timestamp ordering is not checked
+/// here: a single fragment carries no history, so the strictly-increasing invariant is enforced
+/// against the database's high-water mark in [`crate::snapshot::Snapshot::apply`].
 pub(crate) fn check_batch(batch: &WriteBatch) -> Result<()> {
     let mut iter = batch.iter();
     while let Some(kvr) = iter.next()? {
@@ -74,9 +70,9 @@ mod tests {
     #[test]
     fn round_trip() {
         let mut batch = WriteBatch::new();
-        batch.put(b"a", SSTDB_TIMESTAMP, b"1").unwrap();
-        batch.del(b"b", SSTDB_TIMESTAMP).unwrap();
-        batch.put(b"c", SSTDB_TIMESTAMP, b"").unwrap();
+        batch.put(b"a", 1, b"1").unwrap();
+        batch.del(b"b", 2).unwrap();
+        batch.put(b"c", 3, b"").unwrap();
         let bytes = encode(&batch).unwrap();
         let back = decode(&bytes).unwrap();
         assert_eq!(batch, back);
@@ -97,7 +93,7 @@ mod tests {
     #[test]
     fn small_fragment_is_compact() {
         let mut batch = WriteBatch::new();
-        batch.put(b"a", SSTDB_TIMESTAMP, b"1").unwrap();
+        batch.put(b"a", 1, b"1").unwrap();
         let bytes = encode(&batch).unwrap();
         assert!(!bytes.is_empty());
         // Far below the 1 MiB block boundary: no block-sized padding crept in.
@@ -112,17 +108,20 @@ mod tests {
     #[test]
     fn reserved_detection() {
         let mut batch = WriteBatch::new();
-        batch.put(&[0xff; 6], SSTDB_TIMESTAMP, b"x").unwrap();
+        batch.put(&[0xff; 6], 1, b"x").unwrap();
         assert!(check_batch(&batch).is_err());
         let mut ok = WriteBatch::new();
-        ok.put(&[0xff; 4], SSTDB_TIMESTAMP, b"x").unwrap();
+        ok.put(&[0xff; 4], 1, b"x").unwrap();
         assert!(check_batch(&ok).is_ok());
     }
 
+    /// `check_batch` validates only the reserved-key range.  Non-zero timestamps are accepted here:
+    /// the strictly-increasing invariant needs the database's high-water mark, so it is enforced in
+    /// `Snapshot::apply`, not per-fragment.
     #[test]
-    fn timestamp_detection() {
+    fn nonzero_timestamp_accepted_by_check_batch() {
         let mut batch = WriteBatch::new();
         batch.put(b"a", 1, b"x").unwrap();
-        assert!(check_batch(&batch).is_err());
+        assert!(check_batch(&batch).is_ok());
     }
 }

--- a/sstdb/src/lib.rs
+++ b/sstdb/src/lib.rs
@@ -68,13 +68,17 @@ pub(crate) fn reserved_key() -> SError {
         .with_message("key is in the reserved meta-key range")
 }
 
-/// A client-supplied [`WriteBatch`] used a timestamp other than sstdb's materialized timestamp 0
-/// (code `invalid-timestamp`).
-pub(crate) fn invalid_timestamp(timestamp: u64) -> SError {
+/// A client-supplied [`WriteBatch`] used a timestamp that was not strictly greater than the
+/// database's high-water mark (code `invalid-timestamp`).  sstdb requires every write's timestamp
+/// to exceed the highest timestamp it has incorporated, so the timestamps form a strictly
+/// increasing total order supplied by the client and enforced by the database.  `timestamp` is the
+/// offending entry's timestamp; `high_water_mark` is the value it had to beat.
+pub(crate) fn invalid_timestamp(timestamp: u64, high_water_mark: u64) -> SError {
     SError::new(ERROR_PHASE)
         .with_code("invalid-timestamp")
-        .with_message("sstdb write batches must use timestamp 0")
+        .with_message("sstdb write batches must use strictly-increasing timestamps")
         .with_atom_field("timestamp", timestamp)
+        .with_atom_field("high-water-mark", high_water_mark)
 }
 
 /// A loaded SST's recomputed setsum did not match its stamped setsum: corruption (code

--- a/sstdb/src/snapshot.rs
+++ b/sstdb/src/snapshot.rs
@@ -171,7 +171,9 @@ impl Snapshot {
 
     /// Iterate over all live user key/value pairs in sorted order.
     pub fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
-        self.map.iter().map(|(k, (_, v))| (k.as_slice(), v.as_slice()))
+        self.map
+            .iter()
+            .map(|(k, (_, v))| (k.as_slice(), v.as_slice()))
     }
 
     /// Produce a new snapshot with `batch` applied and `log_hi` advanced to `offset`.
@@ -199,7 +201,9 @@ impl Snapshot {
             high_water_mark = kvr.timestamp;
             match kvr.value {
                 Some(value) => {
-                    if let Some((_, old)) = map.insert(kvr.key.to_vec(), (kvr.timestamp, value.to_vec())) {
+                    if let Some((_, old)) =
+                        map.insert(kvr.key.to_vec(), (kvr.timestamp, value.to_vec()))
+                    {
                         setsum.remove(&setsum_item(kvr.key, &old));
                     }
                     setsum.insert(&setsum_item(kvr.key, value));

--- a/sstdb/src/snapshot.rs
+++ b/sstdb/src/snapshot.rs
@@ -23,9 +23,9 @@ use std::ops::Bound;
 use setsum::Setsum;
 use sst::file_manager::InMemoryFile;
 use sst::log::WriteBatch;
-use sst::{Builder, Cursor, Key, Sst, SstBuilder, SstOptions};
+use sst::{Builder, Cursor, Sst, SstBuilder, SstOptions};
 
-use crate::fragment::{SSTDB_TIMESTAMP, is_reserved_key};
+use crate::fragment::is_reserved_key;
 use crate::{
     META_PREFIX_LEN, Result, corruption, invalid_timestamp, reserved_key, setsum_mismatch,
 };
@@ -35,6 +35,7 @@ pub const META_PREFIX: [u8; META_PREFIX_LEN] = [0xff; META_PREFIX_LEN];
 
 const META_LOG_LO: &[u8] = b"/log_lo";
 const META_LOG_HI: &[u8] = b"/log_hi";
+const META_TIMESTAMP_HI: &[u8] = b"/timestamp_hi";
 const META_SETSUM: &[u8] = b"/setsum";
 
 /// All SSTs in sstdb share one fixed option set so that `apply` is byte-deterministic across
@@ -52,7 +53,9 @@ fn meta_key(suffix: &[u8]) -> Vec<u8> {
 }
 
 /// The framed setsum item for a single key/value pair.  Framing the key length prevents a key/value
-/// boundary ambiguity from aliasing distinct pairs into the same multiset element.
+/// boundary ambiguity from aliasing distinct pairs into the same multiset element.  The setsum is
+/// over the materialized user keyspace (key, value); the timestamp is an ordering token, not part
+/// of the materialized identity, so it is deliberately excluded.
 fn setsum_item(key: &[u8], value: &[u8]) -> Vec<u8> {
     let mut item = Vec::with_capacity(8 + key.len() + value.len());
     item.extend_from_slice(&(key.len() as u64).to_le_bytes());
@@ -61,23 +64,20 @@ fn setsum_item(key: &[u8], value: &[u8]) -> Vec<u8> {
     item
 }
 
-fn snapshot_key(key: &[u8]) -> Key {
-    Key {
-        key: key.to_vec(),
-        timestamp: SSTDB_TIMESTAMP,
-    }
-}
-
 /// The materialized database: the user keyspace plus the log metadata.
 #[derive(Clone, Debug)]
 pub struct Snapshot {
-    /// The live user keyspace, sorted.  Tombstones are not represented — a deleted key is simply
-    /// absent.
-    map: BTreeMap<Key, Vec<u8>>,
+    /// The live user keyspace, sorted by key.  Each entry carries the timestamp of the write that
+    /// last touched it; sstdb materializes exactly one version per key (the latest write wins), so
+    /// tombstones are not represented — a deleted key is simply absent.
+    map: BTreeMap<Vec<u8>, (u64, Vec<u8>)>,
     /// Lowest fragment offset still represented (0 for v1 without GC).
     log_lo: u64,
     /// Highest fragment offset incorporated.  The recovery anchor.
     log_hi: u64,
+    /// The highest timestamp incorporated.  The strictly-increasing high-water mark: every entry
+    /// of the next write must carry a timestamp greater than this.
+    timestamp_hi: u64,
     /// The setsum over the user keyspace.  Maintained incrementally by [`Snapshot::apply`].
     setsum: Setsum,
 }
@@ -89,12 +89,14 @@ impl Default for Snapshot {
 }
 
 impl Snapshot {
-    /// The genesis (empty) database: no user keys, `log_lo == log_hi == 0`.
+    /// The genesis (empty) database: no user keys, `log_lo == log_hi == 0`, and a timestamp
+    /// high-water mark of 0 (so the first write must use a timestamp strictly greater than 0).
     pub fn empty() -> Self {
         Snapshot {
             map: BTreeMap::new(),
             log_lo: 0,
             log_hi: 0,
+            timestamp_hi: 0,
             setsum: Setsum::default(),
         }
     }
@@ -107,6 +109,12 @@ impl Snapshot {
     /// Highest fragment offset incorporated.  The next offset to claim is `log_hi() + 1`.
     pub fn log_hi(&self) -> u64 {
         self.log_hi
+    }
+
+    /// The highest timestamp incorporated: the strictly-increasing high-water mark.  Every entry of
+    /// the next write must carry a timestamp greater than this value.
+    pub fn timestamp_hi(&self) -> u64 {
+        self.timestamp_hi
     }
 
     /// The next offset a writer would claim.
@@ -134,7 +142,7 @@ impl Snapshot {
         if is_reserved_key(key) {
             return None;
         }
-        self.map.get(&snapshot_key(key)).map(|v| v.as_slice())
+        self.map.get(key).map(|(_, v)| v.as_slice())
     }
 
     /// Range scan over the user keyspace, returning owned key/value pairs in sorted order.  Meta
@@ -145,55 +153,60 @@ impl Snapshot {
         E: AsRef<[u8]>,
     {
         let start = match &start {
-            Bound::Included(s) => Bound::Included(snapshot_key(s.as_ref())),
-            Bound::Excluded(s) => Bound::Excluded(snapshot_key(s.as_ref())),
+            Bound::Included(s) => Bound::Included(s.as_ref().to_vec()),
+            Bound::Excluded(s) => Bound::Excluded(s.as_ref().to_vec()),
             Bound::Unbounded => Bound::Unbounded,
         };
         let end = match &end {
-            Bound::Included(e) => Bound::Included(snapshot_key(e.as_ref())),
-            Bound::Excluded(e) => Bound::Excluded(snapshot_key(e.as_ref())),
+            Bound::Included(e) => Bound::Included(e.as_ref().to_vec()),
+            Bound::Excluded(e) => Bound::Excluded(e.as_ref().to_vec()),
             Bound::Unbounded => Bound::Unbounded,
         };
         self.map
             .range((start, end))
-            .filter(|(k, _)| !is_reserved_key(&k.key))
-            .map(|(k, v)| (k.key.clone(), v.clone()))
+            .filter(|(k, _)| !is_reserved_key(k))
+            .map(|(k, (_, v))| (k.clone(), v.clone()))
             .collect()
     }
 
     /// Iterate over all live user key/value pairs in sorted order.
     pub fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
-        self.map
-            .iter()
-            .map(|(k, v)| (k.key.as_slice(), v.as_slice()))
+        self.map.iter().map(|(k, (_, v))| (k.as_slice(), v.as_slice()))
     }
 
     /// Produce a new snapshot with `batch` applied and `log_hi` advanced to `offset`.
     ///
     /// This is the pure, deterministic rollup `apply(SST, fragment)` (Invariant 4).  The setsum is
     /// maintained incrementally: `setsum' = setsum + additions - removals` (§8).
+    ///
+    /// The client-supplied timestamps are enforced here, against the snapshot's high-water mark:
+    /// every entry of `batch` must carry a timestamp strictly greater than the last timestamp the
+    /// database incorporated (and strictly greater than the preceding entry of the same batch), so
+    /// the incorporated timestamps form a strictly increasing total order.  The high-water mark is
+    /// advanced to the batch's final timestamp.
     pub fn apply(&self, batch: &WriteBatch, offset: u64) -> Result<Snapshot> {
         let mut map = self.map.clone();
         let mut setsum = self.setsum;
+        let mut high_water_mark = self.timestamp_hi;
         let mut iter = batch.iter();
         while let Some(kvr) = iter.next()? {
-            if kvr.timestamp != SSTDB_TIMESTAMP {
-                return Err(invalid_timestamp(kvr.timestamp));
+            if kvr.timestamp <= high_water_mark {
+                return Err(invalid_timestamp(kvr.timestamp, high_water_mark));
             }
             if is_reserved_key(kvr.key) {
                 return Err(reserved_key());
             }
-            let key = snapshot_key(kvr.key);
+            high_water_mark = kvr.timestamp;
             match kvr.value {
                 Some(value) => {
-                    if let Some(old) = map.insert(key.clone(), value.to_vec()) {
-                        setsum.remove(&setsum_item(&key.key, &old));
+                    if let Some((_, old)) = map.insert(kvr.key.to_vec(), (kvr.timestamp, value.to_vec())) {
+                        setsum.remove(&setsum_item(kvr.key, &old));
                     }
-                    setsum.insert(&setsum_item(&key.key, value));
+                    setsum.insert(&setsum_item(kvr.key, value));
                 }
                 None => {
-                    if let Some(old) = map.remove(&key) {
-                        setsum.remove(&setsum_item(&key.key, &old));
+                    if let Some((_, old)) = map.remove(kvr.key) {
+                        setsum.remove(&setsum_item(kvr.key, &old));
                     }
                 }
             }
@@ -202,6 +215,7 @@ impl Snapshot {
             map,
             log_lo: self.log_lo,
             log_hi: offset,
+            timestamp_hi: high_water_mark,
             setsum,
         })
     }
@@ -210,20 +224,21 @@ impl Snapshot {
     /// loaded SST before building on it (§8).
     pub fn recompute_setsum(&self) -> Setsum {
         let mut s = Setsum::default();
-        for (k, v) in &self.map {
-            s.insert(&setsum_item(&k.key, v));
+        for (k, (_, v)) in &self.map {
+            s.insert(&setsum_item(k, v));
         }
         s
     }
 
     /// Serialize this snapshot to a real SST's bytes.  The meta keys are stamped from the
-    /// snapshot's own `log_lo`/`log_hi`/`setsum` (§8: stamping the setsum does not perturb it,
-    /// because meta keys are excluded from the setsum domain).
+    /// snapshot's own `log_lo`/`log_hi`/`timestamp_hi`/`setsum` (§8: stamping the setsum does not
+    /// perturb it, because meta keys are excluded from the setsum domain).
     pub fn to_sst_bytes(&self) -> Result<Vec<u8>> {
         let mut builder = SstBuilder::<Vec<u8>>::from_write(sst_options(), Vec::new());
-        // User keys first (already sorted), all at timestamp 0 for a single materialized version.
-        for (k, v) in &self.map {
-            builder.put(&k.key, k.timestamp, v)?;
+        // User keys first (already sorted), each stamped with the timestamp of the write that
+        // last touched it.
+        for (k, (timestamp, v)) in &self.map {
+            builder.put(k, *timestamp, v)?;
         }
         // Meta keys sort after all user keys; emit them in sorted order among themselves.
         let mut metas: Vec<(Vec<u8>, Vec<u8>)> = vec![
@@ -234,6 +249,10 @@ impl Snapshot {
             (
                 meta_key(META_LOG_HI),
                 format!("{:016x}", self.log_hi).into_bytes(),
+            ),
+            (
+                meta_key(META_TIMESTAMP_HI),
+                format!("{:016x}", self.timestamp_hi).into_bytes(),
             ),
             (meta_key(META_SETSUM), self.setsum.hexdigest().into_bytes()),
         ];
@@ -263,13 +282,11 @@ impl Snapshot {
         let mut map = BTreeMap::new();
         let mut log_lo: Option<u64> = None;
         let mut log_hi: Option<u64> = None;
+        let mut timestamp_hi: Option<u64> = None;
         let mut stamped_setsum: Option<String> = None;
 
         while let Some(kvr) = cursor.key_value() {
             let key = kvr.key;
-            if kvr.timestamp != SSTDB_TIMESTAMP {
-                return Err(invalid_timestamp(kvr.timestamp));
-            }
             if is_reserved_key(key) {
                 let suffix = &key[META_PREFIX_LEN..];
                 let value = kvr.value.unwrap_or(&[]);
@@ -277,6 +294,8 @@ impl Snapshot {
                     log_lo = Some(parse_hex_u64(value)?);
                 } else if suffix == META_LOG_HI {
                     log_hi = Some(parse_hex_u64(value)?);
+                } else if suffix == META_TIMESTAMP_HI {
+                    timestamp_hi = Some(parse_hex_u64(value)?);
                 } else if suffix == META_SETSUM {
                     stamped_setsum = Some(
                         std::str::from_utf8(value)
@@ -286,19 +305,23 @@ impl Snapshot {
                 }
                 // Unknown meta keys are ignored for forward compatibility.
             } else if let Some(v) = kvr.value {
-                map.insert(snapshot_key(key), v.to_vec());
+                map.insert(key.to_vec(), (kvr.timestamp, v.to_vec()));
             }
             cursor.next()?;
         }
 
         let log_lo = log_lo.ok_or_else(|| corruption("meta: missing log_lo"))?;
         let log_hi = log_hi.ok_or_else(|| corruption("meta: missing log_hi"))?;
+        // SSTs written before timestamps were tracked carry no `timestamp_hi` meta key; default to
+        // 0, the baseline from which strictly-increasing timestamps begin.
+        let timestamp_hi = timestamp_hi.unwrap_or(0);
         let stamped = stamped_setsum.ok_or_else(|| corruption("meta: missing setsum"))?;
 
         let snapshot = Snapshot {
             map,
             log_lo,
             log_hi,
+            timestamp_hi,
             setsum: Setsum::from_hexdigest(&stamped)
                 .ok_or_else(|| corruption("meta: setsum not valid hex"))?,
         };
@@ -330,6 +353,7 @@ mod tests {
         let back = Snapshot::from_sst_bytes(&bytes, true).unwrap();
         assert_eq!(back.log_lo(), 0);
         assert_eq!(back.log_hi(), 0);
+        assert_eq!(back.timestamp_hi(), 0);
         assert!(back.is_empty());
         assert_eq!(back.setsum().hexdigest(), Setsum::default().hexdigest());
     }
@@ -337,10 +361,11 @@ mod tests {
     #[test]
     fn apply_and_round_trip() {
         let mut batch = WriteBatch::new();
-        batch.put(b"alpha", SSTDB_TIMESTAMP, b"1").unwrap();
-        batch.put(b"beta", SSTDB_TIMESTAMP, b"2").unwrap();
+        batch.put(b"alpha", 1, b"1").unwrap();
+        batch.put(b"beta", 2, b"2").unwrap();
         let snap = Snapshot::empty().apply(&batch, 1).unwrap();
         assert_eq!(snap.log_hi(), 1);
+        assert_eq!(snap.timestamp_hi(), 2);
         assert_eq!(snap.get(b"alpha"), Some(&b"1"[..]));
 
         let bytes = snap.to_sst_bytes().unwrap();
@@ -348,6 +373,7 @@ mod tests {
         assert_eq!(back.get(b"alpha"), Some(&b"1"[..]));
         assert_eq!(back.get(b"beta"), Some(&b"2"[..]));
         assert_eq!(back.log_hi(), 1);
+        assert_eq!(back.timestamp_hi(), 2);
         // The stamped setsum survived the round trip and verifies.
         assert_eq!(back.setsum().hexdigest(), snap.setsum().hexdigest());
     }
@@ -355,13 +381,14 @@ mod tests {
     #[test]
     fn incremental_setsum_matches_recompute() {
         let mut batch = WriteBatch::new();
-        batch.put(b"a", SSTDB_TIMESTAMP, b"x").unwrap();
-        batch.put(b"b", SSTDB_TIMESTAMP, b"y").unwrap();
-        batch.put(b"a", SSTDB_TIMESTAMP, b"z").unwrap(); // overwrite
-        batch.del(b"b", SSTDB_TIMESTAMP).unwrap();
+        batch.put(b"a", 1, b"x").unwrap();
+        batch.put(b"b", 2, b"y").unwrap();
+        batch.put(b"a", 3, b"z").unwrap(); // overwrite
+        batch.del(b"b", 4).unwrap();
         let snap = Snapshot::empty().apply(&batch, 1).unwrap();
         assert_eq!(snap.get(b"a"), Some(&b"z"[..]));
         assert_eq!(snap.get(b"b"), None);
+        assert_eq!(snap.timestamp_hi(), 4);
         assert_eq!(
             snap.setsum().hexdigest(),
             snap.recompute_setsum().hexdigest()
@@ -375,5 +402,37 @@ mod tests {
         assert_eq!(snap.get(&META_PREFIX), None);
         let all = snap.scan::<&[u8], &[u8]>(Bound::Unbounded, Bound::Unbounded);
         assert!(all.is_empty());
+    }
+
+    /// The database enforces strictly-increasing timestamps.  A batch whose first timestamp does
+    /// not exceed the genesis high-water mark (0) is rejected, as is a batch that repeats or
+    /// decreases a timestamp within itself.
+    #[test]
+    fn strictly_increasing_enforced() {
+        // Timestamp 0 is not strictly greater than the genesis high-water mark 0.
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", 0, b"x").unwrap();
+        assert!(Snapshot::empty().apply(&batch, 1).is_err());
+
+        // A batch must be internally strictly increasing too.
+        let mut batch = WriteBatch::new();
+        batch.put(b"a", 1, b"x").unwrap();
+        batch.put(b"b", 1, b"y").unwrap();
+        assert!(Snapshot::empty().apply(&batch, 1).is_err());
+
+        // A later batch must exceed the prior high-water mark.
+        let mut first = WriteBatch::new();
+        first.put(b"a", 5, b"x").unwrap();
+        let snap = Snapshot::empty().apply(&first, 1).unwrap();
+        assert_eq!(snap.timestamp_hi(), 5);
+        let mut second = WriteBatch::new();
+        second.put(b"b", 5, b"y").unwrap(); // not strictly greater than 5
+        assert!(snap.apply(&second, 2).is_err());
+        let mut third = WriteBatch::new();
+        third.put(b"b", 6, b"y").unwrap(); // strictly greater than 5
+        let snap2 = snap.apply(&third, 2).unwrap();
+        assert_eq!(snap2.timestamp_hi(), 6);
+        assert_eq!(snap2.get(b"a"), Some(&b"x"[..]));
+        assert_eq!(snap2.get(b"b"), Some(&b"y"[..]));
     }
 }


### PR DESCRIPTION
sstdb previously materialized every write at a fixed timestamp 0 and
rejected any batch that used another value.  Replace that with
client-supplied timestamps that must form a strictly-increasing total
order across the database.

Key changes:
- put/delete on Database and Transaction now take a timestamp argument.
- Snapshot tracks a timestamp high-water mark, persisted as a new
  /timestamp_hi meta key and defaulted to 0 when loading older SSTs.
- Snapshot::apply enforces that every entry (including within a single
  batch) carries a timestamp strictly greater than the high-water mark,
  returning invalid-timestamp otherwise.
- Snapshot::map now stores (timestamp, value) per key and stamps each
  user key with its own timestamp on serialization.
- check_batch no longer validates timestamps: a single fragment carries
  no history, so the invariant is enforced against the high-water mark
  in Snapshot::apply rather than per-fragment.

The setsum domain is unchanged: timestamps are ordering tokens and are
deliberately excluded from the materialized (key, value) identity.

invalid_timestamp now carries both the offending timestamp and the
high-water mark it failed to beat.

Co-authored-by: AI
