### PR TITLE
A series of commits to caternary, melded to save CI costs

### DIFF
--- a/caternary/Cargo.toml
+++ b/caternary/Cargo.toml
@@ -54,3 +54,8 @@ required-features = ["binaries"]
 name = "m14_attestation"
 path = "examples/m14_attestation.rs"
 required-features = ["binaries"]
+
+[[example]]
+name = "probe"
+path = "examples/probe.rs"
+required-features = ["binaries"]

--- a/caternary/README.md
+++ b/caternary/README.md
@@ -150,6 +150,32 @@ single-`Num` decision but demand integer-valued operands at runtime, so
 `[ 1 0.5 | ] :main` passes `check` and fails when run (documented on
 `register_scalar_builtins`).
 
+Beyond value-domain rejections, the type system itself over-rejects runnable
+code: it exposes only the `Num` and `Bool` base types, with no `Word` (or top)
+type, so a bare word that is not a definition, a registered operator, a numeric
+literal, or a bound local — which the runtime pushes as a literal `Word` value
+— is typed as unresolved and rejected by `check`. `[ foo ] :main` runs (leaving
+`[:foo]` on the stack) but fails `check`. Closing it is a structural decision
+(introducing a `Word`/top base type), recorded here alongside the bitwise case
+as a documented gate hole rather than silently fixed.
+
+`=`/`==`/`!=` are a third documented gap, in the opposite direction: their
+contract is the same-type `( a a -- Bool )` (both operands must share a type),
+but the runtime falls back to token equality for any pair, so
+`[ 1 true = ] :main` runs (yielding `false`) while `check` rejects
+`Num`-versus-`Bool`. The same-type requirement is an intentional gate
+tightening — the contract promises same-type polymorphic equality, not
+heterogeneous token equality — not an oversight.
+
+The conditional words and boolean connectives are the same family of
+intentional tightening: `IF`/`WHEN`/`UNLESS` demand a `Bool` condition and
+`&&`/`||`/`!`/`and`/`or`/`not` demand `Bool` operands, while the runtime is
+truthy-generic (`is_truthy` is total — any value is a valid runtime
+condition). So `[ 1 [ 2 ] [ 3 ] IF ] :main` runs (yielding `2`) and
+`[ 5 ! ] :main` runs (yielding `false`), but `check` rejects both
+`Num`-versus-`Bool`. The contracts promise boolean control flow; truthiness
+is the runtime's escape hatch, not a typed promise.
+
 `caternary repl` starts the development REPL. Normal input is parsed, loaded,
 and evaluated against a persistent definition table and stack. Definition pairs
 such as `[ 1 + ] :inc` are loaded but not pushed onto the runtime stack.
@@ -228,6 +254,15 @@ a host predicate with that name is also registered.
 | `IF` | `0 [10] [20] IF` | `20` |
 | `WHEN` | `true [99] WHEN` | `99` |
 | `UNLESS` | `false [99] UNLESS` | `99` |
+
+`WHEN`/`UNLESS` share a recorded `caternary check` limitation: their scheme
+forces both control paths to the same stack depth. With a *statically-known*
+literal condition the runtime only ever runs the taken branch and is fine, but
+`check` cannot specialize on the literal, so it over-rejects — e.g.
+`[ 5 true [ DROP ] WHEN ] :main` runs to an empty stack yet fails `check` (the
+unused branch's depth mismatch surfaces as a cyclic-type error). For a dynamic
+condition the two branches really would leave different depths, so the
+rejection is correct; it over-rejects only when the condition is known.
 
 ### Sequence Combinators
 

--- a/caternary/TODO.md
+++ b/caternary/TODO.md
@@ -7,9 +7,65 @@ Holes 1, 2, and 4 are fixed and pinned by regression tests in
 
 ## High
 
-(none open)
+### Higher-order definitions fail closed: applying a quotation parameter cannot pass the gate (BUGS §B1)
+
+Tier 1 seeds a definition's inputs as opaque *terms* (`seed_opaque_inputs`),
+so a body that `CALL`s/`DIP`s a quotation **parameter** is a hard shadow error
+("expected a quotation, found a value term") — `[ CALL ] :apply`,
+`[ >q q CALL ] :apply`, the `@name`-annotated rank-2 pattern, and callers of
+quotation-*returning* definitions are all rejected while the runtime runs
+them. (A quotation bound from a **literal in the same body** works:
+`[ 5 [ 1 + ] >f f CALL DROP ] :main` verifies — the §B2 locals fix.)
+
+The direction is safe (pure over-rejection), and — important — it currently
+**masks a soundness hole**: nothing verifies a literal quotation argument's
+body at a call site (`[ 1 0 / DROP ]` passed to `apply` is consumed opaquely;
+its division is only checked because `apply` itself CALLs it — which is
+exactly the part that fails closed today). A fix that merely lets the
+definition-side CALL move data opaquely would open that hole gate-wide.
+
+The sound fix is the **definition side of §10.6** (higher-order contracts at
+both ends of the boundary):
+
+1. A definition whose signature declares a quotation binder
+   `q: ( pre -- post )` seeds that input as a **contract-carrying symbolic
+   quotation**: running it inside the body discharges `pre` as an obligation
+   (bound at the invocation point), moves data per the contract's binder
+   counts, and asserts `post` on the fresh outputs.
+2. At each call site, the provided quotation must satisfy the expected
+   contract. Relay handles `[ w ]` (already implemented,
+   `relay_provided_contract`); a **literal body** must be *verified against
+   the expected contract* right there (seed `pre`, verify the body, prove
+   `post`) — and its possible reach past the contract's declared slots (the
+   §A1b row-absorption problem) must be excluded or havocked.
+3. Unrefined quotation parameters (including the `@name`-annotation-only
+   rank-2 pattern) stay fail-closed: with no contract there is nothing sound
+   to assume at the definition and nothing to check at the boundary.
+
+Pinned (fail-closed today, and the same-body-local carve-out) by
+`check::tests::quotation_parameter_application_fails_closed`.
 
 ## Medium
+
+### BI@/TRI@ rank-1 schemes: one shared row, two applications (BUGS §A3/§B6)
+
+`BI@ : ( 'S a a ('r a -- 'r b) -- 'S b b )` (and TRI@'s triple) reuse a single
+row/element pair for every application of the quotation, but the two runtime
+applications occur at *different* stack depths (the second sees the first's
+result) — which no rank-1 arrow can state. Two directions of imprecision:
+
+- **§A3 (unsound at Tier 0 only):** the shared row can absorb a tail element,
+  so `1 2 [ SWAP ] BI@` types `( 'S -- 'S Num Num )` on the Tier-0-only
+  surfaces (`check()`, `infer_quote_type`, REPL `:type`) while the runtime
+  underflows. The **full gate is unaffected** — the Tier-1 shadow re-executes
+  the real shuffle and rejects.
+- **§B6 (over-rejection everywhere):** the same single row forces exactly
+  `( a -- b )` per application, so runnable `[ DROP ]` / `[ DUP ]` bodies
+  occurs-check out ("cyclic type").
+
+Fixing either direction needs per-application instantiation of the quotation's
+arrow (rank-2 style generalization of a *value*), which the rank-1 substitution
+cannot express. Pinned by `check::tests::bi_at_rank1_scheme_limits_are_recorded`.
 
 ### API sharp edges
 

--- a/caternary/examples/probe.rs
+++ b/caternary/examples/probe.rs
@@ -1,0 +1,166 @@
+//! Probe: read a program from argv[1] (or stdin), run the whole-program gate
+//! and then the evaluator, printing both verdicts side by side.
+
+use std::io::Read;
+
+use caternary::*;
+
+#[derive(Clone, Debug, PartialEq)]
+enum Value {
+    Word(String),
+    Int(i128),
+    Float(f64),
+    Bool(bool),
+    Quotation(Vec<QuoteItem<Value>>),
+}
+
+impl From<Token> for Value {
+    fn from(token: Token) -> Self {
+        match token {
+            Token::Word(w) => {
+                if let Ok(n) = w.parse::<i128>() {
+                    Value::Int(n)
+                } else if is_integer_literal(&w) {
+                    // Out-of-range integer: preserve the exact lexeme (the
+                    // runtime rejects it loudly) — never round through f64.
+                    Value::Word(w)
+                } else if let Ok(f) = w.parse::<f64>() {
+                    if f.is_finite() {
+                        Value::Float(f)
+                    } else {
+                        Value::Word(w)
+                    }
+                } else if w == "true" {
+                    Value::Bool(true)
+                } else if w == "false" {
+                    Value::Bool(false)
+                } else {
+                    Value::Word(w)
+                }
+            }
+            Token::Bracket(tokens) => Value::Quotation(quote_items_from_tokens(&tokens)),
+        }
+    }
+}
+
+impl Quotable for Value {
+    fn as_quotation(&self) -> Option<&[QuoteItem<Value>]> {
+        match self {
+            Value::Quotation(tokens) => Some(tokens),
+            _ => None,
+        }
+    }
+    fn from_quotation(items: Vec<QuoteItem<Self>>) -> Self {
+        Value::Quotation(items)
+    }
+    fn to_tokens(&self) -> Vec<Token> {
+        match self {
+            Value::Word(w) => vec![Token::Word(w.clone())],
+            Value::Int(n) => vec![Token::Word(n.to_string())],
+            Value::Float(f) => vec![Token::Word(f.to_string())],
+            Value::Bool(b) => vec![Token::Word(b.to_string())],
+            Value::Quotation(items) => vec![Token::Bracket(quote_items_to_tokens(items))],
+        }
+    }
+    fn is_truthy(&self) -> bool {
+        match self {
+            Value::Bool(b) => *b,
+            Value::Int(n) => *n != 0,
+            Value::Float(f) => *f != 0.0,
+            _ => true,
+        }
+    }
+    fn as_sequence(&self) -> Option<Vec<Self>> {
+        match self {
+            Value::Quotation(items) => Some(quote_items_to_values(items)),
+            _ => None,
+        }
+    }
+    fn from_sequence(elements: Vec<Self>) -> Self {
+        Value::Quotation(elements.into_iter().map(QuoteItem::Push).collect())
+    }
+}
+
+fn fmt(v: &Value) -> String {
+    match v {
+        Value::Word(w) => format!("W({w})"),
+        Value::Int(n) => format!("I({n})"),
+        Value::Float(f) => format!("F({f})"),
+        Value::Bool(b) => format!("B({b})"),
+        Value::Quotation(items) => {
+            let parts: Vec<String> = quote_items_to_tokens(items)
+                .iter()
+                .map(|t| match t {
+                    Token::Word(w) => w.clone(),
+                    Token::Bracket(_) => "[..]".to_string(),
+                })
+                .collect();
+            format!("Q[{}]", parts.join(" "))
+        }
+    }
+}
+
+fn main() {
+    let source = if let Some(src) = std::env::args().nth(1) {
+        src
+    } else {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).unwrap();
+        s
+    };
+
+    // Gate.
+    let mut evaluator = Evaluator::new();
+    register_all_builtins(&mut evaluator);
+    match parse_with_spans(&source) {
+        Ok(tokens) => {
+            if let Err(e) = evaluator.load_with_spans(&tokens) {
+                println!("load: ERR {e}");
+                return;
+            }
+            match check_whole_program(&evaluator, SmtLibSolver::new) {
+                Ok(_) => println!("gate: OK"),
+                Err(e) => println!("gate: ERR {e}"),
+            }
+            match evaluator.definition_body("main") {
+                Some(body) => match infer_quote_type(&evaluator, body) {
+                    Ok(w) => println!("type(main): {}", format_word_type(&w)),
+                    Err(e) => println!("type(main): ERR {e}"),
+                },
+                None => {
+                    let toks: Vec<Token> = tokens.iter().map(SpannedToken::to_token).collect();
+                    match infer_quote_type(&evaluator, &toks) {
+                        Ok(w) => println!("type: {}", format_word_type(&w)),
+                        Err(e) => println!("type: ERR {e}"),
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            println!("parse: ERR {e}");
+            return;
+        }
+    }
+
+    // Runtime: evaluate `main` like the gate assumes.
+    let evaluator2 = evaluator.clone();
+    if let Some(body) = evaluator2.definition_body("main") {
+        let body = body.to_vec();
+        match evaluator2.eval(&body) {
+            Ok(stack) => {
+                let rendered: Vec<String> = stack.iter().map(fmt).collect();
+                println!("eval: OK [{}]", rendered.join(" "));
+            }
+            Err(e) => println!("eval: ERR {e}"),
+        }
+    } else {
+        let tokens = parse(&source).unwrap();
+        match evaluator2.eval(&tokens) {
+            Ok(stack) => {
+                let rendered: Vec<String> = stack.iter().map(fmt).collect();
+                println!("eval: OK [{}]", rendered.join(" "));
+            }
+            Err(e) => println!("eval: ERR {e}"),
+        }
+    }
+}

--- a/caternary/src/bin/caternary.rs
+++ b/caternary/src/bin/caternary.rs
@@ -69,6 +69,10 @@ impl From<Token> for Value {
             Token::Word(w) => {
                 if let Ok(n) = w.parse::<i128>() {
                     Value::Int(n)
+                } else if caternary::is_integer_literal(&w) {
+                    // An out-of-range integer lexeme stays a Word (exact,
+                    // rejected loudly by the operators) — never a rounded f64.
+                    Value::Word(w)
                 } else if let Ok(f) = w.parse::<f64>()
                     && f.is_finite()
                 {

--- a/caternary/src/builtins.rs
+++ b/caternary/src/builtins.rs
@@ -142,12 +142,16 @@ fn scalar_word<T: Quotable>(value: &T) -> Result<String, EvalError> {
 /// **exactly wherever it can**: an integer-lexeme operand is an `i128` and
 /// integer arithmetic is checked (overflow is a runtime error, never a silent
 /// wrap or rounding — `9007199254740993 1 +` is `9007199254740994`, not
-/// `…992`). Fractional lexemes fall back to `f64` as the **documented escape
-/// hatch**: `f64` arithmetic rounds, so a proven refinement over fractional
-/// values holds only up to `f64` rounding. Non-finite lexemes (`inf`, `NaN`)
-/// have no `Real` semantics and are **not** numbers — the Tier-0 literal
-/// grammar ([`crate::types::is_numeric_literal`]) rejects them and so does
-/// this parser.
+/// `…992`). An integer lexeme **beyond** the `i128` range is likewise a loud
+/// runtime error ([`literal_overflow`]), never a rounded `f64`: the reasoner
+/// models the lexeme exactly, so rounding it at runtime would let two distinct
+/// integers compare equal (BUGS §A4). Fractional lexemes fall back to `f64` as
+/// the **documented escape hatch**: `f64` arithmetic rounds, so a proven
+/// refinement over fractional values holds only up to `f64` rounding.
+/// Non-finite lexemes (`inf`, `NaN`) have no `Real` semantics and are **not**
+/// numbers — the Tier-0 literal grammar
+/// ([`crate::types::is_numeric_literal`]) rejects them and so does this
+/// parser.
 #[derive(Clone, Copy, Debug)]
 enum Num {
     /// An exactly-represented integer.
@@ -157,11 +161,21 @@ enum Num {
 }
 
 impl Num {
-    /// Parse a numeric lexeme: `i128` first (exact), then finite `f64`.
+    /// Parse a numeric lexeme: `i128` first (exact), then finite `f64` — but
+    /// **only for fractional lexemes**. An integer lexeme beyond the `i128`
+    /// range must never fall through to a rounded `f64` (the reasoner models
+    /// the lexeme exactly, and "an integer-lexeme operand is an `i128`" is the
+    /// documented contract): it parses as no number at all, and the operator
+    /// that popped it raises the loud overflow error ([`literal_overflow`]).
     /// Non-finite lexemes are not numbers.
     fn parse(word: &str) -> Option<Num> {
         if let Ok(n) = word.parse::<i128>() {
             return Some(Num::Int(n));
+        }
+        if is_integer_lexeme(word) {
+            // Out-of-range integer: exactness is unrepresentable — not a
+            // rounded float, not a number.
+            return None;
         }
         match word.parse::<f64>() {
             Ok(f) if f.is_finite() => Some(Num::Float(f)),
@@ -217,11 +231,29 @@ fn overflow(op: &str) -> EvalError {
     ))
 }
 
+// An integer-form lexeme is exact by contract (`Num` docs above): one that
+// overflows `i128` must fail loudly, never round through `f64`.
+use crate::types::is_integer_literal as is_integer_lexeme;
+
+/// The loud error for an integer lexeme beyond the exact `i128` range —
+/// the literal-operand sibling of [`overflow`] ("overflow is a runtime error,
+/// never a silent wrap or rounding").
+fn literal_overflow(word: &str) -> EvalError {
+    operator_error(format!(
+        "numeric overflow: integer literal `{word}` exceeds the exact integer range (i128)"
+    ))
+}
+
 fn pop_num<T: Quotable>(stack: &mut Vec<T>) -> Result<Num, EvalError> {
     let value = stack.pop().ok_or_else(|| stack_underflow(1, stack.len()))?;
     let word = scalar_word(&value)?;
-    Num::parse(&word)
-        .ok_or_else(|| operator_error(format!("expected numeric value, found `{word}`")))
+    Num::parse(&word).ok_or_else(|| {
+        if is_integer_lexeme(&word) {
+            literal_overflow(&word)
+        } else {
+            operator_error(format!("expected numeric value, found `{word}`"))
+        }
+    })
 }
 
 fn pop_int<T: Quotable>(stack: &mut Vec<T>) -> Result<i128, EvalError> {
@@ -310,7 +342,17 @@ fn divide<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), E
         match (a, b) {
             // Exact when the quotient is an integer; otherwise the f64 escape
             // hatch (the model's division is exact rational — documented gap).
-            (Num::Int(a), Num::Int(b)) if a % b == 0 => Ok(Num::Int(a / b)),
+            // `a % b` and `a / b` both overflow for `i128::MIN / -1`; checked
+            // arithmetic raises a runtime error instead of panicking (debug)
+            // or silently wrapping to `i128::MIN` (release).
+            (Num::Int(a), Num::Int(b)) => {
+                let exact = a.checked_rem(b).map(|r| r == 0).ok_or_else(|| overflow("/"))?;
+                if exact {
+                    Ok(Num::Int(a.checked_div(b).ok_or_else(|| overflow("/"))?))
+                } else {
+                    Ok(Num::Float((a as f64) / (b as f64)))
+                }
+            }
             (a, b) => Ok(Num::Float(a.as_f64() / b.as_f64())),
         }
     })
@@ -322,7 +364,11 @@ fn modulo<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), E
             return Err(operator_error("modulo by zero"));
         }
         match (a, b) {
-            (Num::Int(a), Num::Int(b)) => Ok(Num::Int(a % b)),
+            (Num::Int(a), Num::Int(b)) => {
+                // `a % b` overflows for `i128::MIN % -1`; checked arithmetic
+                // raises a runtime error instead of panicking or wrapping.
+                Ok(Num::Int(a.checked_rem(b).ok_or_else(|| overflow("%"))?))
+            }
             (a, b) => Ok(Num::Float(a.as_f64() % b.as_f64())),
         }
     })
@@ -384,23 +430,31 @@ fn bool_not<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(),
 /// real equality, so `1 1.0 =` is `true` under every embedder `Value` — never
 /// rendering-dependent); non-numeric operands fall back to token equality
 /// (their Tier-0 contract is same-type polymorphic equality, and quotations /
-/// free words have no numeric reading).
-fn values_equal<T: Quotable>(a: &T, b: &T) -> bool {
+/// free words have no numeric reading). An **overflowing integer lexeme** is
+/// numeric but unrepresentable: comparing it is the loud
+/// [`literal_overflow`] error, never a token comparison of digit strings (nor,
+/// pre-fix, a rounded-`f64` equality that called two distinct integers equal).
+fn values_equal<T: Quotable>(a: &T, b: &T) -> Result<bool, EvalError> {
     let a_tokens = a.to_tokens();
     let b_tokens = b.to_tokens();
-    if let ([Token::Word(aw)], [Token::Word(bw)]) = (a_tokens.as_slice(), b_tokens.as_slice())
-        && let (Some(an), Some(bn)) = (Num::parse(aw), Num::parse(bw))
-    {
-        return an.num_eq(bn);
+    if let ([Token::Word(aw)], [Token::Word(bw)]) = (a_tokens.as_slice(), b_tokens.as_slice()) {
+        for w in [aw, bw] {
+            if is_integer_lexeme(w) && w.parse::<i128>().is_err() {
+                return Err(literal_overflow(w));
+            }
+        }
+        if let (Some(an), Some(bn)) = (Num::parse(aw), Num::parse(bw)) {
+            return Ok(an.num_eq(bn));
+        }
     }
-    a_tokens == b_tokens
+    Ok(a_tokens == b_tokens)
 }
 
 fn eq<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalError> {
     require_len(stack, 2)?;
     let b = stack.pop().unwrap();
     let a = stack.pop().unwrap();
-    push_word(stack, values_equal(&a, &b).to_string());
+    push_word(stack, values_equal(&a, &b)?.to_string());
     Ok(())
 }
 
@@ -408,7 +462,7 @@ fn ne<T: Quotable>(stack: &mut Vec<T>, _eval: &Evaluator<T>) -> Result<(), EvalE
     require_len(stack, 2)?;
     let b = stack.pop().unwrap();
     let a = stack.pop().unwrap();
-    push_word(stack, (!values_equal(&a, &b)).to_string());
+    push_word(stack, (!values_equal(&a, &b)?).to_string());
     Ok(())
 }
 
@@ -504,7 +558,7 @@ fn same_same_bool_scheme() -> Scheme {
     )
 }
 
-fn num_num_num_refinements() -> [(&'static str, &'static str); 4] {
+fn num_num_num_refinements() -> [(&'static str, &'static str); 7] {
     [
         ("+", "+ : ( a: Num b: Num -- c: Num where c = a + b )"),
         ("-", "- : ( a: Num b: Num -- c: Num where c = a - b )"),
@@ -512,6 +566,32 @@ fn num_num_num_refinements() -> [(&'static str, &'static str); 4] {
         (
             "/",
             "/ : ( a: Num b: Num where b * b > 0 -- c: Num where c = a / b )",
+        ),
+        // `%` mirrors `/`'s divisor demand (`b * b > 0`) so the gate rejects
+        // `[ 5 0 % DROP ]` just as it rejects `[ 5 0 / DROP ]`. No output
+        // guarantee: the modulo remainder is not expressible in the Real
+        // predicate language (the same value-domain gap as the bitwise case),
+        // and the demand alone closes the soundness hole.
+        (
+            "%",
+            "% : ( a: Num b: Num where b * b > 0 -- c: Num )",
+        ),
+        // The shifts demand the runtime's accepted amount range (`checked_shl`
+        // / `checked_shr` on i128: 0..=127) so the gate rejects `[ 1 -1 << ]`
+        // and `[ 1 200 << ]` instead of admitting a runtime "invalid shift
+        // amount" (BUGS §A5). `b * (127 - b) >= 0` is `0 <= b <= 127` as one
+        // atom: a conjunction's negated goal is a disjunction the linear
+        // reasoner treats as opaque (never discharges) — the same reason `/`
+        // demands `b * b > 0` rather than `b != 0`. No output guarantee, and
+        // the *integrality* of the amount stays unmodeled — that is the
+        // documented bitwise gap.
+        (
+            "<<",
+            "<< : ( a: Num b: Num where b * ( 127 - b ) >= 0 -- c: Num )",
+        ),
+        (
+            ">>",
+            ">> : ( a: Num b: Num where b * ( 127 - b ) >= 0 -- c: Num )",
         ),
     ]
 }
@@ -554,6 +634,19 @@ where
 /// value-domain rejections by these operators. Embedders who need the gate to
 /// carry that guarantee should register bitwise operators under their own
 /// attested, integrality-aware contracts instead of these.
+///
+/// # Recorded limitation: arithmetic overflow is unmodeled (gate-green ≠ crash-free)
+///
+/// The same shape of gap affects `+`/`-`/`*`. The solver models `Num` as
+/// unbounded `Real`, so these operators' guarantees (`c = a + b`, `c = a - b`,
+/// `c = a * b`) can never overflow in the model; the runtime uses checked
+/// `i128` and errors on overflow, so
+/// `[ 170141183460469231731687303715884105727 1 + ] :main` (`i128::MAX + 1`)
+/// passes `caternary check` and then fails at runtime with
+/// ``numeric overflow: `+` exceeds the exact integer range (i128) ``. Closing
+/// it needs a bounded-integer refinement (a range/integrality obligation) the
+/// predicate language currently lacks, so — like the bitwise case above — this
+/// is an explicitly documented soundness gap, not a silent one.
 pub fn register_scalar_builtins<T>(evaluator: &mut Evaluator<T>)
 where
     T: Quotable,
@@ -681,6 +774,10 @@ mod tests {
                 Token::Word(w) => {
                     if let Ok(n) = w.parse::<i128>() {
                         Value::Int(n)
+                    } else if crate::types::is_integer_literal(&w) {
+                        // Out-of-range integer: keep the exact lexeme (the
+                        // operators reject it loudly) — never a rounded f64.
+                        Value::Word(w)
                     } else if let Ok(f) = w.parse::<f64>()
                         && f.is_finite()
                     {
@@ -829,6 +926,46 @@ mod tests {
         assert_eq!(stack, vec![Value::Float(0.5)]);
     }
 
+    /// `i128::MIN / -1` and `i128::MIN % -1` overflow `i128` (the quotient
+    /// `2^127` is out of range). The unchecked `%`/`/` used to panic in debug
+    /// and silently wrap in release; both must be a runtime error instead.
+    #[test]
+    fn min_div_minus_one_is_a_runtime_error_not_a_crash() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        register_scalar_builtins(&mut eval);
+        // `-170141183460469231731687303715884105728` is `i128::MIN`.
+        let err = eval
+            .eval(&parse("-170141183460469231731687303715884105728 -1 /").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("overflow"), "got: {err}");
+        let err = eval
+            .eval(&parse("-170141183460469231731687303715884105728 -1 %").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("overflow"), "got: {err}");
+    }
+
+    /// BUGS §A4: an integer lexeme beyond `i128` used to fall through to a
+    /// rounded `f64`, so two *distinct* integers compared equal (the reasoner
+    /// models the lexemes exactly). The runtime must fail loudly instead —
+    /// for `=`/`!=` and for the numeric operators alike — never round.
+    #[test]
+    fn out_of_range_integer_literals_error_instead_of_rounding() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        register_scalar_builtins(&mut eval);
+        // 2^127 and 2^127 + 1: distinct integers, identical as f64.
+        let src = "170141183460469231731687303715884105728 \
+                   170141183460469231731687303715884105729 =";
+        let err = eval.eval(&parse(src).unwrap()).unwrap_err();
+        assert!(err.to_string().contains("overflow"), "got: {err}");
+        let err = eval
+            .eval(&parse("170141183460469231731687303715884105728 1 +").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("overflow"), "got: {err}");
+        // In-range integers and fractional lexemes are untouched.
+        let stack = eval.eval(&parse("1 1.0 =").unwrap()).unwrap();
+        assert_eq!(stack, vec![Value::Bool(true)]);
+    }
+
     #[test]
     fn forth_rotations_run() {
         let mut eval: Evaluator<Number> = Evaluator::new();
@@ -923,5 +1060,35 @@ mod tests {
         eval.load_with_spans(&tokens).unwrap();
 
         check_whole_program(&eval, crate::SmtLibSolver::new).unwrap();
+    }
+
+    /// BUGS §A5: the shift amount's runtime range (0..=127 — `checked_shl` /
+    /// `checked_shr` on i128) is modeled as a demand, so an out-of-range
+    /// amount fails the gate instead of surfacing only as a runtime "invalid
+    /// shift amount"; in-range amounts still discharge.
+    #[test]
+    fn shift_amount_range_is_gated() {
+        let gate = |src: &str| {
+            let mut eval: Evaluator<Value> = Evaluator::new();
+            register_scalar_builtins(&mut eval);
+            let tokens = parse_with_spans(src).unwrap();
+            eval.load_with_spans(&tokens).unwrap();
+            check_whole_program(&eval, crate::SmtLibSolver::new)
+        };
+        for src in [
+            "[ 1 -1 << DROP ] :main",
+            "[ 1 200 << DROP ] :main",
+            "[ 1 128 >> DROP ] :main",
+        ] {
+            assert!(gate(src).is_err(), "out-of-range shift must fail: {src}");
+        }
+        for src in [
+            "[ 1 0 << DROP ] :main",
+            "[ 1 3 << DROP ] :main",
+            "[ 1 127 << DROP ] :main",
+            "[ 8 2 >> DROP ] :main",
+        ] {
+            assert!(gate(src).is_ok(), "in-range shift must pass: {src}");
+        }
     }
 }

--- a/caternary/src/check.rs
+++ b/caternary/src/check.rs
@@ -164,6 +164,18 @@ pub enum TypeError {
         /// The span of the annotation.
         span: Span,
     },
+    /// A `>name` binder rebinds a name already bound in the **innermost**
+    /// lexical scope. The runtime forbids this (`single-assignment violation`,
+    /// `evaluator.rs`); the checker must reject it too so the gate does not
+    /// admit unrunnable code. Nested quotation-scope shadowing is unaffected: a
+    /// quotation opens a fresh scope, so an inner `>name` shadowing an outer
+    /// binding is a different scope and stays legal.
+    DuplicateBind {
+        /// The name being re-bound in the same scope.
+        name: String,
+        /// The span of the offending `>name` binder.
+        span: Span,
+    },
 }
 
 impl std::fmt::Display for TypeError {
@@ -220,6 +232,13 @@ impl std::fmt::Display for TypeError {
                 write!(
                     f,
                     "malformed stack-effect annotation for `{name}` (byte {}): {detail}",
+                    span.start
+                )
+            }
+            TypeError::DuplicateBind { name, span } => {
+                write!(
+                    f,
+                    "single-assignment violation: `{name}` is already bound in this scope (byte {})",
                     span.start
                 )
             }
@@ -847,11 +866,19 @@ where
     let row = ctx.fresh_row();
     let mut acc = WordTy::new(StackTy::empty(row, span), StackTy::empty(row, span));
 
+    // The innermost lexical scope begins at the current `locals` length: it is
+    // 0 for a fresh body (the entry definition / `main`) and the enclosing
+    // clone size for a quotation (which captures outer locals by value for
+    // *resolution* but opens a fresh single-assignment scope, mirroring the
+    // runtime's per-execution `env`). Binds pushed during this sequence sit at
+    // indices `>= scope_base`; only those count for a same-scope rebind check.
+    let scope_base = locals.len();
+
     for token in tokens {
         // The per-token effect, and (for words) the name to blame on underflow.
         let (word_arrow, blame): (WordTy, Option<&str>) = match &token.kind {
             SpannedTokenKind::Word(w) => (
-                word_effect(evaluator, w, token.span, ctx, locals, def_env, poly)?,
+                word_effect(evaluator, w, token.span, ctx, locals, def_env, poly, scope_base)?,
                 Some(w),
             ),
             SpannedTokenKind::Bracket(inner) => {
@@ -957,6 +984,7 @@ where
 /// of a bound local, a numeric or boolean literal, a registered operator, a
 /// language-core primitive, or a definition (resolved through its generalized
 /// `Scheme`, or its monomorphic in-SCC assumption for a recursive call, §6).
+#[allow(clippy::too_many_arguments)]
 fn word_effect<T>(
     evaluator: &Evaluator<T>,
     w: &str,
@@ -965,6 +993,7 @@ fn word_effect<T>(
     locals: &mut Vec<Local>,
     def_env: &DefEnv,
     poly: &HashMap<String, Scheme>,
+    scope_base: usize,
 ) -> Result<WordTy, TypeError>
 where
     T: Quotable,
@@ -972,6 +1001,20 @@ where
     // `>name` : ( 'a t -- 'a ), introducing `name : t` (fresh `t`) for the rest
     // of the scope; the local is monomorphic (§5).
     if let Some(name) = bind_target(w) {
+        // The runtime forbids rebinding a name already bound in the *same*
+        // scope (`single-assignment violation`, `evaluator.rs`). A quotation
+        // opens a fresh scope, so only binds pushed at or after `scope_base`
+        // (this scope's own binds) count; an outer captured binding at a lower
+        // index is a different scope and may be shadowed.
+        if locals[scope_base..]
+            .iter()
+            .any(|l| l.name() == name)
+        {
+            return Err(TypeError::DuplicateBind {
+                name: name.to_string(),
+                span,
+            });
+        }
         let r = ctx.fresh_row();
         let t = Ty::var(ctx.fresh_ty(), span);
         let input = StackTy::new(vec![t.clone()], r, span);
@@ -2204,6 +2247,89 @@ mod tests {
             check_whole_program(&eval, crate::SmtLibSolver::new).is_err(),
             "gate must not verify a program whose `/` demand is undecidable"
         );
+    }
+
+
+    // =======================================================================
+    // Regression: `%` modulo must carry the same divisor demand as `/`
+    // (BUGS.md B1 — `%` did the same runtime division as `/` but had no
+    // `b * b > 0` refinement, so the gate admitted `[ 5 0 % DROP ]` and the
+    // runtime errored `modulo by zero`.)
+    // =======================================================================
+
+    /// `[ 5 0 % DROP ] :main` must be rejected by the whole-program gate: `%`
+    /// performs the same runtime division as `/`, so its refinement carries
+    /// the same `b * b > 0` divisor demand, which the literal `0` refutes.
+    #[test]
+    fn gate_rejects_modulo_by_zero() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens = parse_with_spans("[ 5 0 % DROP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_err(),
+            "the gate must reject a `%` whose divisor is the literal 0"
+        );
+    }
+
+    /// The control: a nonzero divisor satisfies the `%` demand, so
+    /// `[ 5 3 % DROP ] :main` still type-checks.
+    #[test]
+    fn gate_accepts_modulo_with_nonzero_divisor() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens = parse_with_spans("[ 5 3 % DROP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_ok(),
+            "a `%` with a nonzero divisor must still pass the gate"
+        );
+    }
+
+
+    // =======================================================================
+    // Regression: same-scope `>name` rebind must be rejected (BUGS.md B4)
+    // The checker used to treat a second `>x` as shadowing (just pushing
+    // another Local) but the runtime forbids rebinding a name already bound
+    // in the same scope, so the gate admitted unrunnable code.
+    // =======================================================================
+
+    /// `[ 1 >x 2 >x x DROP ] :main` binds `x` twice in the same (top-level)
+    /// scope. The runtime rejects the second bind with `single-assignment
+    /// violation`; the gate must reject it too, naming `x`.
+    #[test]
+    fn gate_rejects_same_scope_local_rebind() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens = parse_with_spans("[ 1 >x 2 >x x DROP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        let err = check_whole_program(&eval, crate::SmtLibSolver::new)
+            .unwrap_err();
+        assert!(
+            matches!(err, GateError::Tier0(TypeError::DuplicateBind { ref name, .. }) if name == "x"),
+            "a same-scope `>x` rebind must be rejected as DuplicateBind, got {err:?}"
+        );
+    }
+
+    /// The fix must not break nested quotation-scope shadowing: a quotation
+    /// opens a fresh single-assignment scope, so an inner `>x` shadowing an
+    /// outer `x` is legal and type-checks (and runs).
+    #[test]
+    fn gate_accepts_nested_quotation_scope_shadowing() {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens =
+            parse_with_spans("[ 1 >x [ 2 >x x DROP ] CALL x DROP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_ok(),
+            "nested quotation-scope shadowing must still type-check"
+        );
+        // And it must genuinely run (the runtime allows the inner fresh-scope bind).
+        let body = eval.definition_body("main").unwrap().to_vec();
+        let mut stack = Vec::new();
+        eval.eval_with_stack(&body, &mut stack).unwrap();
+        assert!(stack.is_empty(), "the nested-shadow program runs to an empty stack");
     }
 
     #[test]
@@ -4599,5 +4725,262 @@ mod tests {
         let ledger = check_whole_program(&mk("1"), crate::SmtLibSolver::new)
             .expect("a guarantee the body establishes discharges");
         assert!(ledger.is_clean());
+    }
+
+    // =======================================================================
+    // Regression (BUGS §A1): WHEN/UNLESS/MAP/FILTER/FOLD/EACH quotation
+    // bodies are verified — not skipped opaquely — and the tail they share
+    // with the continuation cannot smuggle stale knowledge past the gate.
+    // =======================================================================
+
+    fn gate(src: &str) -> Result<crate::Ledger, GateError> {
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens = parse_with_spans(src).unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        check_whole_program(&eval, crate::SmtLibSolver::new)
+    }
+
+    /// §A1(a): a refinement obligation inside the body is generated and
+    /// refuted under every one of the six combinators (the same division the
+    /// gate catches inline), including nested inside an `IF` arm, and a user
+    /// contract violated through `WHEN`.
+    #[test]
+    fn combinator_bodies_generate_their_obligations() {
+        for src in [
+            "[ true [ 1 0 / DROP ] WHEN ] :main",
+            "[ false [ 1 0 / DROP ] UNLESS ] :main",
+            "[ [ 1 ] [ 1 0 / DROP ] MAP DROP ] :main",
+            "[ [ 1 ] 0 [ SWAP / ] FOLD DROP ] :main",
+            "[ [ 1 ] [ DROP 1 0 / DROP true ] FILTER DROP ] :main",
+            "[ [ 1 ] [ DROP 1 0 / DROP ] EACH ] :main",
+            "[ true [ true [ 1 0 / DROP ] [ ] IF ] WHEN ] :main",
+            "[ 1 - ] :dec
+             \"dec : ( n: Num where n > 0 -- r: Num )\"
+             [ true [ 0 dec DROP ] WHEN ] :main",
+        ] {
+            assert!(
+                gate(src).is_err(),
+                "a runtime-crashing (or contract-violating) body must fail the gate: {src}"
+            );
+        }
+    }
+
+    /// §A1(b): a shape-preserving scrambler body may permute the tail it runs
+    /// on (`WHEN`'s `('S -- 'S)`, `MAP`'s shared row absorbing tail slots), so
+    /// the shadow must not let pre-combinator knowledge about that tail
+    /// discharge downstream demands.
+    #[test]
+    fn combinator_bodies_invalidate_the_permutable_tail() {
+        for src in [
+            "[ 0 5 true [ SWAP ] WHEN 1 SWAP / DROP ] :main",
+            "[ 5 [ 0 ] [ SWAP ] MAP DROP 1 SWAP / DROP ] :main",
+        ] {
+            assert!(
+                gate(src).is_err(),
+                "tail knowledge must not survive a permuting body: {src}"
+            );
+        }
+    }
+
+    // =======================================================================
+    // Recorded (BUGS §B1): applying a quotation PARAMETER (or a quotation
+    // returned by a definition) fails the gate — the fail-closed floor of the
+    // unbuilt definition-side of §10.6 (see TODO.md "Higher-order definitions
+    // fail closed"). Do not "fix" this by letting the definition-side CALL
+    // move data opaquely: nothing verifies a literal quotation argument's
+    // body at the call site, so that would open an A1-class hole gate-wide.
+    // =======================================================================
+
+    #[test]
+    fn quotation_parameter_application_fails_closed() {
+        for src in [
+            // A quotation parameter, applied point-free or through a local.
+            "[ CALL ] :apply [ 5 [ 1 + ] apply ] :main",
+            "[ >q q CALL ] :apply [ 5 [ 1 + ] apply ] :main",
+            // The @name-annotated rank-2 pattern.
+            "[ [ a -- ] -- ] @r2 [ >f 1 f CALL true f CALL ] :r2 [ 5 [ DROP 0 ] r2 ] :main",
+            // A quotation-returning definition's output is opaque downstream.
+            "[ [ 1 2 + ] ] :mk [ 3 mk CALL ] :main",
+        ] {
+            assert!(
+                gate(src).is_err(),
+                "quotation-parameter application must fail closed: {src}"
+            );
+            // Each is runnable: the rejection is over-rejection, not a crash.
+            let mut eval: Evaluator<Value> = Evaluator::new();
+            crate::register_all_builtins(&mut eval);
+            let tokens = parse_with_spans(src).unwrap();
+            eval.load_with_spans(&tokens).unwrap();
+            let body = eval.definition_body("main").unwrap().to_vec();
+            eval.eval(&body)
+                .unwrap_or_else(|e| panic!("the runtime accepts {src}: {e}"));
+        }
+        // The carve-out the §B2 locals fix bought: a quotation bound from a
+        // LITERAL in the same body is fully verifiable.
+        assert!(
+            gate("[ 5 [ 1 + ] >f f CALL DROP ] :main").is_ok(),
+            "a same-body literal quotation local stays CALLable"
+        );
+    }
+
+    // =======================================================================
+    // Regression (BUGS §B3): an IF whose branches both leave a quotation in a
+    // slot joins to the conditional pair `[ P [then] [else] IF ]` instead of
+    // an opaque term, so a later CALL re-splits on the path condition.
+    // =======================================================================
+
+    #[test]
+    fn branch_disagreed_quotation_slots_stay_callable() {
+        // The B3 repro: gate used to fail structurally ("expected a
+        // quotation, found a value term"); the runtime yields [1].
+        assert!(
+            gate("[ true [ [ 1 ] ] [ [ 2 ] ] IF CALL DROP ] :main").is_ok(),
+            "a quotation-on-both-paths slot must stay CALLable"
+        );
+        // Precision is not soundness-bought: a demand inside either possible
+        // body is discharged under that branch's path condition only, so a
+        // division hiding in one branch's quotation is still refuted...
+        assert!(
+            gate("[ true [ [ 1 0 / DROP ] ] [ [ 1 1 / DROP ] ] IF CALL ] :main").is_err(),
+            "the then-quotation's zero divisor must still fail the gate"
+        );
+        // ...and two safe bodies both discharge.
+        assert!(
+            gate("[ true [ [ 1 1 / DROP ] ] [ [ 2 1 / DROP ] ] IF CALL ] :main").is_ok(),
+            "two safe conditional bodies must both verify"
+        );
+    }
+
+    // =======================================================================
+    // Recorded (BUGS §A3/§B6): BI@/TRI@'s rank-1 schemes share one row across
+    // both applications of the quotation, which HM rows cannot make rigid.
+    // Both directions of the resulting imprecision are documented in TODO.md
+    // and pinned here so a drift in either direction surfaces.
+    // =======================================================================
+
+    /// §A3: the shared row absorbs a tail element, so `[ SWAP ]` unifies with
+    /// BI@'s `( 'r a -- 'r b )` slot while the runtime's second application
+    /// underflows — Tier-0-only surfaces (`type_check`, `infer_quote_type`,
+    /// REPL `:type`) assert a type for crashing code. The FULL gate is saved
+    /// by the Tier-1 shadow, which re-executes the real shuffle. §B6 is the
+    /// flip side: the same single row forces exactly `( a -- b )` per
+    /// application, so runnable `[ DROP ]`/`[ DUP ]` bodies occurs-check out.
+    #[test]
+    fn bi_at_rank1_scheme_limits_are_recorded() {
+        // A3: Tier 0 alone admits the crashing body; the gate rejects it.
+        let mut eval: Evaluator<Value> = Evaluator::new();
+        crate::register_all_builtins(&mut eval);
+        let tokens = parse_with_spans("[ 1 2 [ SWAP ] BI@ DROP DROP ] :main").unwrap();
+        eval.load_with_spans(&tokens).unwrap();
+        assert!(
+            type_check(&eval).is_ok(),
+            "Tier 0 admits the crashing BI@ body (the documented A3 limit)"
+        );
+        assert!(
+            check_whole_program(&eval, crate::SmtLibSolver::new).is_err(),
+            "the full gate rejects: the Tier-1 shadow runs the real shuffle"
+        );
+        let body = eval.definition_body("main").unwrap().to_vec();
+        assert!(eval.eval(&body).is_err(), "the runtime underflows");
+
+        // B6: runnable non-( a -- b ) bodies are over-rejected (cyclic type).
+        for src in ["[ 1 2 [ DROP ] BI@ ] :main", "[ 1 2 [ DUP ] BI@ ] :main"] {
+            assert!(
+                gate(src).is_err(),
+                "the rank-1 scheme cyclic-rejects this runnable body: {src}"
+            );
+            let mut eval: Evaluator<Value> = Evaluator::new();
+            crate::register_all_builtins(&mut eval);
+            let tokens = parse_with_spans(src).unwrap();
+            eval.load_with_spans(&tokens).unwrap();
+            let body = eval.definition_body("main").unwrap().to_vec();
+            eval.eval(&body)
+                .unwrap_or_else(|e| panic!("the runtime accepts {src}: {e}"));
+        }
+    }
+
+    // =======================================================================
+    // Ratified (BUGS §B4): truthiness is a runtime escape hatch, not a typed
+    // promise — IF/WHEN/UNLESS demand Bool conditions and the connectives
+    // demand Bool operands, the same intentional gate tightening as the
+    // `=`/`==`/`!=` same-type contract (documented in the README).
+    // =======================================================================
+
+    #[test]
+    fn truthiness_tightening_is_ratified() {
+        for src in [
+            "[ 1 [ 2 ] [ 3 ] IF ] :main",
+            "[ 1 2 && DROP ] :main",
+            "[ 5 ! DROP ] :main",
+            "[ 1 [ ] WHEN ] :main",
+        ] {
+            // The gate rejects the non-Bool condition/operand...
+            assert!(gate(src).is_err(), "gate must reject Num-vs-Bool: {src}");
+            // ...while the truthy-generic runtime runs the program fine.
+            let mut eval: Evaluator<Value> = Evaluator::new();
+            crate::register_all_builtins(&mut eval);
+            let tokens = parse_with_spans(src).unwrap();
+            eval.load_with_spans(&tokens).unwrap();
+            let body = eval.definition_body("main").unwrap().to_vec();
+            eval.eval(&body)
+                .unwrap_or_else(|e| panic!("runtime must accept truthiness: {src}: {e}"));
+        }
+    }
+
+    // =======================================================================
+    // Regression (BUGS §B2): `>name` locals are visible to Tier 1 — a binder
+    // pops the top slot into the scope, a use pushes the bound slot back, and
+    // a bracket captures live locals by value (mirroring the runtime).
+    // =======================================================================
+
+    #[test]
+    fn locals_carry_their_knowledge_through_tier1() {
+        // A demand through a local discharges from the bound term's knowledge
+        // (this failed closed as `Unknown` before the binder case existed)...
+        assert!(
+            gate("[ 4 >x x x / DROP ] :main").is_ok(),
+            "`x` must carry the bound 4 into the `/` demand"
+        );
+        // ...including through a by-value capture into a quotation body...
+        assert!(
+            gate("[ 4 >x [ x x / DROP ] CALL ] :main").is_ok(),
+            "a bracket captures `x` by value, like the runtime"
+        );
+        // ...and a quotation-valued local stays CALLable.
+        assert!(
+            gate("[ 5 [ 1 + ] >f f CALL DROP ] :main").is_ok(),
+            "a local bound to a quotation is CALLable"
+        );
+        // The direction stays sound: a violated demand through a local is
+        // still refuted, not merely unknown.
+        assert!(
+            gate("[ 0 >x 1 x / DROP ] :main").is_err(),
+            "a zero divisor through a local must fail the gate"
+        );
+    }
+
+    /// Completeness floor: safe bodies still pass, an identity `WHEN` body
+    /// preserves the tail (join keeps agreed slots), and a quotation sitting
+    /// below an untouched-tail `MAP` remains callable.
+    #[test]
+    fn safe_combinator_bodies_still_pass_the_gate() {
+        for src in [
+            "[ true [ 1 1 / DROP ] WHEN ] :main",
+            "[ [ 1 2 3 ] [ 1 + ] MAP DROP ] :main",
+            "[ [ 1 2 3 ] 0 [ + ] FOLD DROP ] :main",
+            "[ [ 1 2 3 ] [ DROP ] EACH ] :main",
+            "[ [ 1 2 3 ] [ 2 > ] FILTER DROP ] :main",
+            // The identity body provably preserves the 7 on both paths.
+            "[ 7 true [ ] WHEN 1 SWAP / DROP ] :main",
+            // The MAP body never reaches the tail: the quotation below
+            // survives the fixpoint and stays CALLable.
+            "[ [ 1 DROP ] [ 2 3 ] [ 1 + ] MAP DROP CALL ] :main",
+        ] {
+            assert!(
+                gate(src).is_ok(),
+                "a safe body must not be over-rejected: {src}"
+            );
+        }
     }
 }

--- a/caternary/src/evaluator.rs
+++ b/caternary/src/evaluator.rs
@@ -533,6 +533,18 @@ impl<T> Evaluator<T> {
                         "malformed definition binder `{w}`: expected `:name`"
                     ))
                 })?;
+                // A definition named `true`/`false` desyncs the tiers: the
+                // runtime resolves definitions BEFORE literals while the
+                // checker types literals BEFORE definitions, so `[ 42 ] :true`
+                // runs as 42 but types as Bool (BUGS §B5). Numeric names are
+                // already excluded by the identifier rule; exclude the boolean
+                // literals the same way.
+                if crate::types::is_bool_literal(name) {
+                    return Err(definition_error(format!(
+                        "definition `:{name}` shadows the boolean literal `{name}` \
+                         (literals cannot be redefined)"
+                    )));
+                }
                 if i == 0 {
                     return Err(definition_error(format!(
                         "definition `:{name}` has no preceding quotation to bind"
@@ -1544,6 +1556,24 @@ mod tests {
     #[test]
     fn load_rejects_definition_without_preceding_quotation() {
         assert_load_error(":x", "definition `:x` has no preceding quotation to bind");
+    }
+
+    /// BUGS §B5: a definition named `true`/`false` desyncs the tiers — the
+    /// runtime resolves definitions before literals, the checker types
+    /// literals before definitions — so `[ 42 ] :true [ true 1 + ] :main`
+    /// runs as 43 while the gate rejects Bool vs Num, and `[ ] :true` makes
+    /// the gate prove an effect the runtime never produces. Rejected at
+    /// `load`, mirroring the identifier rule that already excludes numerals.
+    #[test]
+    fn load_rejects_boolean_literal_definition_names() {
+        assert_load_error(
+            "[42] :true",
+            "definition `:true` shadows the boolean literal `true`",
+        );
+        assert_load_error(
+            "[] :false",
+            "definition `:false` shadows the boolean literal `false`",
+        );
     }
 
     #[test]

--- a/caternary/src/lib.rs
+++ b/caternary/src/lib.rs
@@ -137,6 +137,7 @@ pub use types::WordTy;
 pub use types::core_scheme;
 pub use types::format_word_type;
 pub use types::is_bool_literal;
+pub use types::is_integer_literal;
 pub use types::is_numeric_literal;
 pub use types::respan_word;
 

--- a/caternary/src/refinement.rs
+++ b/caternary/src/refinement.rs
@@ -296,6 +296,7 @@ enum Tok {
     Minus,
     Star,
     Slash,
+    Percent,
     Ge,
     Le,
     Gt,
@@ -365,6 +366,13 @@ fn lex(src: &str) -> Result<Vec<Spanned>, RefineParseError> {
             b'/' => {
                 out.push(Spanned {
                     tok: Tok::Slash,
+                    span: RefineSpan::new(start, i + 1),
+                });
+                i += 1;
+            }
+            b'%' => {
+                out.push(Spanned {
+                    tok: Tok::Percent,
                     span: RefineSpan::new(start, i + 1),
                 });
                 i += 1;
@@ -523,6 +531,16 @@ impl<'a> Parser<'a> {
             self.pos += 1;
         }
         t
+    }
+
+    /// Is the next token `want`, starting exactly where `prev` ended (no
+    /// intervening whitespace)? Used to join the lexer's two angle tokens into
+    /// the `<<`/`>>` signature-head names.
+    fn peek_contiguous_angle(&self, prev: RefineSpan, want: &Tok) -> bool {
+        match self.toks.get(self.pos) {
+            Some(s) => s.tok == *want && s.span.start == prev.end,
+            None => false,
+        }
     }
 
     fn expect(&mut self, want: &Tok, what: &str) -> Result<RefineSpan, RefineParseError> {
@@ -760,21 +778,34 @@ impl<'a> Parser<'a> {
                 self.peek_span(),
             ));
         };
-        let name = match &spanned.tok {
+        let (head, head_span) = (spanned.tok.clone(), spanned.span);
+        let name = match &head {
             Tok::Ident(n) => n.clone(),
             Tok::Plus => "+".to_string(),
             Tok::Minus => "-".to_string(),
             Tok::Star => "*".to_string(),
             Tok::Slash => "/".to_string(),
+            Tok::Percent => "%".to_string(),
             Tok::Ge => ">=".to_string(),
             Tok::Le => "<=".to_string(),
+            // The predicate grammar has no shift operator, so the lexer emits
+            // `<<`/`>>` as two adjacent angle tokens; as a signature HEAD the
+            // contiguous pair is the shift word's name (`<< : ( ... )`).
+            Tok::Gt if self.peek_contiguous_angle(head_span, &Tok::Gt) => {
+                self.bump();
+                ">>".to_string()
+            }
+            Tok::Lt if self.peek_contiguous_angle(head_span, &Tok::Lt) => {
+                self.bump();
+                "<<".to_string()
+            }
             Tok::Gt => ">".to_string(),
             Tok::Lt => "<".to_string(),
             Tok::Eq => "=".to_string(),
             _ => {
                 return Err(RefineParseError::new(
                     "expected the definition or operator name a refinement signature attaches to",
-                    spanned.span,
+                    head_span,
                 ));
             }
         };
@@ -1251,6 +1282,23 @@ mod tests {
         assert!(err.to_string().contains("malformed numeric literal `1.`"));
         // Proper decimals still lex.
         assert!(parse_predicate("x > 1.5").is_ok());
+    }
+
+    /// The shift operators are legal signature heads: the lexer emits two
+    /// angle tokens, and the head parser joins a **contiguous** pair into
+    /// `<<`/`>>` (BUGS §A5 needs shift-range demands attachable). A spaced
+    /// `< <` stays two tokens — the head is `<` and the second angle errors.
+    #[test]
+    fn shift_operators_are_signature_heads() {
+        let sig = parse_signature("<< : ( a: Num b: Num where b >= 0 -- c: Num )")
+            .expect("<< signature parses");
+        assert_eq!(sig.name, "<<");
+        let sig = parse_signature(">> : ( a: Num b: Num -- c: Num )").expect(">> parses");
+        assert_eq!(sig.name, ">>");
+        assert!(
+            parse_signature("< < : ( a: Num -- c: Num )").is_err(),
+            "a spaced angle pair is not a shift head"
+        );
     }
 
     #[test]

--- a/caternary/src/shadow.rs
+++ b/caternary/src/shadow.rs
@@ -226,6 +226,29 @@ pub enum ShadowWord {
     TwoCurry,
     /// `3CURRY` — prepend three captured slots to a quotation.
     ThreeCurry,
+    /// `WHEN` — pop a quotation and a condition; the quotation (effect
+    /// `('S -- 'S)`) runs on the stack below the condition only on the truthy
+    /// path. The body is executed on a branch copy (under the condition as a
+    /// path condition, where a solver is present) and the result **joined**
+    /// with the skipped path, exactly as `IF` joins its arms.
+    When,
+    /// `UNLESS` — as `WHEN`, but the quotation runs on the falsy path (under
+    /// the negated condition).
+    Unless,
+    /// `MAP` — pop a quotation and a sequence; havoc-to-fixpoint over the
+    /// shared tail ([`ShadowStack::havoc_fixpoint`]), verify the body at the
+    /// fixpoint, and push the (opaque) result sequence.
+    Map,
+    /// `FILTER` — pop a quotation (predicate) and a sequence; as `MAP` (the
+    /// per-element output is the predicate's Bool; the result list is opaque).
+    Filter,
+    /// `FOLD` — pop a quotation, an accumulator, and a sequence; the threaded
+    /// accumulator joins the loop state, so the fixpoint's top slot is the
+    /// final accumulator (opaque unless the step provably preserves it).
+    Fold,
+    /// `EACH` — pop a quotation and a sequence; havoc-to-fixpoint over the
+    /// shared tail and verify the consumer body at the fixpoint.
+    Each,
     /// An interpreted binary operator (arithmetic/comparison/connective): pops
     /// two terms `a b` and pushes the proposition/term `Bin(op, a, b)`.
     Bin(BinOp),
@@ -281,6 +304,12 @@ pub fn core_shadow_word(name: &str) -> Option<ShadowWord> {
         "CURRY" => ShadowWord::Curry,
         "2CURRY" => ShadowWord::TwoCurry,
         "3CURRY" => ShadowWord::ThreeCurry,
+        "WHEN" => ShadowWord::When,
+        "UNLESS" => ShadowWord::Unless,
+        "MAP" => ShadowWord::Map,
+        "FILTER" => ShadowWord::Filter,
+        "FOLD" => ShadowWord::Fold,
+        "EACH" => ShadowWord::Each,
         _ => return None,
     };
     Some(word)
@@ -403,10 +432,17 @@ impl ShadowStack {
 
     /// Mint a fresh literal term for an opaque producer (§10.3). Each call is a
     /// distinct SMT variable; soundness holds, precision degrades gracefully.
-    fn fresh_literal(&mut self) -> Pred {
+    pub(crate) fn fresh_literal(&mut self) -> Pred {
         let p = Pred::Var(format!("$t{}", self.fresh));
         self.fresh += 1;
         p
+    }
+
+    /// Advance this stack's fresh-literal counter past everything `other`
+    /// minted — called after running a probe body on a clone, so terms minted
+    /// here afterwards never alias the probe's.
+    pub(crate) fn absorb_fresh(&mut self, other: &ShadowStack) {
+        self.fresh = self.fresh.max(other.fresh);
     }
 
     /// Join two branch post-states into an `IF`'s post-state (§10.4).
@@ -420,14 +456,32 @@ impl ShadowStack {
     /// would otherwise discharge against a term the runtime's else branch never
     /// produces.)
     ///
-    /// A *disagreed quotation* slot also joins to an opaque term: a later
-    /// combinator that needs to run it fails the shadow structurally, which is
-    /// the fail-closed reading — the checker cannot know which body it would be
-    /// verifying. An ite-aware join could recover precision here later; opacity
-    /// is the conservative floor.
+    /// Without a condition in hand (this wrapper), a *disagreed quotation*
+    /// slot also joins to an opaque term: a later combinator that needs to run
+    /// it fails the shadow structurally — the fail-closed floor. The verifier,
+    /// which does hold the condition, uses [`Self::join_branch_states_ite`] to
+    /// recover precision for quotation-on-both-paths slots (BUGS §B3).
     pub fn join_branch_states(
         then_state: ShadowStack,
         else_state: &ShadowStack,
+    ) -> Result<ShadowStack, ShadowError> {
+        Self::join_branch_states_ite(then_state, else_state, None)
+    }
+
+    /// [`ShadowStack::join_branch_states`] with an **ite-aware quotation
+    /// join** (BUGS §B3): when the branch condition `cond` is supplied and the
+    /// branches disagree on a slot that is a **quotation in both**, the join
+    /// keeps a synthetic conditional quotation `[ cond [then] [else] IF ]`
+    /// instead of an opaque term. A later combinator that runs the slot
+    /// re-enters the verifier's `IF` treatment: each body is verified under
+    /// its own path condition and the results re-join — so the checker knows
+    /// the slot is a quotation without pretending to know which body, and a
+    /// demand inside either body is still discharged only under that branch's
+    /// condition. Every other disagreement stays the opaque fail-closed floor.
+    pub(crate) fn join_branch_states_ite(
+        then_state: ShadowStack,
+        else_state: &ShadowStack,
+        cond: Option<&Pred>,
     ) -> Result<ShadowStack, ShadowError> {
         if then_state.slots.len() != else_state.slots.len() {
             // Tier 0 guarantees shape agreement; this guard keeps the zip total.
@@ -439,6 +493,21 @@ impl ShadowStack {
         joined.fresh = joined.fresh.max(else_state.fresh);
         for i in 0..joined.slots.len() {
             if joined.slots[i] != else_state.slots[i] {
+                if let (Some(cond), Slot::Quote(t), Slot::Quote(e)) =
+                    (cond, &joined.slots[i], &else_state.slots[i])
+                {
+                    // Both control paths leave a quotation here: keep the
+                    // conditional pair. (The `IF` word is safe from local
+                    // shadowing: this body never passes through source-level
+                    // capture, and a quotation body opens a fresh scope.)
+                    joined.slots[i] = Slot::Quote(vec![
+                        ShadowQuoteItem::Push(Slot::Term(cond.clone())),
+                        ShadowQuoteItem::Bracket(t.clone()),
+                        ShadowQuoteItem::Bracket(e.clone()),
+                        ShadowQuoteItem::Word("IF".to_string()),
+                    ]);
+                    continue;
+                }
                 let opaque = joined.fresh_literal();
                 joined.slots[i] = Slot::Term(opaque);
             }
@@ -628,6 +697,72 @@ impl ShadowStack {
             self.push_term(fresh);
         }
         Ok(())
+    }
+
+    /// Havoc-to-fixpoint over the whole current stack — the sound post-state
+    /// for a loop body (`MAP`/`FILTER`/`FOLD`/`EACH`) that runs an **unknown
+    /// number of times** on the stack it shares with the continuation.
+    ///
+    /// `run_body` models exactly one iteration and must be depth-neutral over
+    /// the current stack (push the representative element, run the quotation,
+    /// pop the per-element output — the runtime enforces the same shape per
+    /// iteration). Starting from the current slots as the abstraction, each
+    /// round replays one iteration and **havocs** (replaces with a fresh opaque
+    /// literal) every not-yet-havocked slot the iteration changed — a changed
+    /// quotation slot havocs to an opaque *term*, the fail-closed floor, since
+    /// the checker no longer knows which body that slot holds. The loop stops
+    /// when an iteration changes nothing that isn't already opaque: the
+    /// surviving slots are an **inductive invariant** of the body (preserved
+    /// syntactically even with every havocked slot arbitrary), so they hold
+    /// after zero or any number of iterations. Termination: each round havocs
+    /// at least one new slot or exits, so it runs at most `depth + 1` rounds.
+    ///
+    /// On return the stack *is* the fixpoint state. The caller should verify
+    /// the body one final time **at this state** so its obligations are
+    /// discharged against the inductive invariant (any iteration's entry
+    /// state), never against first-iteration-only knowledge.
+    pub(crate) fn havoc_fixpoint<F>(&mut self, mut run_body: F) -> Result<(), ShadowError>
+    where
+        F: FnMut(&mut ShadowStack) -> Result<(), ShadowError>,
+    {
+        let depth = self.slots.len();
+        let mut havocked = vec![false; depth];
+        loop {
+            // Candidate state: the original slots, havocked ones fresh-opaque.
+            let mut probe = self.clone();
+            for (i, h) in havocked.iter().enumerate() {
+                if *h {
+                    let fresh = probe.fresh_literal();
+                    probe.slots[i] = Slot::Term(fresh);
+                }
+            }
+            let entry = probe.slots.clone();
+            run_body(&mut probe)?;
+            if probe.slots.len() != depth {
+                return Err(ShadowError::new(
+                    "sequence-combinator body changed the shared stack depth \
+                     (Tier 0 should have rejected this program)",
+                ));
+            }
+            self.fresh = self.fresh.max(probe.fresh);
+            let mut widened = false;
+            for i in 0..depth {
+                if !havocked[i] && probe.slots[i] != entry[i] {
+                    havocked[i] = true;
+                    widened = true;
+                }
+            }
+            if !widened {
+                // Fixpoint: install the inductive state.
+                for (i, h) in havocked.iter().enumerate() {
+                    if *h {
+                        let fresh = self.fresh_literal();
+                        self.slots[i] = Slot::Term(fresh);
+                    }
+                }
+                return Ok(());
+            }
+        }
     }
 
     // --- token-driven execution (mirrors evaluator.rs::eval_scope) ---
@@ -830,6 +965,68 @@ impl ShadowStack {
                         ];
                         combined.extend(body);
                         self.push_quote(combined);
+                    }
+                    // WHEN/UNLESS: the quotation (effect 'S -- 'S) runs on the
+                    // stack below the condition, on one control path only.
+                    // Execute the body on a branch copy and JOIN with the
+                    // skipped path (the unchanged stack), exactly as IF joins
+                    // its two arms: only knowledge both control paths agree on
+                    // survives, so a body that permutes the tail can't leave
+                    // one path's values speaking for the other.
+                    ShadowWord::When | ShadowWord::Unless => {
+                        self.require(2)?;
+                        let body = self.pop_quote()?;
+                        let _cond = self.pop()?;
+                        let mut ran = self.clone();
+                        ran.exec_quote(&body, resolve)?;
+                        let joined = ShadowStack::join_branch_states(ran, self)?;
+                        *self = joined;
+                    }
+                    // MAP/FILTER/EACH: pop the quotation and the sequence, then
+                    // havoc-to-fixpoint over the shared tail — the body runs
+                    // once per element at runtime, so every tail slot an
+                    // iteration can change must go opaque, and the body is
+                    // replayed at the fixpoint so the abstraction is inductive.
+                    // MAP/FILTER additionally push the (opaque) result sequence.
+                    ShadowWord::Map | ShadowWord::Filter => {
+                        self.require(2)?;
+                        let body = self.pop_quote()?;
+                        let _seq = self.pop()?;
+                        self.havoc_fixpoint(|st| {
+                            let elem = st.fresh_literal();
+                            st.push_term(elem);
+                            st.exec_quote(&body, resolve)?;
+                            st.pop()?; // per-element output (MAP: b; FILTER: the Bool)
+                            Ok(())
+                        })?;
+                        let out = self.fresh_literal();
+                        self.push_term(out);
+                    }
+                    ShadowWord::Each => {
+                        self.require(2)?;
+                        let body = self.pop_quote()?;
+                        let _seq = self.pop()?;
+                        self.havoc_fixpoint(|st| {
+                            let elem = st.fresh_literal();
+                            st.push_term(elem);
+                            st.exec_quote(&body, resolve) // body consumes the element
+                        })?;
+                    }
+                    // FOLD: the threaded accumulator is part of the loop state —
+                    // push the init back and fix over (tail + acc); the fixpoint
+                    // top IS the final accumulator (opaque unless the step
+                    // provably preserves it).
+                    ShadowWord::Fold => {
+                        self.require(3)?;
+                        let body = self.pop_quote()?;
+                        let init = self.pop()?;
+                        let _seq = self.pop()?;
+                        self.push_slot(init);
+                        self.havoc_fixpoint(|st| {
+                            let elem = st.fresh_literal();
+                            st.push_term(elem);
+                            st.exec_quote(&body, resolve) // body leaves the new acc
+                        })?;
                     }
                     ShadowWord::Bin(op) => self.bin(op)?,
                     ShadowWord::Un(op) => self.un(op)?,

--- a/caternary/src/solver.rs
+++ b/caternary/src/solver.rs
@@ -124,6 +124,7 @@ use crate::refinement::RefinementSide;
 use crate::refinement::RefinementSig;
 use crate::refinement::UnOp;
 use crate::refinement::parse_assume;
+use crate::evaluator::bind_target;
 use crate::shadow::NamedBinding;
 use crate::shadow::ShadowError;
 use crate::shadow::ShadowQuoteItem;
@@ -1347,7 +1348,133 @@ fn apply_core<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
             stack.push_quote(combined);
             Ok(())
         }
+        // WHEN runs its body on the truthy path only; UNLESS on the falsy path.
+        ShadowWord::When => verify_one_armed_if(stack, false, resolve, solver, ctx),
+        ShadowWord::Unless => verify_one_armed_if(stack, true, resolve, solver, ctx),
+        // MAP/FILTER: the body runs once per element on the tail it shares with
+        // the continuation; verify it at the havoc fixpoint, then push the
+        // (opaque) result sequence. The per-element output (MAP's b / FILTER's
+        // Bool) is popped by each iteration.
+        ShadowWord::Map | ShadowWord::Filter => {
+            stack.require(2)?;
+            let body = stack.pop_quote()?;
+            let _seq = stack.pop()?;
+            verify_loop_body(stack, &body, true, resolve, solver, ctx)?;
+            let out = stack.fresh_literal();
+            stack.push_term(out);
+            Ok(())
+        }
+        // EACH: as MAP, but the body consumes the element and nothing is pushed.
+        ShadowWord::Each => {
+            stack.require(2)?;
+            let body = stack.pop_quote()?;
+            let _seq = stack.pop()?;
+            verify_loop_body(stack, &body, false, resolve, solver, ctx)
+        }
+        // FOLD: the threaded accumulator is part of the loop state — push the
+        // init back and fix over (tail + acc). The step body consumes acc+elem
+        // and leaves the new acc, so it pops no extra output; the fixpoint's
+        // top slot is the final accumulator (opaque unless the step provably
+        // preserves it).
+        ShadowWord::Fold => {
+            stack.require(3)?;
+            let body = stack.pop_quote()?;
+            let init = stack.pop()?;
+            let _seq = stack.pop()?;
+            stack.push_slot(init);
+            verify_loop_body(stack, &body, false, resolve, solver, ctx)
+        }
     }
+}
+
+/// The path-condition treatment of `WHEN`/`UNLESS` (§10.4 applied to the
+/// one-armed conditional): `cond [ body ] WHEN` is `cond [ body ] [ ] IF`, so
+/// verify the body on a branch copy under the appropriate path condition
+/// (`P` for `WHEN`, `¬P` for `UNLESS`) and **join** with the skipped path —
+/// the unchanged incoming stack. The body's Tier 0 effect is `('S -- 'S)`,
+/// which admits shape-preserving scramblers, so only slot-wise agreed
+/// knowledge may survive into the unconditional continuation
+/// ([`ShadowStack::join_branch_states`]).
+fn verify_one_armed_if<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
+    stack: &mut ShadowStack,
+    negate_cond: bool,
+    resolve: &R,
+    solver: &mut S,
+    ctx: &mut VerifyCtx,
+) -> Result<(), ShadowError> {
+    stack.require(2)?;
+    let body = stack.pop_quote()?;
+    let cond = stack.pop_term()?;
+    let path = if negate_cond { negate(&cond) } else { cond };
+
+    let ran = {
+        let mut branch = stack.clone();
+        solver.push_scope();
+        solver.assert(&path);
+        verify_quote_ctx(&body, &mut branch, solver, resolve, ctx)?;
+        solver.pop_scope();
+        branch
+    };
+
+    // Join with the skipped path: the incoming stack, unchanged. A slot that
+    // is a quotation on both paths joins to the conditional pair keyed on the
+    // ran-branch's path condition (`join_branch_states_ite`, BUGS §B3).
+    let joined = ShadowStack::join_branch_states_ite(ran, stack, Some(&path))?;
+    *stack = joined;
+    Ok(())
+}
+
+/// Verify a sequence-combinator body (`MAP`/`FILTER`/`FOLD`/`EACH`) that runs
+/// an unknown number of times on the stack it shares with the continuation.
+///
+/// Two phases over [`ShadowStack::havoc_fixpoint`]:
+///
+///   1. **Fixpoint rounds** replay one iteration at a time — a fresh opaque
+///      element pushed, the body run, the per-element output popped when the
+///      combinator's contract has one (`pops_output`) — inside a pushed solver
+///      scope with a **scratch** [`VerifyCtx`], so probe facts and probe
+///      obligations are discarded: only the final, inductive replay is
+///      ledgered.
+///   2. **The verified replay** at the fixpoint state discharges the body's
+///      obligations into the real `ctx`, against the inductive invariant (any
+///      iteration's entry state) — never against first-iteration-only
+///      knowledge. Its facts stay scoped: they speak about that replay's fresh
+///      element, which does not exist downstream.
+///
+/// On return `stack` is the fixpoint state — the sound post-state of the loop
+/// for zero or any number of iterations.
+fn verify_loop_body<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
+    stack: &mut ShadowStack,
+    body: &[ShadowQuoteItem],
+    pops_output: bool,
+    resolve: &R,
+    solver: &mut S,
+    ctx: &mut VerifyCtx,
+) -> Result<(), ShadowError> {
+    stack.havoc_fixpoint(|st| {
+        let elem = st.fresh_literal();
+        st.push_term(elem);
+        let mut probe_ctx = VerifyCtx::new();
+        solver.push_scope();
+        let ran = verify_quote_ctx(body, st, solver, resolve, &mut probe_ctx);
+        solver.pop_scope();
+        ran?;
+        if pops_output {
+            st.pop()?;
+        }
+        Ok(())
+    })?;
+
+    // The verified replay at the inductive state.
+    let mut replay = stack.clone();
+    let elem = replay.fresh_literal();
+    replay.push_term(elem);
+    solver.push_scope();
+    let ran = verify_quote_ctx(body, &mut replay, solver, resolve, ctx);
+    solver.pop_scope();
+    ran?;
+    stack.absorb_fresh(&replay);
+    Ok(())
 }
 
 /// Verify a token sequence with **path conditions** (§10.4): execute the shadow
@@ -1389,23 +1516,18 @@ pub fn verify_ctx<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
     resolve: &R,
     ctx: &mut VerifyCtx,
 ) -> Result<(), ShadowError> {
+    // A fresh locals scope per walk, mirroring `Evaluator::eval_with_stack`
+    // (each definition body / top level opens its own `>name` scope — §B2).
+    let mut env = ShadowLocals::new();
     for token in tokens {
         match token {
-            Token::Bracket(body) => stack.push_quote(shadow_quote_from_tokens(body)),
-            Token::Word(w) if is_if(w) => {
-                verify_if(stack, solver, resolve, ctx)?;
+            Token::Bracket(body) => {
+                // A quotation value captures the locals in scope by value —
+                // the shadow image of `evaluator.rs::capture_tokens`.
+                let items = shadow_quote_from_tokens(body);
+                stack.push_quote(capture_locals(&items, &env));
             }
-            Token::Word(w) if parse_assume(w).is_some() => {
-                // Safe: `is_some()` above. A malformed `assume(` body surfaces as
-                // a located ShadowError rather than being mistaken for a word.
-                let pred = parse_assume(w).unwrap().map_err(|e| ShadowError {
-                    message: format!("malformed `assume` clause: {e}"),
-                })?;
-                apply_assume(stack, w, pred, solver, ctx)?;
-            }
-            Token::Word(w) => {
-                apply_effect(stack, w, resolve, solver, ctx)?;
-            }
+            Token::Word(w) => verify_word(w, stack, solver, resolve, ctx, &mut env)?,
         }
     }
     Ok(())
@@ -1418,25 +1540,116 @@ fn verify_quote_ctx<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
     resolve: &R,
     ctx: &mut VerifyCtx,
 ) -> Result<(), ShadowError> {
+    // A fresh locals scope per quotation body, mirroring
+    // `Evaluator::eval_quote_with_stack` (enclosing locals reach a body only
+    // through by-value capture at the bracket, never dynamically).
+    let mut env = ShadowLocals::new();
     for item in items {
         match item {
-            ShadowQuoteItem::Word(w) if is_if(w) => {
-                verify_if(stack, solver, resolve, ctx)?;
-            }
-            ShadowQuoteItem::Word(w) if parse_assume(w).is_some() => {
-                let pred = parse_assume(w).unwrap().map_err(|e| ShadowError {
-                    message: format!("malformed `assume` clause: {e}"),
-                })?;
-                apply_assume(stack, w, pred, solver, ctx)?;
-            }
-            ShadowQuoteItem::Word(w) => {
-                apply_effect(stack, w, resolve, solver, ctx)?;
-            }
-            ShadowQuoteItem::Bracket(body) => stack.push_quote(body.clone()),
+            ShadowQuoteItem::Word(w) => verify_word(w, stack, solver, resolve, ctx, &mut env)?,
+            ShadowQuoteItem::Bracket(body) => stack.push_quote(capture_locals(body, &env)),
             ShadowQuoteItem::Push(slot) => stack.push_slot(slot.clone()),
         }
     }
     Ok(())
+}
+
+/// The `>name` locals live during one verify walk (BUGS §B2): each maps a
+/// bound local to the shadow **slot** it captured — a value term keeps its
+/// knowledge (so `4 >x x x /` discharges `x * x > 0`), a quotation slot stays
+/// CALLable. One scope per walk, exactly like the runtime's per-scope `env`.
+type ShadowLocals = std::collections::HashMap<String, Slot>;
+
+/// Verify a single word, mirroring `evaluator.rs::eval_word`'s resolution
+/// order: `>name` binder first, then a bound local, then the verifier's
+/// interceptions (`IF`, `assume(...)`), then ordinary word resolution. The
+/// binder **pops the top slot into the scope** and a use **pushes the bound
+/// slot back** — the runtime's data flow, byte for byte; before this case
+/// existed, `>x` pushed a phantom `Var(">x")` and a use pushed a free
+/// `Var("x")`, so every demand through a local failed closed (§B2).
+fn verify_word<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
+    w: &str,
+    stack: &mut ShadowStack,
+    solver: &mut S,
+    resolve: &R,
+    ctx: &mut VerifyCtx,
+    env: &mut ShadowLocals,
+) -> Result<(), ShadowError> {
+    if let Some(name) = bind_target(w) {
+        // Mirror the runtime's single-assignment rule (Tier 0 also rejects a
+        // same-scope rebind; this guard keeps the walk total on its own).
+        if env.contains_key(name) {
+            return Err(ShadowError {
+                message: format!(
+                    "single-assignment violation: `{name}` is already bound in this scope"
+                ),
+            });
+        }
+        let slot = stack.pop()?;
+        env.insert(name.to_string(), slot);
+        return Ok(());
+    }
+    if let Some(slot) = env.get(w) {
+        // Locals resolve scope-first, ahead of definitions and operators.
+        stack.push_slot(slot.clone());
+        return Ok(());
+    }
+    if is_if(w) {
+        return verify_if(stack, solver, resolve, ctx);
+    }
+    if let Some(pred) = parse_assume(w) {
+        // A malformed `assume(` body surfaces as a located ShadowError rather
+        // than being mistaken for a word.
+        let pred = pred.map_err(|e| ShadowError {
+            message: format!("malformed `assume` clause: {e}"),
+        })?;
+        return apply_assume(stack, w, pred, solver, ctx);
+    }
+    apply_effect(stack, w, resolve, solver, ctx)
+}
+
+/// Bake the walk's live locals into a quotation body **by value** — the shadow
+/// image of `evaluator.rs::capture_tokens`: a use of a captured local becomes a
+/// `Push` of its slot, a `>name` bound *inside* the body shadows the capture
+/// for the rest of that body, and nested brackets recurse under the shadowed
+/// environment.
+fn capture_locals(items: &[ShadowQuoteItem], env: &ShadowLocals) -> Vec<ShadowQuoteItem> {
+    if env.is_empty() {
+        return items.to_vec();
+    }
+    let mut local: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            ShadowQuoteItem::Word(w) => {
+                if let Some(name) = bind_target(w) {
+                    local.insert(name);
+                    out.push(item.clone());
+                } else if !local.contains(w.as_str())
+                    && let Some(slot) = env.get(w)
+                {
+                    out.push(ShadowQuoteItem::Push(slot.clone()));
+                } else {
+                    out.push(item.clone());
+                }
+            }
+            ShadowQuoteItem::Bracket(inner) => {
+                let captured = if local.is_empty() {
+                    capture_locals(inner, env)
+                } else {
+                    let shadowed: ShadowLocals = env
+                        .iter()
+                        .filter(|(k, _)| !local.contains(k.as_str()))
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    capture_locals(inner, &shadowed)
+                };
+                out.push(ShadowQuoteItem::Bracket(captured));
+            }
+            ShadowQuoteItem::Push(_) => out.push(item.clone()),
+        }
+    }
+    out
 }
 
 /// The path-condition core (§10.4) for `cond [ then ] [ else ] IF`.
@@ -1488,8 +1701,10 @@ fn verify_if<R: VerifyResolve, S: Solver + CounterModel + FactSnapshot>(
     };
 
     // Advance the real stack by the join: only branch-agreed knowledge
-    // survives into the unconditional continuation.
-    *stack = ShadowStack::join_branch_states(then_stack, &else_stack)?;
+    // survives into the unconditional continuation — except a slot that is a
+    // quotation on both paths, which joins to the conditional pair
+    // (`join_branch_states_ite`, BUGS §B3) so a later CALL re-splits on `P`.
+    *stack = ShadowStack::join_branch_states_ite(then_stack, &else_stack, Some(&cond))?;
     Ok(())
 }
 
@@ -5882,18 +6097,25 @@ mod tests {
 
     #[test]
     fn resolver_falls_back_to_the_core_tier0_arrow_before_var() {
-        // `MAP` has a core Tier-0 scheme ( 'S (List a) ('r a -- 'r b) -- 'S
-        // (List b) ) but no shadow word and no sig: it must resolve Opaque with
-        // that arrow's arity (pop 2, push 1) — never Var (pop 0, push 1).
+        // `IF` has a core Tier-0 scheme ( 'S Bool ('S -- 'T) ('S -- 'T) -- 'T )
+        // but no shadow word (the verifier intercepts it before resolution) and
+        // no sig: reaching the resolver it must be Opaque with that arrow's
+        // arity (pop 3) — never Var (pop 0). (`MAP` pinned this fallback before
+        // the sequence combinators became real shadow words — BUGS §A1; it now
+        // resolves to `ShadowWord::Map`, asserted below.)
         let lookup = |_: &str| None;
         let resolve = SigResolver::new(&lookup);
-        match resolve.resolve("MAP") {
+        match resolve.resolve("IF") {
             VerifyWord::Core(ShadowWord::Opaque(arrow)) => {
-                assert_eq!(arrow.input.elems.len(), 2, "MAP pops the list and the fn");
-                assert_eq!(arrow.output.elems.len(), 1, "MAP pushes the mapped list");
+                assert_eq!(arrow.input.elems.len(), 3, "IF pops cond and both arms");
+                assert_eq!(arrow.output.elems.len(), 0, "IF's result rides the row");
             }
-            other => panic!("MAP must be Opaque per its core Tier 0 arrow, got {other:?}"),
+            other => panic!("IF must be Opaque per its core Tier 0 arrow, got {other:?}"),
         }
+        assert!(
+            matches!(resolve.resolve("MAP"), VerifyWord::Core(ShadowWord::Map)),
+            "MAP is a real shadow word — its body is verified, not skipped"
+        );
     }
 
     #[test]

--- a/caternary/src/types.rs
+++ b/caternary/src/types.rs
@@ -66,6 +66,18 @@ pub fn is_numeric_literal(word: &str) -> bool {
     !word.is_empty() && word.parse::<f64>().map(f64::is_finite).unwrap_or(false)
 }
 
+/// Is this word an **integer-form** lexeme — an optional sign followed by
+/// digits only? A subset of [`is_numeric_literal`]. The distinction matters
+/// because an integer lexeme is **exact by contract** (the `Num` semantics in
+/// `builtins.rs`, mirrored by the reasoner's exact model): one that exceeds
+/// the `i128` range must fail loudly at runtime — never round through `f64` —
+/// and an embedder's `Value::from` should preserve its lexeme (fall through to
+/// a `Word`) rather than construct a rounded float.
+pub fn is_integer_literal(word: &str) -> bool {
+    let digits = word.strip_prefix(['+', '-']).unwrap_or(word);
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
 /// The Tier-0 decision for what counts as a boolean literal.
 ///
 /// `docs/typing.md` §5 spells out the numeric-literal rule but the `IF`


### PR DESCRIPTION
fix(caternary): give % the same divisor refinement as /

`%` performs the same runtime division as `/` (guard `modulo by zero`)
but had no `b * b > 0` demand, so `[ 5 0 % DROP ] :main` passed check
and errored at runtime. Add `%` to `num_num_num_refinements` mirroring
`/`'s divisor demand (no output guarantee: the remainder is not
expressible in the Real predicate language) and teach the refinement
lexer/head parser the `%` token.

Pinned by gate_rejects_modulo_by_zero (rejects `[ 5 0 % DROP ]`) and
gate_accepts_modulo_with_nonzero_divisor (`[ 5 3 % DROP ]` still
passes).

Co-authored-by: AI

fix(caternary): reject same-scope >name rebind in the gate

`word_effect`'s `>name` branch always pushed a new `Local`, so a second
`>x` in the same scope type-checked as shadowing while the runtime
forbids it (`single-assignment violation`). Capture the innermost scope
base at `infer_seq` entry (0 for a fresh body, the enclosing clone size
for a quotation, which opens a fresh per-execution scope) and reject a
bind whose name is already bound at index `>= scope_base` as
`TypeError::DuplicateBind`. Nested quotation-scope shadowing still
works.

Pinned by gate_rejects_same_scope_local_rebind (`[ 1 >x 2 >x x DROP ]`
rejected as DuplicateBind naming `x`) and
gate_accepts_nested_quotation_scope_shadowing.

Co-authored-by: AI

docs(caternary): record the i128 arithmetic-overflow gate hole

The solver models `Num` as unbounded Real so `+`/`-`/`*` guarantees
never overflow in the model, but the runtime uses checked i128; `[
i128::MAX 1 + ]` passes check and runtime-errors. Documented alongside
the bitwise caveat on `register_scalar_builtins` (structural; needs a
bounded-integer refinement the predicate language lacks).

Co-authored-by: AI

docs(caternary): document the no-Word-base-type gate hole

The type system exposes only Num/Bool base types, so an unresolved bare
word (`[ foo ] :main`) is typed unresolved and rejected by check though
the runtime pushes a literal Word. Documented alongside the bitwise
caveat as a structural gap (needs a Word/top base type).

Co-authored-by: AI

docs(caternary): document =/==/!= same-type gate tightening

The contract is same-type `( a a -- Bool )` but the runtime falls back
to token equality for any pair, so `[ 1 true = ]` runs (-> false) while
check rejects Num-vs-Bool. Recorded as an intentional gate tightening,
not an oversight.

Co-authored-by: AI

docs(caternary): note WHEN/UNLESS literal-condition over-rejection

WHEN/UNLESS force both branches to the same stack depth; with a
statically known literal condition the runtime runs only the taken
branch, but check cannot specialize and over-rejects (`[ 5 true [ DROP ]
WHEN ] :main` runs yet fails check). Noted in the README caternary-check
caveats.

Co-authored-by: AI

fix(caternary): BUGS §A2 i128::MIN/-1 divide/modulo no longer crash

divide and modulo used unchecked `a % b` / `a / b`, which overflow and

panic (Abort trap: 6) in debug and silently wrap in release for

i128::MIN / -1 and i128::MIN % -1.  Replace both with checked_rem /

checked_div so the case is a runtime EvalError, matching the documented

"overflow is a runtime error, never a silent wrap or a crash" contract

for Num.  Regression test added.  BUGS.md §A2 marked resolved.

Co-authored-by: AI

chore(caternary): add the gate-vs-eval probe example

Every repro in BUGS.md was run through examples/probe.rs: it parses a
program, runs the whole-program gate (check_whole_program with
SmtLibSolver), prints the inferred type, and then evaluates main,
printing both verdicts side by side. Register it as a binaries-gated
example so the repros stay one command away.

Co-authored-by: AI

fix(caternary): BUGS §A1 verify combinator bodies in Tier 1

WHEN/UNLESS/MAP/FILTER/FOLD/EACH resolved to ShadowWord::Opaque, so
their quotation bodies were never verified: refinement obligations
inside the body were silently skipped (gate-green division by zero), and
the opaque post-state presumed an untouched tail even though the quote
arrows admit shape-preserving scramblers that permute it.

Make the six words real shadow words in both the verifier
(solver.rs::apply_core) and the shadow evaluator (shadow.rs::exec):

- WHEN/UNLESS verify the body on a branch copy under the path condition
  (P / not-P) and join with the skipped path via join_branch_states,
  exactly as IF joins its arms — obligations are generated, and only
  path-agreed knowledge survives.
- MAP/FILTER/FOLD/EACH havoc the shared tail to a fixpoint
  (ShadowStack::havoc_fixpoint): each round replays one iteration and
  opaques every not-yet-havocked slot it changed (a changed quotation
  slot fail-closes to an opaque term); the surviving slots are an
  inductive invariant, so untouched tail slots keep their knowledge and
  quotations below an untouching body stay CALLable. The body is then
  verified once at the fixpoint — never against first-iteration-only
  knowledge. FOLD threads its accumulator as part of the loop state.

Fixpoint probe rounds run in a pushed solver scope with a scratch
VerifyCtx so only the final, inductive replay is ledgered.

The resolver fallback test that used MAP as its exemplar now uses IF
(the remaining core-scheme word without a shadow word) and pins that MAP
resolves to ShadowWord::Map. Regression tests cover all eight
gate-must-reject repros and seven completeness controls.

Co-authored-by: AI

fix(caternary): BUGS §A4 out-of-range integer literals fail loudly

An integer lexeme beyond i128 fell through Num::parse to a rounded f64,
so two distinct integers (2^127 and 2^127 + 1) compared equal at runtime
while the reasoner models the lexemes exactly. This violated the
recorded Num semantics ("an integer-lexeme operand is an i128"; overflow
is a runtime error, never a silent wrap or rounding).

Add is_integer_literal (types.rs, exported) — optional sign + digits —
and refuse the f64 fallthrough for integer-form lexemes everywhere:

- Num::parse returns None for an out-of-range integer lexeme, and
  pop_num raises a targeted "numeric overflow: integer literal ..."
  error instead of "expected numeric value".
- values_equal (=/==/!=) errors on an overflowing integer operand
  instead of comparing rounded f64s or digit strings.
- The CLI, the builtins-test Value, and the probe example keep the exact
  lexeme as a Word instead of minting a rounded Float.

The repro is now a loud runtime error, the same documented gate-gap
family as +/-/* i128 overflow. Regression test:
builtins::tests::out_of_range_integer_literals_error_instead_of_rounding.

Co-authored-by: AI

fix(caternary): BUGS §A5 model the shift-amount range

The runtime rejects shift amounts outside 0..=127 (checked_shl /
checked_shr on i128) but << and >> carried no demand, so [ 1 -1 << ] and
[ 1 200 << ] were gate-green and crashed at runtime.

Attach `b * ( 127 - b ) >= 0` — i.e. 0 <= b <= 127 as one atom — to both
shifts. A two-conjunct demand never discharges in the in-tree reasoner
(the negated goal is a disjunction it treats as opaque), which is the
same reason / demands b * b > 0 rather than b != 0.

The refinement signature-head parser now joins a contiguous angle pair
into <</>> (the predicate grammar has no shift operator, so the lexer
emits two angle tokens); a spaced `< <` stays two tokens.  Integrality
of the amount remains the documented bitwise gap.

Co-authored-by: AI

fix(caternary): BUGS §B5 reject true/false definition names

The runtime resolves definitions before literals while the checker types
literals before definitions, so [ 42 ] :true [ true 1 + ] :main
evaluated to 43 but was gate-rejected (Bool vs Num), and [ ] :true
[ true ] :main produced a proven effect ( -- Bool ) the runtime never
delivers (the stack stays empty).

Reject the two boolean-literal names in load (the single choke point
both load paths share), mirroring the identifier rule that already
excludes numeric definition names. Regression test:
evaluator::tests::load_rejects_boolean_literal_definition_names.

Co-authored-by: AI

fix(caternary): BUGS §B2 make >name locals visible to Tier 1

The verify path had no binder case: `>x` resolved as a free word and
pushed a phantom Var(">x") instead of popping, and a use of `x` pushed a
free Var("x"), so every demand through a local failed closed
([ 4 >x x x / DROP ] :main was rejected with the `/` demand Unknown
while the runtime computes 4 / 4 = 1).

Thread a per-scope ShadowLocals map through verify_ctx /
verify_quote_ctx, mirroring eval_word byte for byte: binder first (pop
the top slot into the scope, single-assignment enforced), bound local
next (push the slot back — a value term keeps its knowledge, a quotation
slot stays CALLable), then the IF/assume interceptions, then ordinary
resolution. Brackets capture live locals by value into the shadow
quotation (the image of capture_tokens, with inner `>name` shadowing and
nested-bracket recursion), and each quotation body opens a fresh scope
exactly like eval_quote_with_stack.

Violated demands through locals are still refuted (0 >x 1 x / is Sat,
not merely Unknown). Regression test:
check::tests::locals_carry_their_knowledge_through_tier1.

Co-authored-by: AI

docs(caternary): BUGS §B4 ratify the Bool-condition tightening

IF/WHEN/UNLESS demand a Bool condition and &&/||/!/and/or/not demand
Bool operands, while the runtime is truthy-generic (is_truthy is total),
so [ 1 [ 2 ] [ 3 ] IF ] :main runs (yielding 2) but check rejects
Num-versus-Bool. Ratify this as the same intentional gate tightening as
the documented =/==/!= same-type contract: the contracts promise boolean
control flow; truthiness is the runtime escape hatch, not a typed
promise.

Recorded in the README caveats beside the = gap; pinned by
check::tests::truthiness_tightening_is_ratified (gate rejects each BUGS
repro, runtime runs it).

Co-authored-by: AI

docs(caternary): BUGS §A3/§B6 record the BI@/TRI@ rank-1 limits

BI@/TRI@ reuse one row/element pair for both applications of the
quotation, but the runtime applies it at two different stack depths —
which no rank-1 arrow can state. Both directions of the imprecision are
now recorded in TODO.md and pinned:

- §A3: the shared row absorbs a tail element, so 1 2 [ SWAP ] BI@ types
  on the Tier-0-only surfaces (check(), infer_quote_type, REPL :type)
  while the runtime underflows; the full gate is unaffected because the
  Tier-1 shadow re-executes the real shuffle.
- §B6: the same single row forces exactly ( a -- b ) per application, so
  runnable [ DROP ]/[ DUP ] bodies occurs-check out.

Fixing either direction needs per-application instantiation of the
quotation arrow (rank-2 generalization of a value), which the rank-1
substitution cannot express. Pinned by
check::tests::bi_at_rank1_scheme_limits_are_recorded, asserting all
three behaviors so drift in any direction surfaces.

Co-authored-by: AI

fix(caternary): BUGS §B3 ite-aware join for quotation slots

join_branch_states replaced any slot the IF branches disagreed on with
an opaque term — even when both branches produced quotations — so [ true
[ [ 1 ] ] [ [ 2 ] ] IF CALL ] :main failed structurally ("expected a
quotation, found a value term") while the runtime yields [1]. The code
called this the deliberate fail-closed floor and noted "an ite-aware
join could recover precision here later".

Recover it: join_branch_states_ite keeps a quotation-on-both-paths slot
as the synthetic conditional quotation [ P [then] [else] IF ] (P = the
branch condition; the ran-path condition for WHEN/UNLESS).  A later
combinator that runs the slot re-enters verify_if: each body is verified
under its own path condition and the results re-join, so the checker
knows the slot is a quotation without pretending to know which body, and
a demand inside either body discharges only under its branch condition —
a division hiding in one branch quotation is still refuted. All other
disagreements (and the condition-free wrapper used by the shadow
evaluator) keep the opaque fail-closed floor.

Regression test:
check::tests::branch_disagreed_quotation_slots_stay_callable.

Co-authored-by: AI

docs(caternary): BUGS §B1 record the higher-order fail-closed floor

Applying a quotation PARAMETER (or a quotation returned by a definition)
cannot pass the gate: Tier 1 seeds definition inputs as opaque terms, so
CALL/DIP on them is a hard shadow error. The local half of §B1 is
already fixed by the §B2 locals work (a same-body literal quotation
bound with >f stays CALLable); the parameter half is recorded in TODO.md
(High) with the sound fix design — the unbuilt definition side of §10.6:
contract-carrying symbolic quotation seeds, literal-body verification
against the expected contract at call sites, unrefined parameters
staying fail-closed.

Critically, the over-rejection currently masks a soundness hole: nothing
verifies a literal quotation argument body at a call site
([ 1 0 / DROP ] passed to apply is consumed opaquely — its division is
only checked because apply CALLs it, which is exactly what fails closed
today). The naive fix of letting the definition-side CALL move data
opaquely would open that hole gate-wide; the TODO entry and the pinning
test both warn against it.

Pinned by check::tests::quotation_parameter_application_fails_closed
(all four BUGS repros gate-reject and run; the locals carve-out
gate-passes).

Co-authored-by: AI

docs(caternary): BUGS.md header records the resolved status

Every finding is now fixed or ratified-and-recorded with pinning tests;
the stale "nothing here is pinned" claim is scoped to the time of the
review and a status summary points at each resolution.

Co-authored-by: AI

HITL: remove caternary/BUGS.md
